### PR TITLE
Refactor configuration

### DIFF
--- a/doc-examples/example-groovy/src/test/resources/application-ec2.yml
+++ b/doc-examples/example-groovy/src/test/resources/application-ec2.yml
@@ -2,4 +2,4 @@ micronaut:
   object-storage:
     aws:
       default:
-        name: profile-pictures-bucket
+        bucket: profile-pictures-bucket

--- a/doc-examples/example-java/src/test/resources/application-azure.yml
+++ b/doc-examples/example-java/src/test/resources/application-azure.yml
@@ -9,5 +9,5 @@ micronaut:
   object-storage:
     azure:
       default:
-        name: profile-pictures-container
+        container: profile-pictures-container
         endpoint: https://my-account.blob.core.windows.net

--- a/doc-examples/example-java/src/test/resources/application-ec2.yml
+++ b/doc-examples/example-java/src/test/resources/application-ec2.yml
@@ -2,4 +2,4 @@ micronaut:
   object-storage:
     aws:
       default:
-        name: profile-pictures-bucket
+        bucket: profile-pictures-bucket

--- a/doc-examples/example-java/src/test/resources/application-gcp.yml
+++ b/doc-examples/example-java/src/test/resources/application-gcp.yml
@@ -5,4 +5,4 @@ micronaut:
   object-storage:
     gcp:
       default:
-        name: profile-pictures-bucket
+        bucket: profile-pictures-bucket

--- a/doc-examples/example-java/src/test/resources/application-oraclecloud.yml
+++ b/doc-examples/example-java/src/test/resources/application-oraclecloud.yml
@@ -6,5 +6,5 @@ micronaut:
   object-storage:
     oracle-cloud:
       default:
-        name: profile-pictures-bucket
+        bucket: profile-pictures-bucket
         namespace: MyNamespace

--- a/doc-examples/example-kotlin/src/test/resources/application-ec2.yml
+++ b/doc-examples/example-kotlin/src/test/resources/application-ec2.yml
@@ -2,4 +2,4 @@ micronaut:
   object-storage:
     aws:
       default:
-        name: profile-pictures-bucket
+        bucket: profile-pictures-bucket

--- a/object-storage-aws/build.gradle.kts
+++ b/object-storage-aws/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
     api(libs.amazon.awssdk.s3)
 
     implementation(platform(mn.micronaut.aws.bom))
+    annotationProcessor(mn.micronaut.validation)
+    implementation(mn.micronaut.validation)
 
     testImplementation(projects.objectStorageTck)
     testImplementation(libs.testcontainers.spock)

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Configuration.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Configuration.java
@@ -17,8 +17,12 @@ package io.micronaut.objectstorage.aws;
 
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.objectstorage.AbstractObjectStorageConfiguration;
+import io.micronaut.objectstorage.ObjectStorageConfiguration;
+
+import javax.validation.constraints.Pattern;
 
 import static io.micronaut.objectstorage.aws.AwsS3Configuration.PREFIX;
 
@@ -29,23 +33,36 @@ import static io.micronaut.objectstorage.aws.AwsS3Configuration.PREFIX;
  * @since 1.0
  */
 @EachProperty(PREFIX)
