### PR TITLE
feat: S3 bucket-name validation

### DIFF
--- a/object-storage-aws/build.gradle.kts
+++ b/object-storage-aws/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
     api(libs.amazon.awssdk.s3)
 
     implementation(platform(mn.micronaut.aws.bom))
+    annotationProcessor(mn.micronaut.validation)
+    implementation(mn.micronaut.validation)
 
     testImplementation(projects.objectStorageTck)
     testImplementation(libs.testcontainers.spock)

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Configuration.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Configuration.java
@@ -17,8 +17,10 @@ package io.micronaut.objectstorage.aws;
 
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.objectstorage.AbstractObjectStorageConfiguration;
-
+import javax.validation.constraints.Pattern;
 import static io.micronaut.objectstorage.aws.AwsS3Configuration.PREFIX;
 
 /**
@@ -28,23 +30,39 @@ import static io.micronaut.objectstorage.aws.AwsS3Configuration.PREFIX;
  * @since 1.0
  */
 @EachProperty(PREFIX)
+@Introspected
 public class AwsS3Configuration extends AbstractObjectStorageConfiguration {
 
     public static final String NAME = "aws";
 
     public static final String PREFIX = GENERIC_PREFIX + '.' + NAME;
 
+    /**
+     * Bucket Name.
+     * <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html">Bucket Name Requirements</a>
+     */
+    @NonNull
+    @Pattern(regexp = "(?!xn--)(?!.*-s3alias)^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$")
+    private String bucketName;
+
     public AwsS3Configuration(@Parameter String name) {
         super(name);
     }
 
     /**
-     * The name of the AWS S3 bucket.
      *
-     * @param name the name to set.
+     * @return The name of the AWS S3 bucket.
      */
-    @Override
-    public void setName(String name) {
-        super.setName(name);
+    @NonNull
+    public String getBucketName() {
+        return bucketName;
+    }
+
+    /**
+     *
+     * @param bucketName The name of the AWS S3 bucket.
+     */
+    public void setBucketName(@NonNull String bucketName) {
+        this.bucketName = bucketName;
     }
 }

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3ConfigurationTest.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3ConfigurationTest.groovy
@@ -1,0 +1,96 @@
+package io.micronaut.objectstorage.aws
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.See
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import javax.validation.ConstraintViolationException
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+
+@Property(name = "micronaut.object-storage.aws.pictures.bucket-name", value = "pictures-bucket")
+@Property(name =  "micronaut.object-storage.aws.logos.bucket-name", value = "logos-bucket")
+@Property(name = "spec.name", value = "AwsS3ConfigurationTest")
+@MicronautTest(startApplication = false)
+class AwsS3ConfigurationTest extends Specification {
+
+    @Inject
+    BeanContext beanContext
+
+    void "there is one object mapper correctly qualified with the name"() {
+        expect:
+        beanContext.containsBean(ObjectStorageOperations, Qualifiers.byName("pictures"))
+        beanContext.containsBean(ObjectStorageOperations, Qualifiers.byName("logos"))
+        beanContext.containsBean(AwsS3Configuration, Qualifiers.byName("pictures"))
+
+        when:
+        AwsS3Configuration awsS3Configuration = beanContext.getBean(AwsS3Configuration, Qualifiers.byName("pictures"))
+
+        then:
+        'pictures' == awsS3Configuration.name
+        'pictures-bucket' == awsS3Configuration.bucketName
+    }
+
+    @See("https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html")
+    @Unroll("#description")
+    void "bucket name validation"(String bucketName, String description) {
+        given:
+        MockService service = beanContext.getBean(MockService)
+
+        when:
+        AwsS3Configuration configuration = new AwsS3Configuration("foo")
+        configuration.bucketName = bucketName
+        service.validate(configuration)
+
+        then:
+        thrown(ConstraintViolationException)
+
+        where:
+        bucketName     | description
+        'aa'           | 'Bucket names must be at least 3 characters long.'
+        'a' * 64       | 'Bucket names must be max 63 characters long.'
+        'aa*aa'        | 'Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-).'
+        '-aaaa'        | 'Bucket names must begin and end with a letter or number.'
+        'aa..aa'       | 'Bucket names must not contain two adjacent periods.'
+        '192.168.5.4'  | 'Bucket names must not be formatted as an IP address (for example, 192.168.5.4).'
+        'xn--aaa'      | 'Bucket names must not start with the prefix xn--.'
+        'aaaa-s3alias' | 'Bucket names must not end with the suffix -s3alias.'
+        'aaa.aa'       | "Buckets used with Amazon S3 Transfer Acceleration can't have dots (.) in their name"
+    }
+
+    void "verify valid bucket name"() {
+        given:
+        MockService service = beanContext.getBean(MockService)
+
+        when:
+        AwsS3Configuration configuration = new AwsS3Configuration("foo")
+        configuration.bucketName = 'aaaaa'
+        service.validate(configuration)
+
+        then:
+        noExceptionThrown()
+    }
+
+    static interface MockService {
+        void validate(@NonNull @NotNull @Valid AwsS3Configuration configuration);
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "AwsS3ConfigurationTest")
+    static class DefaultMockService implements MockService {
+        @Override
+        void validate(@NonNull @NotNull @Valid AwsS3Configuration configuration) {
+
+        }
+    }
+
+}

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -22,9 +22,9 @@ micronaut:
   object-storage:
     aws:
       pictures:
-        name: pictures-bucket
+        bucket-name: pictures-bucket
       logos:
-        name: logos-bucket
+        bucket-name: logos-bucket
 ----
 
 You need to use `@Named("pictures")` or `@Named("logos")` to specify which of the object storages you want to use.


### PR DESCRIPTION
This adds regex validation for the S3 bucket name.

Moreover, it decouples the bucket name from the bean qualifier name, which is the value passed in the constructor. I found it a little confusing that we were overriding it via the setter.