### PR TITLE
Allow toggling configuration

### DIFF
--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -1,0 +1,7 @@
+[
+  {
+  "type": "io.micronaut.objectstorage.configuration.AbstractObjectStorageConfiguration",
+  "member": "Field name",
+  "reason": "Private field made final"
+  }
+]

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Configuration.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Configuration.java
@@ -78,4 +78,13 @@ public class AwsS3Configuration extends AbstractObjectStorageConfiguration {
     public void setBucket(@NonNull String bucket) {
         this.bucket = bucket;
     }
+
+    /**
+     * Whether to enable or disable this object storage.
+     * @since 2.0.2
+     */
+    @Override
+    public boolean isEnabled() {
+        return this.enabled;
+    }
 }

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3ModuleConfiguration.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3ModuleConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.aws;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.objectstorage.configuration.AbstractObjectStorageModuleConfiguration;
+
+/**
+ * AWS S3 module configuration.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 2.0.2
+ */
+@ConfigurationProperties(AwsS3Configuration.PREFIX)
+public class AwsS3ModuleConfiguration extends AbstractObjectStorageModuleConfiguration {
+
+    /**
+     * Whether to enable or disable the whole AWS S3 module.
+     */
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+}

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
@@ -17,11 +17,13 @@ package io.micronaut.objectstorage.aws;
 
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.objectstorage.InputStreamMapper;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.ObjectStorageOperations;
+import io.micronaut.objectstorage.configuration.ObjectStorageEnabledCondition;
 import io.micronaut.objectstorage.response.UploadResponse;
 import io.micronaut.objectstorage.request.BytesUploadRequest;
 import io.micronaut.objectstorage.request.FileUploadRequest;
@@ -57,6 +59,8 @@ import java.util.stream.Collectors;
  * @since 1.0
  */
 @EachBean(AwsS3Configuration.class)
+@Requires(condition = ObjectStorageEnabledCondition.class)
+@Requires(beans = AwsS3Configuration.class)
 public class AwsS3Operations implements ObjectStorageOperations<
     PutObjectRequest.Builder, PutObjectResponse, DeleteObjectResponse> {
 

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/package-info.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/package-info.java
@@ -19,4 +19,10 @@
  * @author Sergio del Amo
  * @since 1.0.0
  */
+@Configuration
+@Requires(property = AwsS3Configuration.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
 package io.micronaut.objectstorage.aws;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3ModuleConfigurationSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3ModuleConfigurationSpec.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.objectstorage.aws
+
+import io.micronaut.objectstorage.ObjectStorageConfigurationSpecification
+
+class AwsS3ModuleConfigurationSpec extends ObjectStorageConfigurationSpecification<AwsS3Operations> {
+
+    @Override
+    String getConfigPrefix() {
+        return AwsS3Configuration.PREFIX
+    }
+
+    @Override
+    Class<AwsS3Operations> getObjectStorage() {
+        return AwsS3Operations.class
+    }
+}

--- a/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageConfiguration.java
+++ b/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageConfiguration.java
@@ -81,7 +81,11 @@ public class AzureBlobStorageConfiguration extends AbstractObjectStorageConfigur
     }
 
     /**
-     * @return The blob container name.
+     * Whether to enable or disable this object storage.
+     * @since 2.0.2
      */
-
+    @Override
+    public boolean isEnabled() {
+        return this.enabled;
+    }
 }

--- a/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageEnabledCondition.java
+++ b/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageEnabledCondition.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.azure;
+
+import io.micronaut.context.Qualifier;
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+import io.micronaut.objectstorage.configuration.ObjectStorageEnabledCondition;
+
+/**
+ * Condition to check whether an  Azure object storage should be enabled.
+ *
+ * {@link ObjectStorageEnabledCondition} can't be used in this module since
+ * {@link AzureBlobStorageOperations} has an <code>@EachBean</code> over
+ * {@link com.azure.storage.blob.BlobContainerClient}, and not {@link AzureBlobStorageConfiguration}.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 2.0.2
+ */
+public class AzureBlobStorageEnabledCondition implements Condition {
+
+    @Override
+    public boolean matches(ConditionContext context) {
+        if (context.getBeanResolutionContext() == null) {
+            return true;
+        } else {
+            Qualifier qualifier = ObjectStorageEnabledCondition.getCurrentQualifier(context);
+            if (context.getBeanContext().containsBean(AzureBlobStorageConfiguration.class, qualifier)) {
+                AzureBlobStorageConfiguration configuration = context.getBean(AzureBlobStorageConfiguration.class, qualifier);
+                return configuration.isEnabled();
+            }
+        }
+        return false;
+    }
+
+}

