### PR TITLE
Update versions for Micronaut 4.1.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,28 +1,29 @@
 [versions]
-micronaut = "4.0.2"
-micronaut-platform = "4.0.0-RC1"
+micronaut = "4.1.6"
+micronaut-platform = "4.1.2"
 micronaut-docs = "2.0.0"
-micronaut-test = "4.0.0"
+micronaut-test = "4.0.2"
 micronaut-aws = "4.0.4"
 micronaut-azure = "5.0.1"
 micronaut-gcp = "5.0.4"
-micronaut-oracle-cloud = "3.0.3"
-micronaut-validation = "4.0.1"
+micronaut-oracle-cloud = "3.0.5"
+micronaut-validation = "4.0.3"
 micronaut-logging = "1.0.0"
 
-groovy = '4.0.13'
+groovy = '4.0.15'
 spock = '2.3-groovy-4.0'
 gcp-libraries = '26.18.0'
 testcontainers = '1.18.3'
 bytebuddy = '1.14.5'
 
 # Gradle plugins
-micronaut-gradle-plugin = "4.0.1"
+micronaut-gradle-plugin = "4.0.4"
 kotlin-gradle-plugin = "1.8.22"
 
 [libraries]
 # Core
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
+micronaut-platform = { module = 'io.micronaut.platform:micronaut-platform', version.ref = 'micronaut-platform' }
 
 # AWS
 micronaut-aws = { module = 'io.micronaut.aws:micronaut-aws-bom', version.ref = 'micronaut-aws' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "4.1.6"
+micronaut = "4.1.8"
 micronaut-platform = "4.1.2"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.0.2"


### PR DESCRIPTION
v2.0.3 of this lib was in micronaut 4.1.2, so this PR updates patch releases for 4.1.3

- Micronaut core to 4.1.6
- Micronaut platform to 4.1.2
- Test to 4.0.2
- oracle cloud to 3.0.5
- validation to 4.0.3
- gradle plugin to 4.0.4

Also added a platform library so renovate has a chance

_Think_ this is also required to [fix the object-storage guide in maven](https://github.com/micronaut-projects/micronaut-guides/pull/1333#issuecomment-1735906982) as currently, this pulls in oracle-cloud which pulls multiple versions of oracle libs