+@Introspected
 public class AwsS3Configuration extends AbstractObjectStorageConfiguration {
 
     public static final String NAME = "aws";
 
-    public static final String PREFIX = GENERIC_PREFIX + '.' + NAME;
+    public static final String PREFIX = ObjectStorageConfiguration.PREFIX + '.' + NAME;
+
+    /**
+     * @see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html">Bucket Name Requirements</a>.
+     */
+    @NonNull
+    @Pattern(regexp = "(?!xn--)(?!.*-s3alias)^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$")
+    private String bucket;
 
     public AwsS3Configuration(@Parameter String name) {
         super(name);
     }
 
     /**
-     * The name of the AWS S3 bucket.
-     *
-     * @param name the name to set.
+     * @return The name of the AWS S3 bucket.
      */
-    @Override
-    public void setName(@NonNull String name) {
-        super.setName(name);
+    @NonNull
+    public String getBucket() {
+        return bucket;
+    }
+
+    /**
+     * @param bucket The name of the AWS S3 bucket.
+     */
+    public void setBucket(@NonNull String bucket) {
+        this.bucket = bucket;
     }
 }

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3ObjectStorageEntry.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3ObjectStorageEntry.java
@@ -30,13 +30,14 @@ import java.io.InputStream;
  */
 public class AwsS3ObjectStorageEntry implements ObjectStorageEntry {
 
-    private final ResponseInputStream<GetObjectResponse> responseResponseInputStream;
+    private final ResponseInputStream<GetObjectResponse> responseInputStream;
+
     @NonNull
     private final String key;
 
     AwsS3ObjectStorageEntry(@NonNull String key,
-                            ResponseInputStream<GetObjectResponse> responseResponseInputStream) {
-        this.responseResponseInputStream = responseResponseInputStream;
+                            ResponseInputStream<GetObjectResponse> responseInputStream) {
+        this.responseInputStream = responseInputStream;
         this.key = key;
     }
 
@@ -48,6 +49,6 @@ public class AwsS3ObjectStorageEntry implements ObjectStorageEntry {
 
     @Override
     public InputStream getInputStream() {
-        return responseResponseInputStream;
+        return responseInputStream;
     }
 }

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
@@ -46,14 +46,14 @@ import java.util.Optional;
 public class AwsS3Operations implements ObjectStorageOperations {
 
     private final S3Client s3Client;
-    private final AwsS3Configuration bucketConfiguration;
+    private final AwsS3Configuration configuration;
     private final InputStreamMapper inputStreamMapper;
 
-    public AwsS3Operations(@Parameter AwsS3Configuration bucketConfiguration,
+    public AwsS3Operations(@Parameter AwsS3Configuration configuration,
                            S3Client s3Client,
                            InputStreamMapper inputStreamMapper) {
         this.s3Client = s3Client;
-        this.bucketConfiguration = bucketConfiguration;
+        this.configuration = configuration;
         this.inputStreamMapper = inputStreamMapper;
     }
 
@@ -67,7 +67,7 @@ public class AwsS3Operations implements ObjectStorageOperations {
     public Optional<ObjectStorageEntry> retrieve(String key) throws ObjectStorageException {
         try {
             ResponseInputStream<GetObjectResponse> responseInputStream = s3Client.getObject(GetObjectRequest.builder()
-                .bucket(bucketConfiguration.getName())
+                .bucket(configuration.getBucket())
                 .key(key)
                 .build());
             AwsS3ObjectStorageEntry entry = new AwsS3ObjectStorageEntry(key, responseInputStream);
@@ -80,7 +80,7 @@ public class AwsS3Operations implements ObjectStorageOperations {
     @Override
     public void delete(String key) throws ObjectStorageException {
         s3Client.deleteObject(DeleteObjectRequest.builder()
-            .bucket(bucketConfiguration.getName())
+            .bucket(configuration.getBucket())
             .key(key)
             .build());
     }
@@ -93,7 +93,7 @@ public class AwsS3Operations implements ObjectStorageOperations {
     @NonNull
     protected PutObjectRequest.Builder putRequest(@NonNull UploadRequest uploadRequest) {
         PutObjectRequest.Builder builder = PutObjectRequest.builder()
-            .bucket(bucketConfiguration.getName())
+            .bucket(configuration.getBucket())
             .key(uploadRequest.getKey());
 
         uploadRequest.getContentType().ifPresent(builder::contentType);

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AbstractAwsS3Spec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AbstractAwsS3Spec.groovy
@@ -38,6 +38,6 @@ abstract class AbstractAwsS3Spec extends ObjectStorageOperationsSpecification im
 
     @Override
     Map<String, String> getProperties() {
-        [(PREFIX + '.' + OBJECT_STORAGE_NAME + '.name'): BUCKET_NAME]
+        [(PREFIX + '.' + OBJECT_STORAGE_NAME + '.bucket'): BUCKET_NAME]
     }
 }

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3ConfigurationSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3ConfigurationSpec.groovy
@@ -1,0 +1,97 @@
+package io.micronaut.objectstorage.aws
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.See
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import javax.validation.ConstraintViolationException
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+
+@Property(name = "micronaut.object-storage.aws.pictures.bucket", value = "pictures-bucket")
+@Property(name =  "micronaut.object-storage.aws.logos.bucket", value = "logos-bucket")
+@Property(name = "spec.name", value = SPEC_NAME)
+@MicronautTest(startApplication = false)
+class AwsS3ConfigurationSpec extends Specification {
+
+    public static final String SPEC_NAME = 'AwsS3ConfigurationSpec'
+
+    @Inject
+    BeanContext beanContext
+
+    void "there is one configuration correctly qualified with the name"() {
+        expect:
+        beanContext.containsBean(ObjectStorageOperations, Qualifiers.byName("pictures"))
+        beanContext.containsBean(ObjectStorageOperations, Qualifiers.byName("logos"))
+        beanContext.containsBean(AwsS3Configuration, Qualifiers.byName("pictures"))
+
+        when:
+        AwsS3Configuration awsS3Configuration = beanContext.getBean(AwsS3Configuration, Qualifiers.byName("pictures"))
+
+        then:
+        'pictures' == awsS3Configuration.name
+        'pictures-bucket' == awsS3Configuration.bucket
+    }
+
+    @See("https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html")
+    @Unroll("#description")
+    void "bucket name validation"(String bucketName, String description) {
+        given:
+        MockService service = beanContext.getBean(MockService)
+
+        when:
+        AwsS3Configuration configuration = new AwsS3Configuration("foo")
+        configuration.bucket = bucketName
+        service.validate(configuration)
+
+        then:
+        thrown(ConstraintViolationException)
+
+        where:
+        bucketName     | description
+        'aa'           | 'Bucket names must be at least 3 characters long.'
+        'a' * 64       | 'Bucket names must be max 63 characters long.'
+        'aa*aa'        | 'Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-).'
+        '-aaaa'        | 'Bucket names must begin and end with a letter or number.'
+        'aa..aa'       | 'Bucket names must not contain two adjacent periods.'
+        '192.168.5.4'  | 'Bucket names must not be formatted as an IP address (for example, 192.168.5.4).'
+        'xn--aaa'      | 'Bucket names must not start with the prefix xn--.'
+        'aaaa-s3alias' | 'Bucket names must not end with the suffix -s3alias.'
+        'aaa.aa'       | "Buckets used with Amazon S3 Transfer Acceleration can't have dots (.) in their name"
+    }
+
+    void "verify valid bucket name"() {
+        given:
+        MockService service = beanContext.getBean(MockService)
+
+        when:
+        AwsS3Configuration configuration = new AwsS3Configuration("foo")
+        configuration.bucket = 'aaaaa'
+        service.validate(configuration)
+
+        then:
+        noExceptionThrown()
+    }
+
+    static interface MockService {
+        void validate(@NonNull @NotNull @Valid AwsS3Configuration configuration);
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class DefaultMockService implements MockService {
+        @Override
+        void validate(@NonNull @NotNull @Valid AwsS3Configuration configuration) {
+
+        }
+    }
+}

--- a/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageConfiguration.java
+++ b/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageConfiguration.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.objectstorage.AbstractObjectStorageConfiguration;
+import io.micronaut.objectstorage.ObjectStorageConfiguration;
 
 import static io.micronaut.objectstorage.azure.AzureBlobStorageConfiguration.PREFIX;
 
@@ -33,12 +34,31 @@ public class AzureBlobStorageConfiguration extends AbstractObjectStorageConfigur
 
     public static final String NAME = "azure";
 
-    public static final String PREFIX = GENERIC_PREFIX + '.' + NAME;
+    public static final String PREFIX = ObjectStorageConfiguration.PREFIX + '.' + NAME;
 
+    @NonNull
+    private String container;
+
+    @NonNull
     private String endpoint;
 
     public AzureBlobStorageConfiguration(@Parameter String name) {
         super(name);
+    }
+
+    /**
+     * @return The blob container name.
+     */
+    @NonNull
+    public String getContainer() {
+        return container;
+    }
+
+    /**
+     * @param container The blob container name.
+     */
+    public void setContainer(@NonNull String container) {
+        this.container = container;
     }
 
     /**
@@ -50,18 +70,14 @@ public class AzureBlobStorageConfiguration extends AbstractObjectStorageConfigur
     }
 
     /**
-     * @param endpoint The blob service endpoint to set, in the format of
-     *                 <code>https://{accountName}.blob.core.windows.net</code>
+     * @param endpoint The blob service endpoint to set, in the format of https://{accountName}.blob.core.windows.net.
      */
     public void setEndpoint(@NonNull String endpoint) {
         this.endpoint = endpoint;
     }
 
     /**
-     * The blob container name.
+     * @return The blob container name.
      */
-    @Override
-    public void setName(@NonNull String name) {
-        super.setName(name);
-    }
+
 }

--- a/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageFactory.java
+++ b/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageFactory.java
@@ -95,6 +95,6 @@ public class AzureBlobStorageFactory {
     public BlobContainerClient blobContainerClient(@Parameter String name,
                                                    @NonNull BlobServiceClient serviceClient) {
         final AzureBlobStorageConfiguration configuration = beanContext.getBean(AzureBlobStorageConfiguration.class, Qualifiers.byName(name));
-        return serviceClient.getBlobContainerClient(configuration.getName());
+        return serviceClient.getBlobContainerClient(configuration.getContainer());
     }
 }

--- a/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageOperations.java
+++ b/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageOperations.java
@@ -24,10 +24,8 @@ import com.azure.storage.blob.models.BlobRequestConditions;
 import com.azure.storage.blob.models.BlockBlobItem;
 import com.azure.storage.blob.options.BlobParallelUploadOptions;
 import com.azure.storage.blob.options.BlobUploadFromFileOptions;
-import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
-import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.objectstorage.ObjectStorageEntry;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.ObjectStorageOperations;
@@ -50,14 +48,10 @@ import static java.lang.Boolean.TRUE;
 @Singleton
 public class AzureBlobStorageOperations implements ObjectStorageOperations {
 
-    private final AzureBlobStorageConfiguration configuration;
     private final BlobContainerClient blobContainerClient;
 
-    public AzureBlobStorageOperations(@Parameter String name,
-                                      BlobContainerClient blobContainerClient,
-                                      BeanContext beanContext) {
+    public AzureBlobStorageOperations(@Parameter BlobContainerClient blobContainerClient) {
         this.blobContainerClient = blobContainerClient;
-        this.configuration = beanContext.getBean(AzureBlobStorageConfiguration.class, Qualifiers.byName(name));
     }
 
     @Override
@@ -100,10 +94,4 @@ public class AzureBlobStorageOperations implements ObjectStorageOperations {
         blobClient.getBlockBlobClient().delete();
     }
 
-    /**
-     * @return the configuration.
-     */
-    public AzureBlobStorageConfiguration getConfiguration() {
-        return configuration;
-    }
 }

--- a/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AbstractAzureBlobStorageSpec.groovy
+++ b/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AbstractAzureBlobStorageSpec.groovy
@@ -40,6 +40,6 @@ abstract class AbstractAzureBlobStorageSpec extends ObjectStorageOperationsSpeci
 
     @Override
     Map<String, String> getProperties() {
-        [(PREFIX + '.' + OBJECT_STORAGE_NAME + '.name'): CONTAINER_NAME]
+        [(PREFIX + '.' + OBJECT_STORAGE_NAME + '.container'): CONTAINER_NAME]
     }
 }

--- a/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStorageConfigurationSpec.groovy
+++ b/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStorageConfigurationSpec.groovy
@@ -27,7 +27,7 @@ class AzureBlobStorageConfigurationSpec extends Specification {
         given:
         def applicationContext = ApplicationContext.run(
                 [
-                        (PREFIX + '.test-container.name')    : 'custom-container-name',
+                        (PREFIX + '.test-container.container')    : 'custom-container-name',
                         (PREFIX + '.test-container.endpoint'): 'endpoint'
                 ])
 
@@ -36,7 +36,8 @@ class AzureBlobStorageConfigurationSpec extends Specification {
 
         then:
         configuration
-        configuration.name == 'custom-container-name'
+        configuration.name == 'test-container'
+        configuration.container == 'custom-container-name'
         configuration.endpoint == 'endpoint'
 
         cleanup:

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/AbstractObjectStorageConfiguration.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/AbstractObjectStorageConfiguration.java
@@ -25,8 +25,6 @@ import io.micronaut.core.annotation.NonNull;
  */
 public abstract class AbstractObjectStorageConfiguration implements ObjectStorageConfiguration {
 
-    public static final String GENERIC_PREFIX = "micronaut.object-storage";
-
     @NonNull
     private String name;
 
@@ -34,16 +32,12 @@ public abstract class AbstractObjectStorageConfiguration implements ObjectStorag
         this.name = name;
     }
 
+    /**
+     * @return The name of this object storage configuration.
+     */
     @Override
     @NonNull
     public String getName() {
         return name;
-    }
-
-    /**
-     * @param name the name to set.
-     */
-    public void setName(@NonNull String name) {
-        this.name = name;
     }
 }

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/ObjectStorageConfiguration.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/ObjectStorageConfiguration.java
@@ -25,4 +25,6 @@ import io.micronaut.core.naming.Named;
  */
 public interface ObjectStorageConfiguration extends Named {
 
+    String PREFIX = "micronaut.object-storage";
+
 }

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageConfiguration.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageConfiguration.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.objectstorage.AbstractObjectStorageConfiguration;
+import io.micronaut.objectstorage.ObjectStorageConfiguration;
 
 import static io.micronaut.objectstorage.googlecloud.GoogleCloudStorageConfiguration.PREFIX;
 
@@ -33,17 +34,28 @@ public class GoogleCloudStorageConfiguration extends AbstractObjectStorageConfig
 
     public static final String NAME = "gcp";
 
-    public static final String PREFIX = GENERIC_PREFIX + '.' + NAME;
+    public static final String PREFIX = ObjectStorageConfiguration.PREFIX + '.' + NAME;
+
+    @NonNull
+    private String bucket;
 
     public GoogleCloudStorageConfiguration(@Parameter String name) {
         super(name);
     }
 
     /**
-     * The Cloud Storage bucket name.
+     * @return The name of the Google Cloud Storage bucket.
      */
-    @Override
-    public void setName(@NonNull String name) {
-        super.setName(name);
+    @NonNull
+    public String getBucket() {
+        return bucket;
     }
+
+    /**
+     * @param bucket The name of the Google Cloud Storage bucket.
+     */
+    public void setBucket(@NonNull String bucket) {
+        this.bucket = bucket;
+    }
+
 }

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageFactory.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageFactory.java
@@ -33,17 +33,17 @@ import jakarta.inject.Singleton;
 public class GoogleCloudStorageFactory {
 
     /**
-     * @param googleCloudConfiguration The Google Cloud Configuration
+     * @param configuration The Google Cloud Configuration
      * @param googleCredentials        The Google Credentials
      * @return The storage instance
      */
     @RequiresGoogleProjectId
     @Singleton
     @NonNull
-    public StorageOptions.Builder builder(@NonNull GoogleCloudConfiguration googleCloudConfiguration,
+    public StorageOptions.Builder builder(@NonNull GoogleCloudConfiguration configuration,
                                           @NonNull GoogleCredentials googleCredentials) {
         return StorageOptions.newBuilder()
-            .setProjectId(googleCloudConfiguration.getProjectId())
+            .setProjectId(configuration.getProjectId())
             .setCredentials(googleCredentials);
     }
 

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageOperations.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageOperations.java
@@ -21,6 +21,7 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Parameter;
 import io.micronaut.objectstorage.InputStreamMapper;
 import io.micronaut.objectstorage.ObjectStorageEntry;
 import io.micronaut.objectstorage.ObjectStorageException;
@@ -39,21 +40,21 @@ import java.util.Optional;
 @EachBean(GoogleCloudStorageConfiguration.class)
 public class GoogleCloudStorageOperations implements ObjectStorageOperations {
 
+    private final GoogleCloudStorageConfiguration configuration;
     private final InputStreamMapper inputStreamMapper;
     private final Storage storage;
-    private final GoogleCloudStorageConfiguration configuration;
 
-    public GoogleCloudStorageOperations(InputStreamMapper inputStreamMapper,
-                                        Storage storage,
-                                        GoogleCloudStorageConfiguration configuration) {
+    public GoogleCloudStorageOperations(@Parameter GoogleCloudStorageConfiguration configuration,
+                                        InputStreamMapper inputStreamMapper,
+                                        Storage storage) {
+        this.configuration = configuration;
         this.inputStreamMapper = inputStreamMapper;
         this.storage = storage;
-        this.configuration = configuration;
     }
 
     @Override
     public UploadResponse upload(UploadRequest uploadRequest) throws ObjectStorageException {
-        BlobId blobId = BlobId.of(configuration.getName(), uploadRequest.getKey());
+        BlobId blobId = BlobId.of(configuration.getBucket(), uploadRequest.getKey());
         BlobInfo blobInfo = BlobInfo.newBuilder(blobId)
             .setContentType(uploadRequest.getContentType().orElse(null))
             .build();
@@ -64,7 +65,7 @@ public class GoogleCloudStorageOperations implements ObjectStorageOperations {
 
     @Override
     public Optional<ObjectStorageEntry> retrieve(String key) throws ObjectStorageException {
-        BlobId blobId = BlobId.of(configuration.getName(), key);
+        BlobId blobId = BlobId.of(configuration.getBucket(), key);
         Blob blob = storage.get(blobId);
 
         GoogleCloudStorageEntry storageEntry = null;
@@ -76,7 +77,7 @@ public class GoogleCloudStorageOperations implements ObjectStorageOperations {
 
     @Override
     public void delete(String key) throws ObjectStorageException {
-        BlobId blobId = BlobId.of(configuration.getName(), key);
+        BlobId blobId = BlobId.of(configuration.getBucket(), key);
         storage.delete(blobId);
     }
 }

--- a/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/AbstractGoogleCloudStorageSpec.groovy
+++ b/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/AbstractGoogleCloudStorageSpec.groovy
@@ -22,7 +22,7 @@ abstract class AbstractGoogleCloudStorageSpec extends ObjectStorageOperationsSpe
 
     @Override
     Map<String, String> getProperties() {
-        [(PREFIX + '.' + OBJECT_STORAGE_NAME + '.name'): BUCKET_NAME]
+        [(PREFIX + '.' + OBJECT_STORAGE_NAME + '.bucket'): BUCKET_NAME]
     }
 
     ObjectStorageOperations getObjectStorage() {

--- a/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageConfiguration.java
+++ b/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageConfiguration.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.objectstorage.AbstractObjectStorageConfiguration;
+import io.micronaut.objectstorage.ObjectStorageConfiguration;
 
 import static io.micronaut.objectstorage.oraclecloud.OracleCloudStorageConfiguration.PREFIX;
 
@@ -33,12 +34,31 @@ public class OracleCloudStorageConfiguration extends AbstractObjectStorageConfig
 
     public static final String NAME = "oracle-cloud";
 
-    public static final String PREFIX = GENERIC_PREFIX + '.' + NAME;
+    public static final String PREFIX = ObjectStorageConfiguration.PREFIX + '.' + NAME;
 
+    @NonNull
+    private String bucket;
+
+    @NonNull
     private String namespace;
 
     public OracleCloudStorageConfiguration(@Parameter String name) {
         super(name);
+    }
+
+    /**
+     * @return The name of the AWS S3 bucket.
+     */
+    @NonNull
+    public String getBucket() {
+        return bucket;
+    }
+
+    /**
+     * @param bucket The name of the AWS S3 bucket.
+     */
+    public void setBucket(@NonNull String bucket) {
+        this.bucket = bucket;
     }
 
     /**
@@ -56,11 +76,4 @@ public class OracleCloudStorageConfiguration extends AbstractObjectStorageConfig
         this.namespace = namespace;
     }
 
-    /**
-     * The OCI Object Storage bucket name.
-     */
-    @Override
-    public void setName(@NonNull String name) {
-        super.setName(name);
-    }
 }

--- a/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageOperations.java
+++ b/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageOperations.java
@@ -41,8 +41,8 @@ import java.util.Optional;
  */
 @EachBean(OracleCloudStorageConfiguration.class)
 public class OracleCloudStorageOperations implements ObjectStorageOperations {
-    private final ObjectStorage client;
     private final OracleCloudStorageConfiguration configuration;
+    private final ObjectStorage client;
 
     public OracleCloudStorageOperations(@Parameter OracleCloudStorageConfiguration configuration,
                                         ObjectStorage client) {
@@ -66,7 +66,7 @@ public class OracleCloudStorageOperations implements ObjectStorageOperations {
     protected PutObjectRequest.Builder put(@NonNull UploadRequest uploadRequest) {
         PutObjectRequest.Builder putObjectRequestBuilder = PutObjectRequest.builder()
             .objectName(uploadRequest.getKey())
-            .bucketName(configuration.getName())
+            .bucketName(configuration.getBucket())
             .namespaceName(configuration.getNamespace())
             .putObjectBody(uploadRequest.getInputStream());
 
@@ -78,7 +78,7 @@ public class OracleCloudStorageOperations implements ObjectStorageOperations {
     @Override
     public Optional<ObjectStorageEntry> retrieve(String key) throws ObjectStorageException {
         GetObjectRequest.Builder builder = GetObjectRequest.builder()
-            .bucketName(configuration.getName())
+            .bucketName(configuration.getBucket())
             .namespaceName(configuration.getNamespace())
             .objectName(key);
 
@@ -94,7 +94,7 @@ public class OracleCloudStorageOperations implements ObjectStorageOperations {
     @Override
     public void delete(String key) throws ObjectStorageException {
         client.deleteObject(DeleteObjectRequest.builder()
-            .bucketName(configuration.getName())
+            .bucketName(configuration.getBucket())
             .namespaceName(configuration.getNamespace())
             .objectName(key)
             .build());

--- a/object-storage-oracle-cloud/src/test/groovy/io/micronaut/objectstorage/oraclecloud/AbstractOracleCloudStorageSpec.groovy
+++ b/object-storage-oracle-cloud/src/test/groovy/io/micronaut/objectstorage/oraclecloud/AbstractOracleCloudStorageSpec.groovy
@@ -27,7 +27,7 @@ abstract class AbstractOracleCloudStorageSpec extends ObjectStorageOperationsSpe
 
     @Override
     Map<String, String> getProperties() {
-        [(PREFIX + '.' + OBJECT_STORAGE_NAME + '.name'): BUCKET_NAME]
+        [(PREFIX + '.' + OBJECT_STORAGE_NAME + '.bucket'): BUCKET_NAME]
     }
 
     @Override


### PR DESCRIPTION
This PR decouples the configuration names with the bucket/container names, which allows using the correct terminology for each cloud.

It also simplifies the configuration documentation:

<img width="928" alt="image" src="https://user-images.githubusercontent.com/153880/187683833-ad8ba193-fc08-41b1-aadf-96b1ece12965.png">
<img width="1669" alt="image" src="https://user-images.githubusercontent.com/153880/187683890-fed11fda-0783-47e4-a868-a50e3d71778c.png">
<img width="925" alt="image" src="https://user-images.githubusercontent.com/153880/187683938-5ba5d302-df40-4766-b57b-f6f8d1f8987f.png">
<img width="1202" alt="image" src="https://user-images.githubusercontent.com/153880/187683982-26640031-5c2b-47d5-8e82-11a563e1b90d.png">

Supersedes and closes #86