--- a/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageEnabledCondition.java
+++ b/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageEnabledCondition.java
@@ -18,6 +18,7 @@ package io.micronaut.objectstorage.azure;
 import io.micronaut.context.Qualifier;
 import io.micronaut.context.condition.Condition;
 import io.micronaut.context.condition.ConditionContext;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.objectstorage.configuration.ObjectStorageEnabledCondition;
 
 /**
@@ -30,6 +31,7 @@ import io.micronaut.objectstorage.configuration.ObjectStorageEnabledCondition;
  * @author Álvaro Sánchez-Mariscal
  * @since 2.0.2
  */
+@Internal
 public class AzureBlobStorageEnabledCondition implements Condition {
 
     @Override

--- a/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageModuleConfiguration.java
+++ b/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageModuleConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.azure;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.objectstorage.configuration.AbstractObjectStorageModuleConfiguration;
+
+/**
+ * Azure Object Storage module configuration.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 2.0.2
+ */
+@ConfigurationProperties(AzureBlobStorageConfiguration.PREFIX)
+public class AzureBlobStorageModuleConfiguration extends AbstractObjectStorageModuleConfiguration {
+
+    /**
+     * Whether to enable or disable the whole Azure Object Storage module.
+     */
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+}

--- a/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageOperations.java
+++ b/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageOperations.java
@@ -29,13 +29,13 @@ import com.azure.storage.blob.options.BlobParallelUploadOptions;
 import com.azure.storage.blob.options.BlockBlobSimpleUploadOptions;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.ObjectStorageOperations;
 import io.micronaut.objectstorage.request.UploadRequest;
 import io.micronaut.objectstorage.response.UploadResponse;
-import jakarta.inject.Singleton;
 
 import java.io.BufferedInputStream;
 import java.io.InputStream;
@@ -55,7 +55,8 @@ import static java.lang.Boolean.TRUE;
  * @since 1.0
  */
 @EachBean(BlobContainerClient.class)
-@Singleton
+@Requires(condition = AzureBlobStorageEnabledCondition.class)
+@Requires(beans = BlobContainerClient.class)
 public class AzureBlobStorageOperations
     implements ObjectStorageOperations<BlobParallelUploadOptions, BlockBlobItem, Response<Void>> {
 

--- a/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStorageModuleConfigurationSpec.groovy
+++ b/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStorageModuleConfigurationSpec.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.objectstorage.azure
+
+import io.micronaut.objectstorage.ObjectStorageConfigurationSpecification
+
+class AzureBlobStorageModuleConfigurationSpec extends ObjectStorageConfigurationSpecification<AzureBlobStorageOperations> {
+
+    @Override
+    String getConfigPrefix() {
+        return AzureBlobStorageConfiguration.PREFIX
+    }
+
+    @Override
+    Class<AzureBlobStorageOperations> getObjectStorage() {
+        return AzureBlobStorageOperations.class
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/configuration/AbstractObjectStorageConfiguration.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/configuration/AbstractObjectStorageConfiguration.java
@@ -23,10 +23,10 @@ import io.micronaut.core.annotation.NonNull;
  * @author Pavol Gressa
  * @since 1.0
  */
-public abstract class AbstractObjectStorageConfiguration implements ObjectStorageConfiguration {
+public abstract class AbstractObjectStorageConfiguration extends AbstractObjectStorageModuleConfiguration implements ObjectStorageConfiguration {
 
     @NonNull
-    private String name;
+    protected final String name;
 
     protected AbstractObjectStorageConfiguration(@NonNull String name) {
         this.name = name;

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/configuration/AbstractObjectStorageModuleConfiguration.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/configuration/AbstractObjectStorageModuleConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Object Storage Classes related to Azure Blob Storage.
- * <a href="https://azure.microsoft.com/en-us/services/storage/blobs/#overview">Azure Blob Storage</a>
- * @author Sergio del Amo
- * @since 1.0.0
- */
-@Configuration
-@Requires(property = AzureBlobStorageConfiguration.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
-package io.micronaut.objectstorage.azure;
+package io.micronaut.objectstorage.configuration;
 
-import io.micronaut.context.annotation.Configuration;
-import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.util.StringUtils;
+/**
+ * Base class for all the module configurations.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 2.0.2
+ */
+public class AbstractObjectStorageModuleConfiguration implements ObjectStorageModuleConfiguration {
+
+    protected boolean enabled = DEFAULT_ENABLED;
+
+    /**
+     * @param enabled Whether to enable or disable this object storage.
+     * @since 2.0.2
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/configuration/ObjectStorageConfiguration.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/configuration/ObjectStorageConfiguration.java
@@ -23,7 +23,7 @@ import io.micronaut.core.naming.Named;
  * @author Pavol Gressa
  * @since 1.0
  */
-public interface ObjectStorageConfiguration extends Named {
+public interface ObjectStorageConfiguration extends Named, ObjectStorageModuleConfiguration {
 
     String PREFIX = "micronaut.object-storage";
 

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/configuration/ObjectStorageEnabledCondition.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/configuration/ObjectStorageEnabledCondition.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.configuration;
+
+import io.micronaut.context.Qualifier;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+import io.micronaut.core.annotation.AnnotationMetadataProvider;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.QualifiedBeanType;
+import io.micronaut.inject.qualifiers.Qualifiers;
+
+import java.util.Optional;
+
+/**
+ * Condition to check whether an object storage should be enabled.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 2.0.2
+ */
+@Internal
+public class ObjectStorageEnabledCondition implements Condition {
+
+    @Override
+    public boolean matches(ConditionContext context) {
+        if (context.getBeanResolutionContext() == null) {
+            return true;
+        } else {
+            AnnotationMetadataProvider component = context.getComponent();
+            Optional<Class<?>> configurationClass = component.getAnnotation(EachBean.class).classValue();
+            if (configurationClass.isPresent()) {
+                Qualifier qualifier = getCurrentQualifier(context);
+                if (context.getBeanContext().containsBean(configurationClass.get(), qualifier)) {
+                    ObjectStorageConfiguration configuration = (ObjectStorageConfiguration) context.getBean(configurationClass.get(), qualifier);
+                    return configuration.isEnabled();
+                }
+            }
+        }
+        return false;
+    }
+
+    public static Qualifier<?> getCurrentQualifier(ConditionContext<?> context) {
+        if (context.getBeanResolutionContext() != null) {
+            Qualifier<?> qualifier = context.getBeanResolutionContext().getCurrentQualifier();
+            if (qualifier == null) {
+                qualifier = ((QualifiedBeanType<?>) context.getComponent()).getDeclaredQualifier();
+            }
+            if (qualifier != null) {
+                return qualifier;
+            }
+        }
+        return Qualifiers.byName("default");
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/configuration/ObjectStorageEnabledCondition.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/configuration/ObjectStorageEnabledCondition.java
@@ -21,6 +21,7 @@ import io.micronaut.context.condition.Condition;
 import io.micronaut.context.condition.ConditionContext;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.QualifiedBeanType;
 import io.micronaut.inject.qualifiers.Qualifiers;
 
@@ -34,6 +35,8 @@ import java.util.Optional;
  */
 @Internal
 public class ObjectStorageEnabledCondition implements Condition {
+
+    private static final String DEFAULT_QUALIFIER = "default";
 
     @Override
     public boolean matches(ConditionContext context) {
@@ -53,7 +56,8 @@ public class ObjectStorageEnabledCondition implements Condition {
         return false;
     }
 
-    public static Qualifier<?> getCurrentQualifier(ConditionContext<?> context) {
+    @NonNull
+    public static Qualifier<?> getCurrentQualifier(@NonNull ConditionContext<?> context) {
         if (context.getBeanResolutionContext() != null) {
             Qualifier<?> qualifier = context.getBeanResolutionContext().getCurrentQualifier();
             if (qualifier == null) {
@@ -63,6 +67,6 @@ public class ObjectStorageEnabledCondition implements Condition {
                 return qualifier;
             }
         }
-        return Qualifiers.byName("default");
+        return Qualifiers.byName(DEFAULT_QUALIFIER);
     }
 }

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/configuration/ObjectStorageModuleConfiguration.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/configuration/ObjectStorageModuleConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Object Storage Classes related to Azure Blob Storage.
- * <a href="https://azure.microsoft.com/en-us/services/storage/blobs/#overview">Azure Blob Storage</a>
- * @author Sergio del Amo
- * @since 1.0.0
- */
-@Configuration
-@Requires(property = AzureBlobStorageConfiguration.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
-package io.micronaut.objectstorage.azure;
+package io.micronaut.objectstorage.configuration;
 
-import io.micronaut.context.annotation.Configuration;
-import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.util.StringUtils;
+import io.micronaut.core.util.Toggleable;
+
+/**
+ * Common properties for an Object Storage module.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 2.0.2
+ */
+public interface ObjectStorageModuleConfiguration extends Toggleable {
+
+    boolean DEFAULT_ENABLED = true;
+
+}

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageConfiguration.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageConfiguration.java
@@ -60,4 +60,12 @@ public class GoogleCloudStorageConfiguration extends AbstractObjectStorageConfig
         this.bucket = bucket;
     }
 
+    /**
+     * Whether to enable or disable this object storage.
+     * @since 2.0.2
+     */
+    @Override
+    public boolean isEnabled() {
+        return this.enabled;
+    }
 }

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageModuleConfiguration.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageModuleConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.googlecloud;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.objectstorage.configuration.AbstractObjectStorageModuleConfiguration;
+
+/**
+ * Google Cloud Storage module configuration.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 2.0.2
+ */
+@ConfigurationProperties(GoogleCloudStorageConfiguration.PREFIX)
+public class GoogleCloudStorageModuleConfiguration extends AbstractObjectStorageModuleConfiguration {
+
+    /**
+     * Whether to enable or disable the whole Google Cloud Storage module.
+     */
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageOperations.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageOperations.java
@@ -22,11 +22,13 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.objectstorage.InputStreamMapper;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.ObjectStorageOperations;
+import io.micronaut.objectstorage.configuration.ObjectStorageEnabledCondition;
 import io.micronaut.objectstorage.request.UploadRequest;
 import io.micronaut.objectstorage.response.UploadResponse;
 
@@ -43,6 +45,8 @@ import java.util.stream.StreamSupport;
  * @since 1.0
  */
 @EachBean(GoogleCloudStorageConfiguration.class)
+@Requires(condition = ObjectStorageEnabledCondition.class)
+@Requires(beans = GoogleCloudStorageConfiguration.class)
 public class GoogleCloudStorageOperations
     implements ObjectStorageOperations<BlobInfo.Builder, Blob, Boolean> {
 

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/package-info.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/package-info.java
@@ -19,4 +19,10 @@
  * @author Sergio del Amo
  * @since 1.0.0
  */
+@Configuration
+@Requires(property = GoogleCloudStorageConfiguration.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
 package io.micronaut.objectstorage.googlecloud;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;

--- a/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/GoogleCloudObjectStorageConfigurationSpec.groovy
+++ b/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/GoogleCloudObjectStorageConfigurationSpec.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.objectstorage.googlecloud
+
+import io.micronaut.objectstorage.ObjectStorageConfigurationSpecification
+
+class GoogleCloudObjectStorageConfigurationSpec extends ObjectStorageConfigurationSpecification<GoogleCloudStorageOperations> {
+
+    @Override
+    String getConfigPrefix() {
+        return GoogleCloudStorageConfiguration.PREFIX
+    }
+
+    @Override
+    Class<GoogleCloudStorageOperations> getObjectStorage() {
+        return GoogleCloudStorageOperations.class
+    }
+}

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageConfiguration.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageConfiguration.java
@@ -70,4 +70,13 @@ public class LocalStorageConfiguration extends AbstractObjectStorageConfiguratio
     public void setPath(@NonNull Path path) {
         this.path = path;
     }
+
+    /**
+     * Whether to enable or disable this object storage.
+     * @since 2.0.2
+     */
+    @Override
+    public boolean isEnabled() {
+        return this.enabled;
+    }
 }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageModuleConfiguration.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageModuleConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.local;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.objectstorage.configuration.AbstractObjectStorageModuleConfiguration;
+
+/**
+ * Local Storage module configuration.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 2.0.2
+ */
+@ConfigurationProperties(LocalStorageConfiguration.PREFIX)
+public class LocalStorageModuleConfiguration extends AbstractObjectStorageModuleConfiguration {
+
+    /**
+     * Whether to enable or disable the whole Local Storage module.
+     */
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -17,9 +17,11 @@ package io.micronaut.objectstorage.local;
 
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.ObjectStorageOperations;
+import io.micronaut.objectstorage.configuration.ObjectStorageEnabledCondition;
 import io.micronaut.objectstorage.request.UploadRequest;
 import io.micronaut.objectstorage.response.UploadResponse;
 
@@ -49,6 +51,8 @@ import java.util.stream.Stream;
  * @since 2.0.0
  */
 @EachBean(LocalStorageConfiguration.class)
+@Requires(condition = ObjectStorageEnabledCondition.class)
+@Requires(beans = LocalStorageConfiguration.class)
 public class LocalStorageOperations implements ObjectStorageOperations<
     LocalStorageOperations.LocalStorageFile,
     LocalStorageOperations.LocalStorageFile,

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/package-info.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 /**
- * Object Storage Classes related to Azure Blob Storage.
- * <a href="https://azure.microsoft.com/en-us/services/storage/blobs/#overview">Azure Blob Storage</a>
- * @author Sergio del Amo
- * @since 1.0.0
+ * Object Storage classes relateed to Local storage.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 2.0.2
  */
 @Configuration
-@Requires(property = AzureBlobStorageConfiguration.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
-package io.micronaut.objectstorage.azure;
+@Requires(property = LocalStorageConfiguration.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
+package io.micronaut.objectstorage.local;
 
 import io.micronaut.context.annotation.Configuration;
 import io.micronaut.context.annotation.Requires;

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageConfigurationSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageConfigurationSpec.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.objectstorage.local
+
+import io.micronaut.objectstorage.ObjectStorageConfigurationSpecification
+
+class LocalStorageConfigurationSpec extends ObjectStorageConfigurationSpecification<LocalStorageOperations> {
+
+    @Override
+    String getConfigPrefix() {
+        return LocalStorageConfiguration.PREFIX
+    }
+
+    @Override
+    Class<LocalStorageOperations> getObjectStorage() {
+        return LocalStorageOperations.class
+    }
+}

--- a/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageConfiguration.java
+++ b/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageConfiguration.java
@@ -91,4 +91,12 @@ public class OracleCloudStorageConfiguration extends AbstractObjectStorageConfig
         this.namespace = namespace;
     }
 
+    /**
+     * Whether to enable or disable this object storage.
+     * @since 2.0.2
+     */
+    @Override
+    public boolean isEnabled() {
+        return this.enabled;
+    }
 }

--- a/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageModuleConfiguration.java
+++ b/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageModuleConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.oraclecloud;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.objectstorage.configuration.AbstractObjectStorageModuleConfiguration;
+
+/**
+ * Oracle Cloud Storage module configuration.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 2.0.2
+ */
+@ConfigurationProperties(OracleCloudStorageConfiguration.PREFIX)
+public class OracleCloudStorageModuleConfiguration extends AbstractObjectStorageModuleConfiguration {
+
+    /**
+     * Whether to enable or disable the whole Oracle Cloud Storage module.
+     */
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageOperations.java
+++ b/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageOperations.java
@@ -32,10 +32,12 @@ import com.oracle.bmc.objectstorage.responses.ListObjectsResponse;
 import com.oracle.bmc.objectstorage.responses.PutObjectResponse;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.ObjectStorageOperations;
+import io.micronaut.objectstorage.configuration.ObjectStorageEnabledCondition;
 import io.micronaut.objectstorage.request.UploadRequest;
 import io.micronaut.objectstorage.response.UploadResponse;
 import jakarta.inject.Inject;
@@ -55,6 +57,8 @@ import java.util.stream.Collectors;
  * @since 1.0
  */
 @EachBean(OracleCloudStorageConfiguration.class)
+@Requires(condition = ObjectStorageEnabledCondition.class)
+@Requires(beans = OracleCloudStorageConfiguration.class)
 public class OracleCloudStorageOperations
     implements ObjectStorageOperations<PutObjectRequest.Builder, PutObjectResponse, DeleteObjectResponse> {
 

--- a/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/package-info.java
+++ b/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/package-info.java
@@ -19,4 +19,10 @@
  * @author Sergio del Amo
  * @since 1.0.0
  */
+@Configuration
+@Requires(property = OracleCloudStorageConfiguration.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
 package io.micronaut.objectstorage.oraclecloud;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;

--- a/object-storage-oracle-cloud/src/test/groovy/io/micronaut/objectstorage/oraclecloud/LocalStorageConfigurationSpec.groovy
+++ b/object-storage-oracle-cloud/src/test/groovy/io/micronaut/objectstorage/oraclecloud/LocalStorageConfigurationSpec.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.objectstorage.oraclecloud
+
+import io.micronaut.objectstorage.ObjectStorageConfigurationSpecification
+
+class OracleCloudStorageConfigurationSpec extends ObjectStorageConfigurationSpecification<OracleCloudStorageOperations> {
+
+    @Override
+    String getConfigPrefix() {
+        return OracleCloudStorageConfiguration.PREFIX
+    }
+
+    @Override
+    Class<OracleCloudStorageOperations> getObjectStorage() {
+        return OracleCloudStorageOperations.class
+    }
+}

--- a/object-storage-oracle-cloud/src/test/groovy/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageOciEmulatorSpec.groovy
+++ b/object-storage-oracle-cloud/src/test/groovy/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageOciEmulatorSpec.groovy
@@ -11,12 +11,14 @@ import jakarta.inject.Singleton
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.utility.DockerImageName
 import spock.lang.AutoCleanup
+import spock.lang.Ignore
 import spock.lang.Shared
 
 import static io.micronaut.objectstorage.oraclecloud.OracleCloudStorageConfiguration.PREFIX
 
 @MicronautTest
 @Property(name = 'spec.name', value = SPEC_NAME)
+@Ignore("Emulator is unreliable. To re-evaluate in the future, but low priority since actual cloud tests are run in CI")
 class OracleCloudStorageOciEmulatorSpec extends AbstractOracleCloudStorageSpec {
 
     public static final String SPEC_NAME = 'OracleCloudStorageOciEmulatorSpec'

--- a/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/ObjectStorageConfigurationSpecification.groovy
+++ b/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/ObjectStorageConfigurationSpecification.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import io.micronaut.inject.qualifiers.Qualifiers
+import spock.lang.Specification
+
+abstract class ObjectStorageConfigurationSpecification<O extends ObjectStorageOperations<?, ?, ?>> extends Specification {
+
+    void "it can be disabled"() {
+        given:
+        String configProp = getConfigPrefix() + ".default.enabled"
+        def ctx = ApplicationContext.run([(configProp): false])
+
+        expect:
+        !ctx.containsBean(getObjectStorage())
+
+        cleanup:
+        ctx.close()
+    }
+
+    void "it can be disabled with multiple configurations"() {
+        given:
+        String defaultProp = getConfigPrefix() + ".default.enabled"
+        String otherProp = getConfigPrefix() + ".other.enabled"
+        def ctx = ApplicationContext.run([
+                (defaultProp): false,
+                (otherProp): true
+        ], Environment.TEST)
+
+        expect:
+        !ctx.containsBean(getObjectStorage(), Qualifiers.byName("default"))
+
+        when:
+        def bean = ctx.containsBean(getObjectStorage(), Qualifiers.byName("other"))
+
+        then:
+        bean
+
+        cleanup:
+        ctx.close()
+    }
+
+    void "the whole module can be disabled"() {
+        given:
+        String moduleProp = getConfigPrefix() + ".enabled"
+        String configProp = getConfigPrefix() + ".default.enabled"
+        def ctx = ApplicationContext.run([
+                (configProp): true,
+                (moduleProp): false
+        ])
+
+        expect:
+        !ctx.containsBean(getObjectStorage())
+
+        cleanup:
+        ctx.close()
+    }
+
+    abstract String getConfigPrefix()
+
+    abstract Class<O> getObjectStorage()
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,7 +33,6 @@ configure<MicronautBuildSettingsExtension> {
     useStandardizedProjectNames.set(true)
     importMicronautCatalog()
     importMicronautCatalog("micronaut-aws")
-    importMicronautCatalog("micronaut-logging")
     importMicronautCatalog("micronaut-azure")
     importMicronautCatalog("micronaut-gcp")
     importMicronautCatalog("micronaut-oracle-cloud")


### PR DESCRIPTION
This PR adds the ability to enable disable an object storage, or the whole module.

Several configuration classes were added with the sole purpose of having the configuration reference correctly populated.

Fixes #308