### PR TITLE
Add metadata persistence plugin

### DIFF
--- a/doc-examples/example-java/src/main/java/example/MetadataProfileService.java
+++ b/doc-examples/example-java/src/main/java/example/MetadataProfileService.java
@@ -1,0 +1,55 @@
+package example;
+
+import io.micronaut.objectstorage.metadata.MetadataAwareObjectStorageOperations;
+import io.micronaut.objectstorage.metadata.ObjectStorageMetadataOperations;
+import io.micronaut.objectstorage.metadata.StorageContainerMetadata;
+import io.micronaut.objectstorage.metadata.StorageDescriptor;
+import io.micronaut.objectstorage.metadata.StorageObjectMetadataQuery;
+import io.micronaut.objectstorage.request.UploadRequest;
+import io.micronaut.objectstorage.response.UploadResponse;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+import java.util.Optional;
+
+//tag::beginclass[]
+@Singleton
+public class MetadataProfileService {
+
+    private final MetadataAwareObjectStorageOperations<?, ?, ?> objectStorage;
+    private final ObjectStorageMetadataOperations metadataOperations;
+    private final StorageDescriptor storageDescriptor;
+
+    public MetadataProfileService(@Named("pictures") MetadataAwareObjectStorageOperations<?, ?, ?> objectStorage,
+                                  @Named("pictures") ObjectStorageMetadataOperations metadataOperations,
+                                  @Named("pictures") StorageDescriptor storageDescriptor) {
+        this.objectStorage = objectStorage;
+        this.metadataOperations = metadataOperations;
+        this.storageDescriptor = storageDescriptor;
+    }
+//end::beginclass[]
+
+    //tag::upload[]
+    public UploadResponse<?> uploadProfilePicture(String tenantId, String container, String userId) {
+        UploadRequest request = UploadRequest.fromBytes((tenantId + ":" + userId).getBytes(), container + "/" + userId);
+        return objectStorage.upload(request);
+    }
+    //end::upload[]
+
+    //tag::prefix[]
+    public List<String> listByPrefix(String prefix) {
+        return metadataOperations.listObjects(StorageObjectMetadataQuery.all().withObjectKeyPrefix(prefix))
+            .stream()
+            .map(storageObject -> storageObject.getObjectKey())
+            .toList();
+    }
+    //end::prefix[]
+
+    //tag::hook[]
+    public Optional<StorageContainerMetadata> containerMetadata() {
+        return metadataOperations.findContainer(storageDescriptor);
+    }
+    //end::hook[]
+}
+//end::endclass[]

--- a/doc-examples/example-java/src/test/groovy/example/MetadataProfileServiceSpec.groovy
+++ b/doc-examples/example-java/src/test/groovy/example/MetadataProfileServiceSpec.groovy
@@ -1,0 +1,355 @@
+package example
+
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.env.Environment
+import io.micronaut.objectstorage.aws.AwsS3Operations
+import io.micronaut.objectstorage.metadata.ObjectMetadataReconciliationState
+import io.micronaut.objectstorage.metadata.MetadataAwareObjectStorageOperations
+import io.micronaut.objectstorage.metadata.ObjectStorageLifecycleHook
+import io.micronaut.objectstorage.metadata.ObjectStorageMetadataOperations
+import io.micronaut.objectstorage.metadata.ObjectStorageOperationContext
+import io.micronaut.objectstorage.metadata.ObjectStorageOperationOutcome
+import io.micronaut.objectstorage.metadata.ObjectMetadataSyncStatus
+import io.micronaut.objectstorage.metadata.ObjectStorageOperationType
+import io.micronaut.objectstorage.metadata.StorageContainerMetadata
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata
+import io.micronaut.objectstorage.metadata.StorageObjectMetadataQuery
+import io.micronaut.objectstorage.metadata.TenantResolver
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.objectstorage.response.UploadResponse
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.utility.DockerImageName
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.time.Instant
+import java.util.Optional
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+
+import static io.micronaut.objectstorage.test.ObjectStorageTestConstants.LOCAL_STACK_DOCKER_IMAGE
+
+@MicronautTest(environments = [Environment.AMAZON_EC2, "metadata-profile"])
+class MetadataProfileServiceSpec extends Specification implements TestPropertyProvider {
+
+    public static final String BUCKET_NAME = "profile-pictures-bucket"
+    public static final String USER_ID = "user123"
+    public static final String OBJECT_KEY = USER_ID + "/logo.png"
+
+    @Shared
+    @AutoCleanup
+    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
+            .withServices(LocalStackContainer.Service.S3)
+
+    @Inject
+    MetadataProfileService service
+
+    @Inject
+    @Named("pictures")
+    AwsS3Operations awsS3Operations
+
+    @Inject
+    @Named("pictures")
+    MetadataAwareObjectStorageOperations metadataAwareStorage
+
+    @Inject
+    @Named("pictures")
+    ObjectStorageMetadataOperations metadataOperations
+
+    @Inject
+    @Named("pictures")
+    StorageDescriptor storageDescriptor
+
+    @Inject
+    @Named("pictures")
+    InMemoryMetadataAwareObjectStorageOperations metadataWorkflow
+
+    @Inject
+    RecordingLifecycleHook hook
+
+    @Override
+    Map<String, String> getProperties() {
+        localstack.start()
+        localstack.execInContainer("awslocal", "s3api", "create-bucket", "--bucket", BUCKET_NAME)
+        return [
+                "aws.accessKeyId": localstack.getAccessKey(),
+                "aws.secretKey": localstack.getSecretKey(),
+                "aws.region": localstack.getRegion(),
+                "aws.services.s3.endpoint-override": localstack.getEndpointOverride(LocalStackContainer.Service.S3),
+                "micronaut.object-storage.aws.pictures.bucket": BUCKET_NAME,
+                "micronaut.object-storage.default-storage": "pictures",
+                "micronaut.object-storage.tenant-id": "tenant-a"
+        ]
+    }
+
+    void "it exercises named metadata-aware upload workflow and metadata-backed prefix queries"() {
+        expect:
+        storageDescriptor.storageName == "pictures"
+        storageDescriptor.providerContainer == BUCKET_NAME
+        metadataAwareStorage.getMetadataOperations().is(metadataOperations)
+        !service.containerMetadata().present
+        service.listByPrefix(USER_ID).isEmpty()
+
+        when:
+        def uploadResult = service.uploadProfilePicture("tenant-a", USER_ID, "logo.png")
+
+        then:
+        uploadResult.key == OBJECT_KEY
+        metadataWorkflow.uploadCount.get() == 1
+        awsS3Operations.retrieve(OBJECT_KEY).present
+        metadataOperations.findContainer(storageDescriptor).present
+        metadataOperations.findObject(storageDescriptor, OBJECT_KEY).present
+        metadataOperations.listObjects(StorageObjectMetadataQuery.all().withStorageName("pictures").withObjectKeyPrefix(USER_ID))*.objectKey == [OBJECT_KEY]
+        metadataOperations.listObjects(StorageObjectMetadataQuery.all().withStorageName("logos").withObjectKeyPrefix(USER_ID)).isEmpty()
+        service.listByPrefix(USER_ID) == [OBJECT_KEY]
+        hook.events.size() == 2
+        hook.events[0] == new Event("before", "pictures", OBJECT_KEY, false, null, false)
+        hook.events[1] == new Event("after", "pictures", OBJECT_KEY, true, ObjectStorageOperationType.UPLOAD, true)
+    }
+
+    @Singleton
+    @io.micronaut.context.annotation.Requires(env = "metadata-profile")
+    @Replaces(ObjectStorageLifecycleHook)
+    static class RecordingLifecycleHook implements ObjectStorageLifecycleHook {
+        private final ObjectStorageMetadataOperations metadataOperations
+        List<Event> events = new CopyOnWriteArrayList<>()
+
+        RecordingLifecycleHook(@Named("pictures") ObjectStorageMetadataOperations metadataOperations) {
+            this.metadataOperations = metadataOperations
+        }
+
+        @Override
+        void before(ObjectStorageOperationContext context) {
+            events.add(new Event(
+                "before",
+                context.storageDescriptor.storageName,
+                context.objectKey,
+                metadataOperations.findContainer(context.storageDescriptor).present,
+                null,
+                false
+            ))
+        }
+
+        @Override
+        void after(ObjectStorageOperationContext context, ObjectStorageOperationOutcome outcome) {
+            events.add(new Event(
+                "after",
+                context.storageDescriptor.storageName,
+                context.objectKey,
+                metadataOperations.findContainer(context.storageDescriptor).present,
+                outcome.operationType,
+                outcome.reconciliationId.present
+            ))
+        }
+    }
+
+    @Singleton
+    @io.micronaut.context.annotation.Requires(env = "metadata-profile")
+    @Replaces(TenantResolver)
+    static class FixedTenantResolver implements TenantResolver {
+        @Override
+        String resolveTenantId() {
+            return "tenant-a"
+        }
+    }
+
+    @Factory
+    @io.micronaut.context.annotation.Requires(env = "metadata-profile")
+    static class MetadataWorkflowTestFactory {
+        @Singleton
+        @Named("pictures")
+        StorageDescriptor picturesStorageDescriptor() {
+            new StorageDescriptor("pictures", "aws", BUCKET_NAME, null, BUCKET_NAME)
+        }
+
+        @Singleton
+        @Named("pictures")
+        InMemoryMetadataOperations picturesMetadataOperations(TenantResolver tenantResolver,
+                                                              @Named("pictures") StorageDescriptor descriptor) {
+            new InMemoryMetadataOperations(tenantResolver, descriptor)
+        }
+
+        @Singleton
+        @Named("pictures")
+        InMemoryMetadataAwareObjectStorageOperations picturesMetadataAwareOperations(@Named("pictures") AwsS3Operations delegate,
+                                                                                      @Named("pictures") InMemoryMetadataOperations metadataOperations,
+                                                                                      @Named("pictures") StorageDescriptor descriptor,
+                                                                                      TenantResolver tenantResolver,
+                                                                                      Collection<ObjectStorageLifecycleHook> lifecycleHooks) {
+            new InMemoryMetadataAwareObjectStorageOperations(delegate, metadataOperations, descriptor, tenantResolver, lifecycleHooks)
+        }
+    }
+
+    static class InMemoryMetadataOperations implements ObjectStorageMetadataOperations {
+        private final TenantResolver tenantResolver
+        private final StorageDescriptor descriptor
+        private final Map<String, StorageContainerMetadata> containersByTenant = new ConcurrentHashMap<>()
+        private final Map<String, Map<String, StorageObjectMetadata>> objectsByTenant = new ConcurrentHashMap<>()
+
+        InMemoryMetadataOperations(TenantResolver tenantResolver, StorageDescriptor descriptor) {
+            this.tenantResolver = tenantResolver
+            this.descriptor = descriptor
+        }
+
+        void markUploadVisible(String tenantId, UploadRequest request, UploadResponse<?> response) {
+            Instant now = Instant.now()
+            containersByTenant.computeIfAbsent(tenantId) {
+                new StorageContainerMetadata(tenantId, descriptor, now, now)
+            }
+            StorageObjectMetadata metadata = new StorageObjectMetadata(
+                tenantId,
+                descriptor,
+                request.key,
+                null,
+                request.contentType.orElse(null),
+                request.contentSize.orElse(null),
+                response.ETag,
+                null,
+                null,
+                now,
+                now,
+                new ObjectMetadataSyncStatus(ObjectMetadataReconciliationState.SUCCEEDED, null)
+            )
+            objectsByTenant.computeIfAbsent(tenantId) { new ConcurrentHashMap<>() }
+                .put(request.key, metadata)
+        }
+
+        @Override
+        TenantResolver getTenantResolver() {
+            tenantResolver
+        }
+
+        @Override
+        Optional<StorageContainerMetadata> findContainer(StorageDescriptor storageDescriptor) {
+            if (storageDescriptor.storageName != descriptor.storageName || storageDescriptor.logicalContainer != descriptor.logicalContainer) {
+                return Optional.empty()
+            }
+            Optional.ofNullable(containersByTenant.get(getActiveTenantId()))
+        }
+
+        @Override
+        Optional<StorageObjectMetadata> findObject(StorageDescriptor storageDescriptor, String objectKey) {
+            if (storageDescriptor.storageName != descriptor.storageName || storageDescriptor.logicalContainer != descriptor.logicalContainer) {
+                return Optional.empty()
+            }
+            Optional.ofNullable(objectsByTenant.getOrDefault(getActiveTenantId(), [:]).get(objectKey))
+        }
+
+        @Override
+        List<StorageObjectMetadata> listObjects(StorageObjectMetadataQuery query) {
+            objectsByTenant.getOrDefault(getActiveTenantId(), [:])
+                .values()
+                .findAll { StorageObjectMetadata metadata ->
+                    boolean storageMatches = query.storageName.map { it == metadata.storageName }.orElse(true)
+                    boolean containerMatches = query.logicalContainer.map { it == metadata.logicalContainer }.orElse(true)
+                    boolean prefixMatches = query.objectKeyPrefix.map { metadata.objectKey.startsWith(it) }.orElse(true)
+                    storageMatches && containerMatches && prefixMatches
+                }
+                .sort { a, b -> a.objectKey <=> b.objectKey }
+        }
+    }
+
+    static class InMemoryMetadataAwareObjectStorageOperations implements MetadataAwareObjectStorageOperations<Object, Object, Object> {
+        private final AwsS3Operations delegate
+        private final InMemoryMetadataOperations metadataOperations
+        private final StorageDescriptor descriptor
+        private final TenantResolver tenantResolver
+        private final Collection<ObjectStorageLifecycleHook> lifecycleHooks
+        final AtomicInteger uploadCount = new AtomicInteger()
+
+        InMemoryMetadataAwareObjectStorageOperations(AwsS3Operations delegate,
+                                                     InMemoryMetadataOperations metadataOperations,
+                                                     StorageDescriptor descriptor,
+                                                     TenantResolver tenantResolver,
+                                                     Collection<ObjectStorageLifecycleHook> lifecycleHooks) {
+            this.delegate = delegate
+            this.metadataOperations = metadataOperations
+            this.descriptor = descriptor
+            this.tenantResolver = tenantResolver
+            this.lifecycleHooks = lifecycleHooks
+        }
+
+        @Override
+        ObjectStorageMetadataOperations getMetadataOperations() {
+            metadataOperations
+        }
+
+        @Override
+        Collection<ObjectStorageLifecycleHook> getLifecycleHooks() {
+            lifecycleHooks
+        }
+
+        @Override
+        UploadResponse<Object> upload(UploadRequest request) {
+            String tenantId = tenantResolver.resolveTenantId()
+            ObjectStorageOperationContext context = ObjectStorageOperationContext.forUpload(tenantId, descriptor, request)
+            for (ObjectStorageLifecycleHook hook : getOrderedLifecycleHooks()) {
+                hook.before(context)
+            }
+            try {
+                UploadResponse<Object> response = delegate.upload(request)
+                metadataOperations.markUploadVisible(tenantId, request, response)
+                ObjectStorageOperationOutcome outcome = ObjectStorageOperationOutcome.uploadSuccess(context, response, "example-rec-${uploadCount.incrementAndGet()}")
+                for (ObjectStorageLifecycleHook hook : getOrderedLifecycleHooks()) {
+                    hook.after(context, outcome)
+                }
+                return response
+            } catch (RuntimeException e) {
+                for (ObjectStorageLifecycleHook hook : getOrderedLifecycleHooks()) {
+                    hook.error(context, e)
+                }
+                throw e
+            }
+        }
+
+        @Override
+        UploadResponse<Object> upload(UploadRequest request, java.util.function.Consumer<Object> requestConsumer) {
+            String tenantId = tenantResolver.resolveTenantId()
+            ObjectStorageOperationContext context = ObjectStorageOperationContext.forUpload(tenantId, descriptor, request)
+            for (ObjectStorageLifecycleHook hook : getOrderedLifecycleHooks()) {
+                hook.before(context)
+            }
+            try {
+                UploadResponse<Object> response = delegate.upload(request, requestConsumer)
+                metadataOperations.markUploadVisible(tenantId, request, response)
+                ObjectStorageOperationOutcome outcome = ObjectStorageOperationOutcome.uploadSuccess(context, response, "example-rec-${uploadCount.incrementAndGet()}")
+                for (ObjectStorageLifecycleHook hook : getOrderedLifecycleHooks()) {
+                    hook.after(context, outcome)
+                }
+                return response
+            } catch (RuntimeException e) {
+                for (ObjectStorageLifecycleHook hook : getOrderedLifecycleHooks()) {
+                    hook.error(context, e)
+                }
+                throw e
+            }
+        }
+
+        @Override
+        Optional retrieve(String key) {
+            delegate.retrieve(key)
+        }
+
+        @Override
+        Object delete(String key) {
+            delegate.delete(key)
+        }
+    }
+
+    record Event(String phase,
+                 String storageName,
+                 String objectKey,
+                 boolean containerMetadataPresent,
+                 ObjectStorageOperationType operationType,
+                 boolean reconciliationIdPresent) {
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,8 @@ micronaut-logging = "2.0.0-M2"
 
 gcp-libraries = '26.78.0'
 bytebuddy = '1.17.8'
+testcontainers = '1.21.3'
+postgresql = '42.7.8'
 
 # Gradle plugins
 micronaut-gradle-plugin = "4.6.2"
@@ -40,6 +42,10 @@ gcp-storage = { module = 'com.google.cloud:google-cloud-storage' }
 # Oracle Cloud
 micronaut-oracle-cloud = { module = 'io.micronaut.oraclecloud:micronaut-oraclecloud-bom', version.ref = 'micronaut-oracle-cloud' }
 
+# Data
+micronaut-data = { module = "io.micronaut.data:micronaut-data-bom", version = "4.13.6" }
+micronaut-sql = { module = "io.micronaut.sql:micronaut-sql-bom", version = "6.1.0" }
+
 # Others
 micronaut-test-resources = { module = "io.micronaut.testresources:micronaut-test-resources-bom", version.ref = "micronaut-test-resources" }
 micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "micronaut-validation" }
@@ -51,3 +57,8 @@ bytebuddy = { module = 'net.bytebuddy:byte-buddy', version.ref = 'bytebuddy' }
 gradle-micronaut = { module = 'io.micronaut.gradle:micronaut-gradle-plugin', version.ref = 'micronaut-gradle-plugin' }
 gradle-kotlin = { module = 'org.jetbrains.kotlin:kotlin-gradle-plugin', version.ref = 'kotlin-gradle-plugin' }
 gradle-kotlin-ksp = { module = 'com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin', version.ref = 'kotlin-gradle-ksp-plugin' }
+
+ojdbc11 = { module = "com.oracle.database.jdbc:ojdbc11", version = "23.8.0.25.04" }
+postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
+testcontainers-oracle-free = { module = "org.testcontainers:oracle-free", version = "1.21.3" }
+testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3StorageDescriptorResolver.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3StorageDescriptorResolver.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.aws;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.objectstorage.configuration.ToggeableCondition;
+import io.micronaut.objectstorage.metadata.StorageDescriptor;
+import io.micronaut.objectstorage.metadata.StorageDescriptorResolver;
+
+@EachBean(AwsS3Configuration.class)
+@Requires(condition = ToggeableCondition.class)
+@Requires(beans = AwsS3Configuration.class)
+public final class AwsS3StorageDescriptorResolver implements StorageDescriptorResolver {
+
+    private static final String PROVIDER_ID = "aws";
+
+    private final StorageDescriptor descriptor;
+
+    public AwsS3StorageDescriptorResolver(@Parameter AwsS3Configuration configuration) {
+        this.descriptor = new StorageDescriptor(
+            configuration.getName(),
+            PROVIDER_ID,
+            configuration.getBucket(),
+            null,
+            configuration.getBucket()
+        );
+    }
+
+    @Override
+    public StorageDescriptor resolve() {
+        return descriptor;
+    }
+}

--- a/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageDescriptorResolver.java
+++ b/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageDescriptorResolver.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.azure;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.objectstorage.metadata.StorageDescriptor;
+import io.micronaut.objectstorage.metadata.StorageDescriptorResolver;
+
+@EachBean(AzureBlobStorageConfiguration.class)
+public final class AzureBlobStorageDescriptorResolver implements StorageDescriptorResolver {
+
+    private static final String PROVIDER_ID = "azure";
+
+    private final StorageDescriptor descriptor;
+
+    public AzureBlobStorageDescriptorResolver(@Parameter AzureBlobStorageConfiguration configuration) {
+        this.descriptor = new StorageDescriptor(
+            configuration.getName(),
+            PROVIDER_ID,
+            configuration.getContainer(),
+            null,
+            configuration.getContainer()
+        );
+    }
+
+    @Override
+    public StorageDescriptor resolve() {
+        return descriptor;
+    }
+}

--- a/object-storage-core/build.gradle.kts
+++ b/object-storage-core/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     io.micronaut.build.internal.`objectstorage-module`
 }
 
+val objectStorageTckProject = project(":micronaut-object-storage-tck")
+
 dependencies {
     annotationProcessor(mn.micronaut.inject.java)
 
@@ -11,9 +13,14 @@ dependencies {
     implementation(mn.micronaut.context)
     implementation(mn.micronaut.http.server)
 
+    testCompileOnly(files("${objectStorageTckProject.projectDir}/build/classes/groovy/main"))
+    testCompileOnly(files("${objectStorageTckProject.projectDir}/build/resources/main"))
     testImplementation(projects.micronautObjectStorageTck)
     testImplementation(mn.micronaut.http.server.netty)
-    
-    testImplementation(mn.reactor)
 
+    testImplementation(mn.reactor)
+}
+
+tasks.named("compileTestGroovy") {
+    dependsOn(":micronaut-object-storage-tck:compileGroovy")
 }

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/MetadataAwareObjectStorageOperations.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/MetadataAwareObjectStorageOperations.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import io.micronaut.objectstorage.ObjectStorageOperations;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Metadata-aware object storage workflow API.
+ *
+ * @param <I> Cloud vendor-specific upload request class or builder.
+ * @param <O> Cloud vendor-specific upload response.
+ * @param <D> Cloud vendor-specific delete response.
+ * @since 1.6.0
+ */
+public interface MetadataAwareObjectStorageOperations<I, O, D> extends ObjectStorageOperations<I, O, D> {
+
+    /**
+     * @return Metadata query operations associated with this storage.
+     */
+    @NonNull
+    ObjectStorageMetadataOperations getMetadataOperations();
+
+    /**
+     * @return Registered lifecycle hooks.
+     */
+    @NonNull
+    Collection<ObjectStorageLifecycleHook> getLifecycleHooks();
+
+    /**
+     * @return Deterministically ordered lifecycle hooks.
+     */
+    @NonNull
+    default List<ObjectStorageLifecycleHook> getOrderedLifecycleHooks() {
+        return ObjectStorageLifecycleHook.ordered(getLifecycleHooks());
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/MetadataDispatchException.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/MetadataDispatchException.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import io.micronaut.objectstorage.ObjectStorageException;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Raised when delegate storage succeeds but metadata dispatch/enqueue fails.
+ *
+ * @since 1.6.0
+ */
+public final class MetadataDispatchException extends ObjectStorageException {
+
+    private final ObjectStorageOperationContext operationContext;
+    private final ObjectStorageOperationOutcome operationOutcome;
+    @Nullable
+    private final String reconciliationId;
+
+    public MetadataDispatchException(@NonNull ObjectStorageOperationContext operationContext,
+                                     @NonNull ObjectStorageOperationOutcome operationOutcome,
+                                     @Nullable String reconciliationId,
+                                     @NonNull Throwable cause) {
+        super(buildMessage(operationContext, reconciliationId), Objects.requireNonNull(cause, "cause"));
+        this.operationContext = Objects.requireNonNull(operationContext, "operationContext");
+        this.operationOutcome = Objects.requireNonNull(operationOutcome, "operationOutcome");
+        this.reconciliationId = reconciliationId;
+    }
+
+    @NonNull
+    public ObjectStorageOperationContext getOperationContext() {
+        return operationContext;
+    }
+
+    @NonNull
+    public ObjectStorageOperationOutcome getOperationOutcome() {
+        return operationOutcome;
+    }
+
+    @NonNull
+    public Optional<String> getReconciliationId() {
+        return Optional.ofNullable(reconciliationId);
+    }
+
+    @NonNull
+    private static String buildMessage(@NonNull ObjectStorageOperationContext context,
+                                       @Nullable String reconciliationId) {
+        Objects.requireNonNull(context, "context");
+        StringBuilder message = new StringBuilder("Metadata dispatch failed after successful ")
+            .append(context.getOperationType())
+            .append(" for tenant '")
+            .append(context.getTenantId())
+            .append("' on storage '")
+            .append(context.getStorageDescriptor().getStorageName())
+            .append("' and key '")
+            .append(context.getObjectKey())
+            .append("'");
+        if (reconciliationId != null && !reconciliationId.isBlank()) {
+            message.append(" (reconciliationId=")
+                .append(reconciliationId)
+                .append(')');
+        }
+        return message.toString();
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectMetadataReconciliationState.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectMetadataReconciliationState.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+/**
+ * Reconciliation lifecycle for persisted object metadata visibility.
+ */
+public enum ObjectMetadataReconciliationState {
+    PENDING,
+    PROCESSING,
+    SUCCEEDED,
+    FAILED,
+    DEAD_LETTER
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectMetadataSyncStatus.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectMetadataSyncStatus.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Reconciliation status details tracked for object metadata records.
+ */
+public final class ObjectMetadataSyncStatus {
+
+    private final ObjectMetadataReconciliationState reconciliationState;
+    @Nullable
+    private final String lastErrorSummary;
+
+    public ObjectMetadataSyncStatus(@NonNull ObjectMetadataReconciliationState reconciliationState,
+                                    @Nullable String lastErrorSummary) {
+        this.reconciliationState = Objects.requireNonNull(reconciliationState, "reconciliationState");
+        this.lastErrorSummary = lastErrorSummary;
+    }
+
+    @NonNull
+    public ObjectMetadataReconciliationState getReconciliationState() {
+        return reconciliationState;
+    }
+
+    @NonNull
+    public Optional<String> getLastErrorSummary() {
+        return Optional.ofNullable(lastErrorSummary);
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectStorageLifecycleHook.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectStorageLifecycleHook.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import io.micronaut.core.order.Ordered;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Ordered lifecycle hook for metadata-aware storage workflows.
+ *
+ * Hooks run for upload, copy, and delete operations using deterministic
+ * {@link Ordered} precedence.
+ *
+ * @since 1.6.0
+ */
+public interface ObjectStorageLifecycleHook extends Ordered {
+
+    Comparator<ObjectStorageLifecycleHook> ORDER_COMPARATOR =
+        Comparator.<ObjectStorageLifecycleHook>comparingInt(ObjectStorageLifecycleHook::getOrder)
+            .thenComparing(hook -> hook.getClass().getName());
+
+    /**
+     * Callback before the delegate storage operation is invoked.
+     *
+     * @param context Operation context.
+     */
+    default void before(@NonNull ObjectStorageOperationContext context) {
+    }
+
+    /**
+     * Callback after a successful delegate storage operation.
+     *
+     * @param context Operation context.
+     * @param outcome Operation outcome.
+     */
+    default void after(@NonNull ObjectStorageOperationContext context,
+                       @NonNull ObjectStorageOperationOutcome outcome) {
+    }
+
+    /**
+     * Callback after a failed delegate storage or metadata dispatch operation.
+     *
+     * @param context Operation context.
+     * @param throwable Failure.
+     */
+    default void error(@NonNull ObjectStorageOperationContext context,
+                       @NonNull Throwable throwable) {
+    }
+
+    @Override
+    default int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+
+    /**
+     * @param hooks Hook collection.
+     * @return Hooks ordered deterministically by {@link Ordered#getOrder()}.
+     */
+    @NonNull
+    static List<ObjectStorageLifecycleHook> ordered(@NonNull Collection<ObjectStorageLifecycleHook> hooks) {
+        return hooks.stream().sorted(ORDER_COMPARATOR).toList();
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectStorageMetadataOperations.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectStorageMetadataOperations.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import io.micronaut.core.annotation.Blocking;
+import org.jspecify.annotations.NonNull;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Query API for object storage metadata.
+ *
+ * Implementations must scope all methods to the active tenant resolved by
+ * {@link #getTenantResolver()}.
+ *
+ * @since 1.6.0
+ */
+public interface ObjectStorageMetadataOperations {
+
+    /**
+     * @return Resolver used for active tenant scoping.
+     */
+    @NonNull
+    TenantResolver getTenantResolver();
+
+    /**
+     * @return Active tenant id used for default query scoping.
+     */
+    @NonNull
+    default String getActiveTenantId() {
+        return getTenantResolver().resolveTenantId();
+    }
+
+    /**
+     * Finds storage container metadata for the active tenant.
+     *
+     * @param storageDescriptor Storage descriptor.
+     * @return Container metadata if present.
+     */
+    @Blocking
+    @NonNull
+    Optional<StorageContainerMetadata> findContainer(@NonNull StorageDescriptor storageDescriptor);
+
+    /**
+     * Finds object metadata for the active tenant.
+     *
+     * @param storageDescriptor Storage descriptor.
+     * @param objectKey Object key.
+     * @return Object metadata if present.
+     */
+    @Blocking
+    @NonNull
+    Optional<StorageObjectMetadata> findObject(@NonNull StorageDescriptor storageDescriptor,
+                                               @NonNull String objectKey);
+
+    /**
+     * Lists object metadata for the active tenant.
+     *
+     * @param query Query filter.
+     * @return Matching metadata entries.
+     */
+    @Blocking
+    @NonNull
+    List<StorageObjectMetadata> listObjects(@NonNull StorageObjectMetadataQuery query);
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectStorageOperationContext.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectStorageOperationContext.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import io.micronaut.objectstorage.request.UploadRequest;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Context for lifecycle hook callbacks around storage operations.
+ *
+ * @since 1.6.0
+ */
+public final class ObjectStorageOperationContext {
+
+    private final String tenantId;
+    private final StorageDescriptor storageDescriptor;
+    private final ObjectStorageOperationType operationType;
+    private final String objectKey;
+    @Nullable
+    private final String destinationObjectKey;
+    @Nullable
+    private final UploadRequest uploadRequest;
+
+    public ObjectStorageOperationContext(@NonNull String tenantId,
+                                         @NonNull StorageDescriptor storageDescriptor,
+                                         @NonNull ObjectStorageOperationType operationType,
+                                         @NonNull String objectKey,
+                                         @Nullable String destinationObjectKey,
+                                         @Nullable UploadRequest uploadRequest) {
+        this.tenantId = Objects.requireNonNull(tenantId, "tenantId");
+        this.storageDescriptor = Objects.requireNonNull(storageDescriptor, "storageDescriptor");
+        this.operationType = Objects.requireNonNull(operationType, "operationType");
+        this.objectKey = Objects.requireNonNull(objectKey, "objectKey");
+        this.destinationObjectKey = destinationObjectKey;
+        this.uploadRequest = uploadRequest;
+    }
+
+    @NonNull
+    public static ObjectStorageOperationContext forUpload(@NonNull String tenantId,
+                                                          @NonNull StorageDescriptor storageDescriptor,
+                                                          @NonNull UploadRequest uploadRequest) {
+        Objects.requireNonNull(uploadRequest, "uploadRequest");
+        return new ObjectStorageOperationContext(
+            tenantId,
+            storageDescriptor,
+            ObjectStorageOperationType.UPLOAD,
+            uploadRequest.getKey(),
+            null,
+            uploadRequest
+        );
+    }
+
+    @NonNull
+    public static ObjectStorageOperationContext forCopy(@NonNull String tenantId,
+                                                        @NonNull StorageDescriptor storageDescriptor,
+                                                        @NonNull String sourceKey,
+                                                        @NonNull String destinationKey) {
+        return new ObjectStorageOperationContext(
+            tenantId,
+            storageDescriptor,
+            ObjectStorageOperationType.COPY,
+            sourceKey,
+            Objects.requireNonNull(destinationKey, "destinationKey"),
+            null
+        );
+    }
+
+    @NonNull
+    public static ObjectStorageOperationContext forDelete(@NonNull String tenantId,
+                                                          @NonNull StorageDescriptor storageDescriptor,
+                                                          @NonNull String objectKey) {
+        return new ObjectStorageOperationContext(
+            tenantId,
+            storageDescriptor,
+            ObjectStorageOperationType.DELETE,
+            objectKey,
+            null,
+            null
+        );
+    }
+
+    @NonNull
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    @NonNull
+    public StorageDescriptor getStorageDescriptor() {
+        return storageDescriptor;
+    }
+
+    @NonNull
+    public ObjectStorageOperationType getOperationType() {
+        return operationType;
+    }
+
+    @NonNull
+    public String getObjectKey() {
+        return objectKey;
+    }
+
+    @NonNull
+    public Optional<String> getDestinationObjectKey() {
+        return Optional.ofNullable(destinationObjectKey);
+    }
+
+    @NonNull
+    public Optional<UploadRequest> getUploadRequest() {
+        return Optional.ofNullable(uploadRequest);
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectStorageOperationOutcome.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectStorageOperationOutcome.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import io.micronaut.objectstorage.response.UploadResponse;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Successful delegate storage outcome captured for metadata workflows.
+ *
+ * @since 1.6.0
+ */
+public final class ObjectStorageOperationOutcome {
+
+    private final ObjectStorageOperationType operationType;
+    private final String tenantId;
+    private final StorageDescriptor storageDescriptor;
+    private final String objectKey;
+    @Nullable
+    private final String destinationObjectKey;
+    @Nullable
+    private final String reconciliationId;
+    @Nullable
+    private final UploadResponse<?> uploadResponse;
+    @Nullable
+    private final Object delegateResponse;
+
+    public ObjectStorageOperationOutcome(@NonNull ObjectStorageOperationType operationType,
+                                         @NonNull String tenantId,
+                                         @NonNull StorageDescriptor storageDescriptor,
+                                         @NonNull String objectKey,
+                                         @Nullable String destinationObjectKey,
+                                         @Nullable String reconciliationId,
+                                         @Nullable UploadResponse<?> uploadResponse,
+                                         @Nullable Object delegateResponse) {
+        this.operationType = Objects.requireNonNull(operationType, "operationType");
+        this.tenantId = Objects.requireNonNull(tenantId, "tenantId");
+        this.storageDescriptor = Objects.requireNonNull(storageDescriptor, "storageDescriptor");
+        this.objectKey = Objects.requireNonNull(objectKey, "objectKey");
+        this.destinationObjectKey = destinationObjectKey;
+        this.reconciliationId = reconciliationId;
+        this.uploadResponse = uploadResponse;
+        this.delegateResponse = delegateResponse;
+    }
+
+    @NonNull
+    public static ObjectStorageOperationOutcome uploadSuccess(@NonNull ObjectStorageOperationContext context,
+                                                              @NonNull UploadResponse<?> uploadResponse,
+                                                              @Nullable String reconciliationId) {
+        Objects.requireNonNull(context, "context");
+        return new ObjectStorageOperationOutcome(
+            ObjectStorageOperationType.UPLOAD,
+            context.getTenantId(),
+            context.getStorageDescriptor(),
+            context.getObjectKey(),
+            null,
+            reconciliationId,
+            Objects.requireNonNull(uploadResponse, "uploadResponse"),
+            null
+        );
+    }
+
+    @NonNull
+    public static ObjectStorageOperationOutcome copySuccess(@NonNull ObjectStorageOperationContext context,
+                                                            @Nullable Object delegateResponse,
+                                                            @Nullable String reconciliationId) {
+        Objects.requireNonNull(context, "context");
+        return new ObjectStorageOperationOutcome(
+            ObjectStorageOperationType.COPY,
+            context.getTenantId(),
+            context.getStorageDescriptor(),
+            context.getObjectKey(),
+            context.getDestinationObjectKey().orElse(null),
+            reconciliationId,
+            null,
+            delegateResponse
+        );
+    }
+
+    @NonNull
+    public static ObjectStorageOperationOutcome deleteSuccess(@NonNull ObjectStorageOperationContext context,
+                                                              @Nullable Object delegateResponse,
+                                                              @Nullable String reconciliationId) {
+        Objects.requireNonNull(context, "context");
+        return new ObjectStorageOperationOutcome(
+            ObjectStorageOperationType.DELETE,
+            context.getTenantId(),
+            context.getStorageDescriptor(),
+            context.getObjectKey(),
+            null,
+            reconciliationId,
+            null,
+            delegateResponse
+        );
+    }
+
+    @NonNull
+    public ObjectStorageOperationType getOperationType() {
+        return operationType;
+    }
+
+    @NonNull
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    @NonNull
+    public StorageDescriptor getStorageDescriptor() {
+        return storageDescriptor;
+    }
+
+    @NonNull
+    public String getObjectKey() {
+        return objectKey;
+    }
+
+    @NonNull
+    public Optional<String> getDestinationObjectKey() {
+        return Optional.ofNullable(destinationObjectKey);
+    }
+
+    @NonNull
+    public Optional<String> getReconciliationId() {
+        return Optional.ofNullable(reconciliationId);
+    }
+
+    @NonNull
+    public Optional<UploadResponse<?>> getUploadResponse() {
+        return Optional.ofNullable(uploadResponse);
+    }
+
+    @NonNull
+    public Optional<Object> getDelegateResponse() {
+        return Optional.ofNullable(delegateResponse);
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectStorageOperationType.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectStorageOperationType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+/**
+ * Operation types used by metadata dispatch workflows.
+ *
+ * @since 1.6.0
+ */
+public enum ObjectStorageOperationType {
+    UPLOAD,
+    COPY,
+    DELETE
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/StorageContainerMetadata.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/StorageContainerMetadata.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import org.jspecify.annotations.NonNull;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Metadata snapshot for a logical storage container.
+ */
+public final class StorageContainerMetadata {
+
+    private final String tenantId;
+    private final StorageDescriptor storageDescriptor;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+
+    public StorageContainerMetadata(@NonNull String tenantId,
+                                    @NonNull StorageDescriptor storageDescriptor,
+                                    @NonNull Instant createdAt,
+                                    @NonNull Instant updatedAt) {
+        this.tenantId = Objects.requireNonNull(tenantId, "tenantId");
+        this.storageDescriptor = Objects.requireNonNull(storageDescriptor, "storageDescriptor");
+        this.createdAt = Objects.requireNonNull(createdAt, "createdAt");
+        this.updatedAt = Objects.requireNonNull(updatedAt, "updatedAt");
+    }
+
+    @NonNull
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    @NonNull
+    public StorageDescriptor getStorageDescriptor() {
+        return storageDescriptor;
+    }
+
+    @NonNull
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    @NonNull
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/StorageDescriptor.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/StorageDescriptor.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Descriptor identifying a logical storage binding and provider target.
+ */
+public final class StorageDescriptor {
+
+    private final String storageName;
+    private final String providerId;
+    private final String logicalContainer;
+    @Nullable
+    private final String providerNamespace;
+    private final String providerContainer;
+
+    public StorageDescriptor(@NonNull String storageName,
+                             @NonNull String providerId,
+                             @NonNull String logicalContainer,
+                             @Nullable String providerNamespace,
+                             @NonNull String providerContainer) {
+        this.storageName = Objects.requireNonNull(storageName, "storageName");
+        this.providerId = Objects.requireNonNull(providerId, "providerId");
+        this.logicalContainer = Objects.requireNonNull(logicalContainer, "logicalContainer");
+        this.providerNamespace = providerNamespace;
+        this.providerContainer = Objects.requireNonNull(providerContainer, "providerContainer");
+    }
+
+    @NonNull
+    public String getStorageName() {
+        return storageName;
+    }
+
+    @NonNull
+    public String getProviderId() {
+        return providerId;
+    }
+
+    @NonNull
+    public String getLogicalContainer() {
+        return logicalContainer;
+    }
+
+    @NonNull
+    public Optional<String> getProviderNamespace() {
+        return Optional.ofNullable(providerNamespace);
+    }
+
+    @NonNull
+    public String getProviderContainer() {
+        return providerContainer;
+    }
+
+    @NonNull
+    public String getProviderContainerIdentity() {
+        return getProviderNamespace().map(namespace -> namespace + "/" + providerContainer).orElse(providerContainer);
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/StorageDescriptorResolver.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/StorageDescriptorResolver.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Resolves a storage descriptor for a configured storage bean.
+ *
+ * @since 1.6.0
+ */
+public interface StorageDescriptorResolver {
+
+    /**
+     * @return The resolved storage descriptor.
+     */
+    @NonNull
+    StorageDescriptor resolve();
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/StorageObjectMetadata.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/StorageObjectMetadata.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/**
+ * Metadata snapshot for a single object in logical storage.
+ */
+public final class StorageObjectMetadata {
+
+    private final String tenantId;
+    private final StorageDescriptor storageDescriptor;
+    private final String objectKey;
+    private final String objectKeyHash;
+    @Nullable
+    private final String contentType;
+    @Nullable
+    private final Long contentLength;
+    @Nullable
+    private final String etag;
+    @Nullable
+    private final String providerVersionId;
+    @Nullable
+    private final String checksum;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+    private final ObjectMetadataSyncStatus syncStatus;
+
+    public StorageObjectMetadata(@NonNull String tenantId,
+                                 @NonNull StorageDescriptor storageDescriptor,
+                                 @NonNull String objectKey,
+                                 @Nullable String objectKeyHash,
+                                 @Nullable String contentType,
+                                 @Nullable Long contentLength,
+                                 @Nullable String etag,
+                                 @Nullable String providerVersionId,
+                                 @Nullable String checksum,
+                                 @NonNull Instant createdAt,
+                                 @NonNull Instant updatedAt,
+                                 @NonNull ObjectMetadataSyncStatus syncStatus) {
+        this.tenantId = Objects.requireNonNull(tenantId, "tenantId");
+        this.storageDescriptor = Objects.requireNonNull(storageDescriptor, "storageDescriptor");
+        this.objectKey = Objects.requireNonNull(objectKey, "objectKey");
+        this.objectKeyHash = normalizeObjectKeyHash(objectKey, objectKeyHash);
+        this.contentType = contentType;
+        this.contentLength = contentLength;
+        this.etag = etag;
+        this.providerVersionId = providerVersionId;
+        this.checksum = checksum;
+        this.createdAt = Objects.requireNonNull(createdAt, "createdAt");
+        this.updatedAt = Objects.requireNonNull(updatedAt, "updatedAt");
+        this.syncStatus = Objects.requireNonNull(syncStatus, "syncStatus");
+    }
+
+    @NonNull
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    @NonNull
+    public String getStorageName() {
+        return storageDescriptor.getStorageName();
+    }
+
+    @NonNull
+    public String getProviderId() {
+        return storageDescriptor.getProviderId();
+    }
+
+    @NonNull
+    public String getLogicalContainer() {
+        return storageDescriptor.getLogicalContainer();
+    }
+
+    @NonNull
+    public Optional<String> getProviderNamespace() {
+        return storageDescriptor.getProviderNamespace();
+    }
+
+    @NonNull
+    public String getProviderContainer() {
+        return storageDescriptor.getProviderContainer();
+    }
+
+    @NonNull
+    public String getProviderContainerIdentity() {
+        return storageDescriptor.getProviderContainerIdentity();
+    }
+
+    @NonNull
+    public StorageDescriptor getStorageDescriptor() {
+        return storageDescriptor;
+    }
+
+    @NonNull
+    public String getObjectKey() {
+        return objectKey;
+    }
+
+    @NonNull
+    public String getObjectKeyHash() {
+        return objectKeyHash;
+    }
+
+    @NonNull
+    public Optional<String> getContentType() {
+        return Optional.ofNullable(contentType);
+    }
+
+    @NonNull
+    public OptionalLong getContentLength() {
+        if (contentLength == null) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(contentLength);
+    }
+
+    @NonNull
+    public Optional<String> getEtag() {
+        return Optional.ofNullable(etag);
+    }
+
+    @NonNull
+    public Optional<String> getProviderVersionId() {
+        return Optional.ofNullable(providerVersionId);
+    }
+
+    @NonNull
+    public Optional<String> getChecksum() {
+        return Optional.ofNullable(checksum);
+    }
+
+    @NonNull
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    @NonNull
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    @NonNull
+    public ObjectMetadataSyncStatus getSyncStatus() {
+        return syncStatus;
+    }
+
+    @NonNull
+    public ObjectMetadataReconciliationState getReconciliationStatus() {
+        return syncStatus.getReconciliationState();
+    }
+
+    @NonNull
+    public Optional<String> getLastErrorSummary() {
+        return syncStatus.getLastErrorSummary();
+    }
+
+    @NonNull
+    public static String deterministicObjectKeyHash(@NonNull String objectKey) {
+        Objects.requireNonNull(objectKey, "objectKey");
+        MessageDigest messageDigest;
+        try {
+            messageDigest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm is not available", e);
+        }
+        byte[] digest = messageDigest.digest(objectKey.getBytes(StandardCharsets.UTF_8));
+        return HexFormat.of().formatHex(digest);
+    }
+
+    @NonNull
+    private static String normalizeObjectKeyHash(@NonNull String objectKey, @Nullable String objectKeyHash) {
+        if (objectKeyHash == null || objectKeyHash.isBlank()) {
+            return deterministicObjectKeyHash(objectKey);
+        }
+        return objectKeyHash;
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/StorageObjectMetadataField.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/StorageObjectMetadataField.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import org.jspecify.annotations.NonNull;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Queryable persisted object metadata fields.
+ */
+public enum StorageObjectMetadataField {
+    TENANT_ID("tenantId"),
+    STORAGE_NAME("storageName"),
+    PROVIDER_ID("providerId"),
+    LOGICAL_CONTAINER("logicalContainer"),
+    PROVIDER_NAMESPACE("providerNamespace"),
+    PROVIDER_CONTAINER("providerContainer"),
+    PROVIDER_CONTAINER_IDENTITY("providerContainerIdentity"),
+    OBJECT_KEY("objectKey"),
+    OBJECT_KEY_HASH("objectKeyHash"),
+    CONTENT_TYPE("contentType"),
+    CONTENT_LENGTH("contentLength"),
+    ETAG("etag"),
+    PROVIDER_VERSION_ID("providerVersionId"),
+    CHECKSUM("checksum"),
+    CREATED_AT("createdAt"),
+    UPDATED_AT("updatedAt"),
+    RECONCILIATION_STATUS("reconciliationStatus"),
+    LAST_ERROR_SUMMARY("lastErrorSummary");
+
+    private final String persistedField;
+
+    StorageObjectMetadataField(String persistedField) {
+        this.persistedField = persistedField;
+    }
+
+    @NonNull
+    public String getPersistedField() {
+        return persistedField;
+    }
+
+    @NonNull
+    public static Set<String> persistedFields() {
+        return Arrays.stream(values())
+            .map(StorageObjectMetadataField::getPersistedField)
+            .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/StorageObjectMetadataQuery.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/StorageObjectMetadataQuery.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Query filter for object metadata listing.
+ *
+ * Tenant scoping is intentionally resolved from {@link TenantResolver} by
+ * {@link ObjectStorageMetadataOperations} implementations.
+ *
+ * @since 1.6.0
+ */
+public final class StorageObjectMetadataQuery {
+
+    @Nullable
+    private final String storageName;
+    @Nullable
+    private final String logicalContainer;
+    @Nullable
+    private final String objectKeyPrefix;
+
+    public StorageObjectMetadataQuery(@Nullable String storageName,
+                                      @Nullable String logicalContainer,
+                                      @Nullable String objectKeyPrefix) {
+        this.storageName = storageName;
+        this.logicalContainer = logicalContainer;
+        this.objectKeyPrefix = objectKeyPrefix;
+    }
+
+    @NonNull
+    public static StorageObjectMetadataQuery all() {
+        return new StorageObjectMetadataQuery(null, null, null);
+    }
+
+    @NonNull
+    public StorageObjectMetadataQuery withStorageName(@Nullable String storageName) {
+        return new StorageObjectMetadataQuery(storageName, logicalContainer, objectKeyPrefix);
+    }
+
+    @NonNull
+    public StorageObjectMetadataQuery withLogicalContainer(@Nullable String logicalContainer) {
+        return new StorageObjectMetadataQuery(storageName, logicalContainer, objectKeyPrefix);
+    }
+
+    @NonNull
+    public StorageObjectMetadataQuery withObjectKeyPrefix(@Nullable String objectKeyPrefix) {
+        return new StorageObjectMetadataQuery(storageName, logicalContainer, objectKeyPrefix);
+    }
+
+    @NonNull
+    public Optional<String> getStorageName() {
+        return Optional.ofNullable(storageName);
+    }
+
+    @NonNull
+    public Optional<String> getLogicalContainer() {
+        return Optional.ofNullable(logicalContainer);
+    }
+
+    @NonNull
+    public Optional<String> getObjectKeyPrefix() {
+        return Optional.ofNullable(objectKeyPrefix);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StorageObjectMetadataQuery that = (StorageObjectMetadataQuery) o;
+        return Objects.equals(storageName, that.storageName)
+            && Objects.equals(logicalContainer, that.logicalContainer)
+            && Objects.equals(objectKeyPrefix, that.objectKeyPrefix);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(storageName, logicalContainer, objectKeyPrefix);
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/TenantResolver.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/TenantResolver.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Resolves the active tenant id for metadata operations.
+ *
+ * @since 1.6.0
+ */
+public interface TenantResolver {
+
+    /**
+     * @return The active tenant id.
+     */
+    @NonNull
+    String resolveTenantId();
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/package-info.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Metadata abstractions for object storage integrations.
+ *
+ * <p>
+ * Package provides types used to describe and access object storage metadata.
+ */
+package io.micronaut.objectstorage.metadata;

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/request/StreamingFileUploadRequest.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/request/StreamingFileUploadRequest.java
@@ -77,7 +77,7 @@ public class StreamingFileUploadRequest implements UploadRequest {
     @NonNull
     @Override
     public InputStream getInputStream() {
-    	return streamingFileUpload.asInputStream();
+        return streamingFileUpload.asInputStream();
     }
 
     @Override

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/metadata/CoreMetadataTckFixtureSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/metadata/CoreMetadataTckFixtureSpec.groovy
@@ -1,0 +1,230 @@
+package io.micronaut.objectstorage.metadata
+
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.objectstorage.response.UploadResponse
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+
+class CoreMetadataTckFixtureSpec extends ObjectStorageMetadataSpecification {
+
+    @Override
+    ObjectStorageMetadataSpecification.MetadataTckFixture getMetadataFixture() {
+        return new InMemoryMetadataTckFixture()
+    }
+
+    private static class InMemoryMetadataTckFixture extends ObjectStorageMetadataSpecification.MetadataTckFixture {
+        private static final Instant NOW = Instant.parse('2026-03-17T16:30:00Z')
+        private final StorageDescriptor primaryStorageDescriptor = new StorageDescriptor('primary-storage', 'test-provider', 'avatars', 'tenant-space', 'bucket-a')
+        private final StorageDescriptor secondaryStorageDescriptor = new StorageDescriptor('secondary-storage', 'test-provider', 'reports', 'tenant-space', 'bucket-b')
+        private final MutableTenantResolver tenantResolver = new MutableTenantResolver('tenant-alpha')
+        private final InMemoryMetadataOperations metadataOperations = new InMemoryMetadataOperations(tenantResolver)
+        private final List<ObjectStorageMetadataSpecification.LifecycleEvent> lifecycleEvents = []
+        private final Map<String, String> reconciliationIds = [:]
+
+        @Override
+        ObjectStorageMetadataOperations getMetadataOperations() {
+            return metadataOperations
+        }
+
+        @Override
+        StorageDescriptor getPrimaryStorageDescriptor() {
+            return primaryStorageDescriptor
+        }
+
+        @Override
+        StorageDescriptor getSecondaryStorageDescriptor() {
+            return secondaryStorageDescriptor
+        }
+
+        @Override
+        void seedPendingMetadata(StorageObjectMetadata metadata) {
+            metadataOperations.seedPending(metadata)
+        }
+
+        @Override
+        void seedSucceededMetadata(StorageObjectMetadata metadata) {
+            metadataOperations.seedSucceeded(metadata)
+        }
+
+        @Override
+        UploadResponse<?> upload(StorageDescriptor descriptor, UploadRequest uploadRequest) {
+            return doUpload(descriptor, uploadRequest, false)
+        }
+
+        @Override
+        UploadResponse<?> uploadWithError(StorageDescriptor descriptor, UploadRequest uploadRequest) {
+            return doUpload(descriptor, uploadRequest, true)
+        }
+
+        @Override
+        List<ObjectStorageMetadataSpecification.LifecycleEvent> getLifecycleEvents() {
+            return lifecycleEvents
+        }
+
+        @Override
+        String reconciliationIdFor(String objectKey) {
+            return reconciliationIds[objectKey]
+        }
+
+        @Override
+        def <T> T withTenant(String tenantId, Closure<T> callable) {
+            String previous = tenantResolver.currentTenant
+            tenantResolver.currentTenant = tenantId
+            try {
+                return callable.call()
+            } finally {
+                tenantResolver.currentTenant = previous
+            }
+        }
+
+        private UploadResponse<?> doUpload(StorageDescriptor descriptor, UploadRequest uploadRequest, boolean failDispatch) {
+            lifecycleEvents.clear()
+            ObjectStorageOperationContext context = ObjectStorageOperationContext.forUpload(tenantResolver.resolveTenantId(), descriptor, uploadRequest)
+            List<NamedHook> hooks = ObjectStorageLifecycleHook.ordered([
+                new NamedHook('low-precedence', 100, lifecycleEvents),
+                new NamedHook('high-precedence', -100, lifecycleEvents)
+            ]) as List<NamedHook>
+            hooks.each { it.before(context) }
+            String reconciliationId = "rec-${uploadRequest.key}"
+            reconciliationIds[uploadRequest.key] = reconciliationId
+            UploadResponse<?> response = UploadResponse.of(uploadRequest.key, "etag-${uploadRequest.key}", 'native-upload')
+            ObjectStorageOperationOutcome outcome = ObjectStorageOperationOutcome.uploadSuccess(context, response, reconciliationId)
+            if (failDispatch) {
+                MetadataDispatchException exception = new MetadataDispatchException(context, outcome, reconciliationId, new IllegalStateException('metadata dispatch failed'))
+                hooks.first().error(context, exception)
+                throw exception
+            }
+            hooks.each { it.after(context, outcome) }
+            metadataOperations.scheduleVisibility(succeededMetadata(context.tenantId, descriptor, uploadRequest.key))
+            return response
+        }
+
+        private static StorageObjectMetadata succeededMetadata(String tenantId, StorageDescriptor descriptor, String objectKey) {
+            return new StorageObjectMetadata(
+                tenantId,
+                descriptor,
+                objectKey,
+                null,
+                CONTENT_TYPE,
+                TEXT.length() as Long,
+                "etag-${objectKey}",
+                'v1',
+                null,
+                NOW,
+                NOW,
+                new ObjectMetadataSyncStatus(ObjectMetadataReconciliationState.SUCCEEDED, null)
+            )
+        }
+    }
+
+    private static final class NamedHook implements ObjectStorageLifecycleHook {
+        private final String hookName
+        private final int order
+        private final List<ObjectStorageMetadataSpecification.LifecycleEvent> lifecycleEvents
+
+        NamedHook(String hookName, int order, List<ObjectStorageMetadataSpecification.LifecycleEvent> lifecycleEvents) {
+            this.hookName = hookName
+            this.order = order
+            this.lifecycleEvents = lifecycleEvents
+        }
+
+        @Override
+        int getOrder() {
+            return order
+        }
+
+        @Override
+        void before(ObjectStorageOperationContext context) {
+            lifecycleEvents << new ObjectStorageMetadataSpecification.LifecycleEvent('before', hookName, context)
+        }
+
+        @Override
+        void after(ObjectStorageOperationContext context, ObjectStorageOperationOutcome outcome) {
+            lifecycleEvents << new ObjectStorageMetadataSpecification.LifecycleEvent('after', hookName, context, outcome)
+        }
+
+        @Override
+        void error(ObjectStorageOperationContext context, Throwable throwable) {
+            lifecycleEvents << new ObjectStorageMetadataSpecification.LifecycleEvent('error', hookName, context, null, throwable)
+        }
+    }
+
+    private static final class MutableTenantResolver implements TenantResolver {
+        String currentTenant
+
+        MutableTenantResolver(String currentTenant) {
+            this.currentTenant = currentTenant
+        }
+
+        @Override
+        String resolveTenantId() {
+            return currentTenant
+        }
+    }
+
+    private static final class InMemoryMetadataOperations implements ObjectStorageMetadataOperations {
+        private static final Instant CONTAINER_NOW = Instant.parse('2026-03-17T16:30:00Z')
+        private final TenantResolver tenantResolver
+        private final Map<String, List<StorageObjectMetadata>> visible = new ConcurrentHashMap<>()
+        private final Map<String, List<StorageObjectMetadata>> pending = new ConcurrentHashMap<>()
+
+        InMemoryMetadataOperations(TenantResolver tenantResolver) {
+            this.tenantResolver = tenantResolver
+        }
+
+        void seedPending(StorageObjectMetadata metadata) {
+            pending.compute(metadata.tenantId) { key, entries -> ((entries ?: []) + metadata) as List<StorageObjectMetadata> }
+        }
+
+        void seedSucceeded(StorageObjectMetadata metadata) {
+            visible.compute(metadata.tenantId) { key, entries -> ((entries ?: []) + metadata) as List<StorageObjectMetadata> }
+        }
+
+        void scheduleVisibility(StorageObjectMetadata metadata) {
+            seedPending(metadata)
+            Thread.startDaemon {
+                sleep 150
+                pending.computeIfPresent(metadata.tenantId) { key, entries -> entries.findAll { it.objectKey != metadata.objectKey } }
+                seedSucceeded(metadata)
+            }
+        }
+
+        @Override
+        TenantResolver getTenantResolver() {
+            return tenantResolver
+        }
+
+        @Override
+        Optional<StorageContainerMetadata> findContainer(StorageDescriptor storageDescriptor) {
+            List<StorageObjectMetadata> scoped = visibleForActiveTenant().findAll { sameContainer(it, storageDescriptor) }
+            if (scoped.isEmpty()) {
+                return Optional.empty()
+            }
+            return Optional.of(new StorageContainerMetadata(getActiveTenantId(), storageDescriptor, CONTAINER_NOW, CONTAINER_NOW))
+        }
+
+        @Override
+        Optional<StorageObjectMetadata> findObject(StorageDescriptor storageDescriptor, String objectKey) {
+            return Optional.ofNullable(visibleForActiveTenant().find { sameContainer(it, storageDescriptor) && it.objectKey == objectKey })
+        }
+
+        @Override
+        List<StorageObjectMetadata> listObjects(StorageObjectMetadataQuery query) {
+            return visibleForActiveTenant().findAll { metadata ->
+                boolean storageMatches = query.storageName.map { it == metadata.storageName }.orElse(true)
+                boolean containerMatches = query.logicalContainer.map { it == metadata.logicalContainer }.orElse(true)
+                boolean prefixMatches = query.objectKeyPrefix.map { metadata.objectKey.startsWith(it) }.orElse(true)
+                return storageMatches && containerMatches && prefixMatches
+            }.sort { a, b -> a.objectKey <=> b.objectKey }
+        }
+
+        private List<StorageObjectMetadata> visibleForActiveTenant() {
+            return visible.getOrDefault(getActiveTenantId(), [])
+        }
+
+        private static boolean sameContainer(StorageObjectMetadata metadata, StorageDescriptor storageDescriptor) {
+            return metadata.storageName == storageDescriptor.storageName &&
+                metadata.logicalContainer == storageDescriptor.logicalContainer
+        }
+    }
+}

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/metadata/MetadataHookFailureFixtureSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/metadata/MetadataHookFailureFixtureSpec.groovy
@@ -1,0 +1,44 @@
+package io.micronaut.objectstorage.metadata
+
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.objectstorage.response.UploadResponse
+import spock.util.concurrent.PollingConditions
+
+class MetadataHookFailureFixtureSpec extends CoreMetadataTckFixtureSpec {
+
+    void 'failure fixture exercises eventual polling and hook failure path'() {
+        given:
+        MetadataTckFixture fixture = getMetadataFixture()
+        StorageDescriptor primary = fixture.primaryStorageDescriptor
+        UploadRequest successRequest = UploadRequest.fromBytes(TEXT.bytes, 'images/polled.png', CONTENT_TYPE)
+        successRequest.metadata = METADATA
+        PollingConditions conditions = new PollingConditions(timeout: 10)
+
+        when:
+        UploadResponse<?> response = fixture.withTenant('tenant-alpha') {
+            fixture.upload(primary, successRequest)
+        }
+
+        then:
+        response.key == 'images/polled.png'
+
+        when:
+        conditions.eventually {
+            assert fixture.withTenant('tenant-alpha') {
+                fixture.metadataOperations.findObject(primary, 'images/polled.png')
+            }.present
+        }
+        UploadRequest failingRequest = UploadRequest.fromBytes(TEXT.bytes, 'images/hook-failure.png', CONTENT_TYPE)
+        failingRequest.metadata = METADATA
+        fixture.withTenant('tenant-alpha') {
+            fixture.uploadWithError(primary, failingRequest)
+        }
+
+        then:
+        MetadataDispatchException e = thrown()
+        e.operationContext.objectKey == 'images/hook-failure.png'
+        fixture.lifecycleEvents*.phase == ['before', 'before', 'error']
+        fixture.lifecycleEvents*.hookName == ['high-precedence', 'low-precedence', 'high-precedence']
+        fixture.lifecycleEvents.last().throwable.is(e)
+    }
+}

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/metadata/ObjectStorageLifecycleHookOrderingSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/metadata/ObjectStorageLifecycleHookOrderingSpec.groovy
@@ -1,0 +1,88 @@
+package io.micronaut.objectstorage.metadata
+
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.objectstorage.response.UploadResponse
+import spock.lang.Specification
+
+class ObjectStorageLifecycleHookOrderingSpec extends Specification {
+
+    void "ordered hooks execute deterministically for before after and error phases"() {
+        given:
+        StorageDescriptor descriptor = new StorageDescriptor("pictures", "aws-s3", "profiles", "ns-a", "bucket-a")
+        List<String> events = []
+        List<ObjectStorageLifecycleHook> ordered = ObjectStorageLifecycleHook.ordered([
+            new RecordingHook("late", 100, events),
+            new RecordingHook("early", -10, events),
+            new RecordingHook("middle", 5, events)
+        ])
+        List<ObjectStorageOperationContext> contexts = [
+            ObjectStorageOperationContext.forUpload("tenant-a", descriptor, UploadRequest.fromBytes("abc".bytes, "/profiles/avatar.png", "image/png")),
+            ObjectStorageOperationContext.forCopy("tenant-a", descriptor, "/profiles/avatar.png", "/profiles/avatar-copy.png"),
+            ObjectStorageOperationContext.forDelete("tenant-a", descriptor, "/profiles/avatar.png")
+        ]
+
+        when:
+        contexts.each { context ->
+            ObjectStorageOperationOutcome outcome = outcomeFor(context)
+            ordered.each { it.before(context) }
+            ordered.each { it.after(context, outcome) }
+            ordered.each { it.error(context, new IllegalStateException("boom-${context.operationType}")) }
+        }
+
+        then:
+        ordered*.name == ["early", "middle", "late"]
+
+        and:
+        events == contexts.collectMany { context ->
+            ["before", "after", "error"].collectMany { phase ->
+                ordered*.name.collect { name -> "$phase:${context.operationType}:$name" }
+            }
+        }
+    }
+
+    private static ObjectStorageOperationOutcome outcomeFor(ObjectStorageOperationContext context) {
+        if (context.operationType == ObjectStorageOperationType.UPLOAD) {
+            return ObjectStorageOperationOutcome.uploadSuccess(
+                context,
+                UploadResponse.of(context.objectKey, "etag-1", "native-upload"),
+                "rec-upload"
+            )
+        }
+        if (context.operationType == ObjectStorageOperationType.COPY) {
+            return ObjectStorageOperationOutcome.copySuccess(context, "native-copy", "rec-copy")
+        }
+        return ObjectStorageOperationOutcome.deleteSuccess(context, "native-delete", "rec-delete")
+    }
+
+    private static final class RecordingHook implements ObjectStorageLifecycleHook {
+        final String name
+        final int order
+        final List<String> events
+
+        RecordingHook(String name, int order, List<String> events) {
+            this.name = name
+            this.order = order
+            this.events = events
+        }
+
+        @Override
+        int getOrder() {
+            return order
+        }
+
+        @Override
+        void before(ObjectStorageOperationContext context) {
+            events << "before:${context.operationType}:$name"
+        }
+
+        @Override
+        void after(ObjectStorageOperationContext context, ObjectStorageOperationOutcome outcome) {
+            events << "after:${context.operationType}:$name"
+        }
+
+        @Override
+        void error(ObjectStorageOperationContext context, Throwable throwable) {
+            events << "error:${context.operationType}:$name"
+        }
+    }
+}

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/metadata/ObjectStorageMetadataContractsSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/metadata/ObjectStorageMetadataContractsSpec.groovy
@@ -1,0 +1,176 @@
+package io.micronaut.objectstorage.metadata
+
+import io.micronaut.objectstorage.response.UploadResponse
+import spock.lang.Specification
+
+import java.time.Instant
+
+class ObjectStorageMetadataContractsSpec extends Specification {
+
+    private static final Instant NOW = Instant.parse("2026-03-17T14:00:00Z")
+
+    void "public metadata queries resolve tenant from tenant resolver"() {
+        given:
+        StorageDescriptor descriptor = new StorageDescriptor("pictures", "aws-s3", "profiles", "ns-a", "bucket-a")
+        TrackingTenantResolver tenantResolver = new TrackingTenantResolver("tenant-a")
+        InMemoryMetadataOperations operations = new InMemoryMetadataOperations(tenantResolver)
+        operations.addObject(sampleMetadata("tenant-a", descriptor, "/profiles/avatar.png"))
+        operations.addObject(sampleMetadata("tenant-b", descriptor, "/profiles/avatar.png"))
+
+        when:
+        Optional<StorageObjectMetadata> tenantA = operations.findObject(descriptor, "/profiles/avatar.png")
+        tenantResolver.currentTenant = "tenant-b"
+        Optional<StorageObjectMetadata> tenantB = operations.findObject(descriptor, "/profiles/avatar.png")
+
+        then:
+        tenantA.present
+        tenantA.get().tenantId == "tenant-a"
+        tenantB.present
+        tenantB.get().tenantId == "tenant-b"
+        tenantResolver.resolveCount == 2
+
+        and:
+        ObjectStorageMetadataOperations.declaredMethods.find { it.name == "findContainer" }.parameterCount == 1
+        ObjectStorageMetadataOperations.declaredMethods.find { it.name == "findObject" }.parameterCount == 2
+        ObjectStorageMetadataOperations.declaredMethods.find { it.name == "listObjects" }.parameterCount == 1
+    }
+
+    void "metadata dispatch exception keeps partial-completion context"() {
+        given:
+        StorageDescriptor descriptor = new StorageDescriptor("pictures", "aws-s3", "profiles", "ns-a", "bucket-a")
+        def uploadRequest = io.micronaut.objectstorage.request.UploadRequest.fromBytes("abc".bytes, "/profiles/avatar.png", "image/png")
+        ObjectStorageOperationContext context = ObjectStorageOperationContext.forUpload("tenant-a", descriptor, uploadRequest)
+        ObjectStorageOperationOutcome outcome = ObjectStorageOperationOutcome.uploadSuccess(
+            context,
+            UploadResponse.of("/profiles/avatar.png", "etag-1", "native-upload"),
+            "rec-1"
+        )
+        RuntimeException dispatchFailure = new RuntimeException("outbox insert failed")
+
+        when:
+        MetadataDispatchException exception = new MetadataDispatchException(context, outcome, "rec-1", dispatchFailure)
+
+        then:
+        exception.cause.is(dispatchFailure)
+        exception.message.contains("UPLOAD")
+        exception.message.contains("tenant-a")
+        exception.message.contains("pictures")
+        exception.message.contains("/profiles/avatar.png")
+        exception.reconciliationId.present
+        exception.reconciliationId.get() == "rec-1"
+        exception.operationContext.operationType == ObjectStorageOperationType.UPLOAD
+        exception.operationContext.storageDescriptor.storageName == "pictures"
+        exception.operationOutcome.operationType == ObjectStorageOperationType.UPLOAD
+        exception.operationOutcome.tenantId == "tenant-a"
+        exception.operationOutcome.storageDescriptor.storageName == "pictures"
+        exception.operationOutcome.uploadResponse.present
+        exception.operationOutcome.uploadResponse.get().key == "/profiles/avatar.png"
+        exception.operationOutcome.reconciliationId.present
+        exception.operationOutcome.reconciliationId.get() == "rec-1"
+    }
+
+    void "operation context factories cover upload copy and delete"() {
+        given:
+        StorageDescriptor descriptor = new StorageDescriptor("pictures", "aws-s3", "profiles", "ns-a", "bucket-a")
+        def uploadRequest = io.micronaut.objectstorage.request.UploadRequest.fromBytes("abc".bytes, "/profiles/avatar.png", "image/png")
+
+        when:
+        ObjectStorageOperationContext uploadContext = ObjectStorageOperationContext.forUpload("tenant-a", descriptor, uploadRequest)
+        ObjectStorageOperationContext copyContext = ObjectStorageOperationContext.forCopy("tenant-a", descriptor, "/profiles/avatar.png", "/profiles/avatar-copy.png")
+        ObjectStorageOperationContext deleteContext = ObjectStorageOperationContext.forDelete("tenant-a", descriptor, "/profiles/avatar.png")
+
+        then:
+        uploadContext.operationType == ObjectStorageOperationType.UPLOAD
+        uploadContext.destinationObjectKey.empty
+        uploadContext.uploadRequest.present
+
+        and:
+        copyContext.operationType == ObjectStorageOperationType.COPY
+        copyContext.destinationObjectKey.present
+        copyContext.destinationObjectKey.get() == "/profiles/avatar-copy.png"
+        copyContext.uploadRequest.empty
+
+        and:
+        deleteContext.operationType == ObjectStorageOperationType.DELETE
+        deleteContext.destinationObjectKey.empty
+        deleteContext.uploadRequest.empty
+    }
+
+    private static StorageObjectMetadata sampleMetadata(String tenantId, StorageDescriptor descriptor, String objectKey) {
+        new StorageObjectMetadata(
+            tenantId,
+            descriptor,
+            objectKey,
+            null,
+            "image/png",
+            3L,
+            "etag-1",
+            "v1",
+            null,
+            NOW,
+            NOW,
+            new ObjectMetadataSyncStatus(ObjectMetadataReconciliationState.SUCCEEDED, null)
+        )
+    }
+
+    private static final class TrackingTenantResolver implements TenantResolver {
+        String currentTenant
+        int resolveCount
+
+        TrackingTenantResolver(String currentTenant) {
+            this.currentTenant = currentTenant
+        }
+
+        @Override
+        String resolveTenantId() {
+            resolveCount++
+            return currentTenant
+        }
+    }
+
+    private static final class InMemoryMetadataOperations implements ObjectStorageMetadataOperations {
+        private final TenantResolver tenantResolver
+        private final Map<String, List<StorageObjectMetadata>> byTenant = [:].withDefault { [] }
+
+        InMemoryMetadataOperations(TenantResolver tenantResolver) {
+            this.tenantResolver = tenantResolver
+        }
+
+        void addObject(StorageObjectMetadata metadata) {
+            byTenant[metadata.tenantId] = byTenant[metadata.tenantId] + metadata
+        }
+
+        @Override
+        TenantResolver getTenantResolver() {
+            return tenantResolver
+        }
+
+        @Override
+        Optional<StorageContainerMetadata> findContainer(StorageDescriptor storageDescriptor) {
+            List<StorageObjectMetadata> objects = byTenant[getActiveTenantId()].findAll { metadata ->
+                metadata.storageDescriptor.storageName == storageDescriptor.storageName &&
+                    metadata.logicalContainer == storageDescriptor.logicalContainer
+            }
+            if (objects.isEmpty()) {
+                return Optional.empty()
+            }
+            return Optional.of(new StorageContainerMetadata(getActiveTenantId(), storageDescriptor, NOW, NOW))
+        }
+
+        @Override
+        Optional<StorageObjectMetadata> findObject(StorageDescriptor storageDescriptor, String objectKey) {
+            return Optional.ofNullable(byTenant[getActiveTenantId()]
+                .find { metadata -> metadata.storageDescriptor.storageName == storageDescriptor.storageName && metadata.objectKey == objectKey })
+        }
+
+        @Override
+        List<StorageObjectMetadata> listObjects(StorageObjectMetadataQuery query) {
+            return byTenant[getActiveTenantId()].findAll { metadata ->
+                boolean matchesStorage = query.storageName.map { it == metadata.storageDescriptor.storageName }.orElse(true)
+                boolean matchesContainer = query.logicalContainer.map { it == metadata.logicalContainer }.orElse(true)
+                boolean matchesPrefix = query.objectKeyPrefix.map { metadata.objectKey.startsWith(it) }.orElse(true)
+                return matchesStorage && matchesContainer && matchesPrefix
+            }
+        }
+    }
+}

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/metadata/StorageDescriptorSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/metadata/StorageDescriptorSpec.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.objectstorage.metadata
+
+import spock.lang.Specification
+
+class StorageDescriptorSpec extends Specification {
+
+    void "it keeps provider container identity deterministic"() {
+        when:
+        StorageDescriptor descriptor = new StorageDescriptor("pictures", "aws-s3", "profiles", "team-a", "bucket-one")
+
+        then:
+        descriptor.storageName == "pictures"
+        descriptor.providerId == "aws-s3"
+        descriptor.logicalContainer == "profiles"
+        descriptor.providerNamespace.present
+        descriptor.providerNamespace.get() == "team-a"
+        descriptor.providerContainer == "bucket-one"
+        descriptor.providerContainerIdentity == "team-a/bucket-one"
+    }
+
+    void "it supports provider container identity without namespace"() {
+        when:
+        StorageDescriptor descriptor = new StorageDescriptor("logos", "local", "assets", null, "fs-root")
+
+        then:
+        descriptor.providerNamespace.empty
+        descriptor.providerContainerIdentity == "fs-root"
+    }
+}

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/metadata/StorageObjectMetadataSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/metadata/StorageObjectMetadataSpec.groovy
@@ -1,0 +1,122 @@
+package io.micronaut.objectstorage.metadata
+
+import spock.lang.Specification
+
+import java.time.Instant
+
+class StorageObjectMetadataSpec extends Specification {
+
+    private static final Instant NOW = Instant.parse("2026-03-17T10:15:30Z")
+
+    void "it computes deterministic object-key hashing when missing"() {
+        given:
+        StorageDescriptor descriptor = new StorageDescriptor("pictures", "aws-s3", "profiles", "tenant-a", "bucket-a")
+        ObjectMetadataSyncStatus syncStatus = new ObjectMetadataSyncStatus(ObjectMetadataReconciliationState.PENDING, null)
+
+        when:
+        StorageObjectMetadata first = new StorageObjectMetadata(
+            "tenant-a",
+            descriptor,
+            "/2026/03/avatar.png",
+            null,
+            "image/png",
+            42L,
+            "etag-1",
+            "v1",
+            "sha256:abc",
+            NOW,
+            NOW,
+            syncStatus
+        )
+        StorageObjectMetadata second = new StorageObjectMetadata(
+            "tenant-a",
+            descriptor,
+            "/2026/03/avatar.png",
+            "",
+            "image/png",
+            42L,
+            "etag-1",
+            "v1",
+            "sha256:abc",
+            NOW,
+            NOW,
+            syncStatus
+        )
+
+        then:
+        first.objectKeyHash == second.objectKeyHash
+        first.objectKeyHash == StorageObjectMetadata.deterministicObjectKeyHash("/2026/03/avatar.png")
+        first.objectKeyHash != StorageObjectMetadata.deterministicObjectKeyHash("/2026/03/avatar-2.png")
+    }
+
+    void "it preserves explicit hash and exposes null-safe optionals"() {
+        given:
+        StorageDescriptor descriptor = new StorageDescriptor("logos", "local", "assets", null, "fs-root")
+        ObjectMetadataSyncStatus syncStatus = new ObjectMetadataSyncStatus(ObjectMetadataReconciliationState.FAILED, "provider timeout")
+
+        when:
+        StorageObjectMetadata metadata = new StorageObjectMetadata(
+            "tenant-b",
+            descriptor,
+            "/assets/logo.svg",
+            "fixed-hash",
+            null,
+            null,
+            null,
+            null,
+            null,
+            NOW,
+            NOW,
+            syncStatus
+        )
+
+        then:
+        metadata.tenantId == "tenant-b"
+        metadata.storageName == "logos"
+        metadata.providerId == "local"
+        metadata.logicalContainer == "assets"
+        metadata.providerNamespace.empty
+        metadata.providerContainer == "fs-root"
+        metadata.providerContainerIdentity == "fs-root"
+        metadata.objectKey == "/assets/logo.svg"
+        metadata.objectKeyHash == "fixed-hash"
+        metadata.contentType.empty
+        metadata.contentLength.empty
+        metadata.etag.empty
+        metadata.providerVersionId.empty
+        metadata.checksum.empty
+        metadata.reconciliationStatus == ObjectMetadataReconciliationState.FAILED
+        metadata.lastErrorSummary.present
+        metadata.lastErrorSummary.get() == "provider timeout"
+    }
+
+    void "it freezes v1 persisted field contract and state values"() {
+        expect:
+        StorageObjectMetadataField.persistedFields() == [
+            "tenantId",
+            "storageName",
+            "providerId",
+            "logicalContainer",
+            "providerNamespace",
+            "providerContainer",
+            "providerContainerIdentity",
+            "objectKey",
+            "objectKeyHash",
+            "contentType",
+            "contentLength",
+            "etag",
+            "providerVersionId",
+            "checksum",
+            "createdAt",
+            "updatedAt",
+            "reconciliationStatus",
+            "lastErrorSummary"
+        ] as Set
+
+        and:
+        ObjectStorageOperationType.values()*.name() == ["UPLOAD", "COPY", "DELETE"]
+
+        and:
+        ObjectMetadataReconciliationState.values()*.name() == ["PENDING", "PROCESSING", "SUCCEEDED", "FAILED", "DEAD_LETTER"]
+    }
+}

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageDescriptorResolver.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageDescriptorResolver.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.googlecloud;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.objectstorage.metadata.StorageDescriptor;
+import io.micronaut.objectstorage.metadata.StorageDescriptorResolver;
+
+@EachBean(GoogleCloudStorageConfiguration.class)
+public final class GoogleCloudStorageDescriptorResolver implements StorageDescriptorResolver {
+
+    private static final String PROVIDER_ID = "gcp";
+
+    private final StorageDescriptor descriptor;
+
+    public GoogleCloudStorageDescriptorResolver(@Parameter GoogleCloudStorageConfiguration configuration) {
+        this.descriptor = new StorageDescriptor(
+            configuration.getName(),
+            PROVIDER_ID,
+            configuration.getBucket(),
+            null,
+            configuration.getBucket()
+        );
+    }
+
+    @Override
+    public StorageDescriptor resolve() {
+        return descriptor;
+    }
+}

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageDescriptorResolver.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageDescriptorResolver.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.local;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.objectstorage.configuration.ToggeableCondition;
+import io.micronaut.objectstorage.metadata.StorageDescriptor;
+import io.micronaut.objectstorage.metadata.StorageDescriptorResolver;
+
+@EachBean(LocalStorageConfiguration.class)
+@Requires(condition = ToggeableCondition.class)
+@Requires(beans = LocalStorageConfiguration.class)
+public final class LocalStorageDescriptorResolver implements StorageDescriptorResolver {
+
+    private static final String PROVIDER_ID = "local";
+
+    private final StorageDescriptor descriptor;
+
+    public LocalStorageDescriptorResolver(@Parameter LocalStorageConfiguration configuration) {
+        String path = configuration.getPath().toAbsolutePath().normalize().toString();
+        this.descriptor = new StorageDescriptor(
+            configuration.getName(),
+            PROVIDER_ID,
+            configuration.getName(),
+            path,
+            configuration.getName()
+        );
+    }
+
+    @Override
+    public StorageDescriptor resolve() {
+        return descriptor;
+    }
+}

--- a/object-storage-metadata-jdbc/build.gradle.kts
+++ b/object-storage-metadata-jdbc/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    io.micronaut.build.internal.`objectstorage-module`
+}
+
+dependencies {
+    api(projects.micronautObjectStorageCore)
+    implementation(mnData.micronaut.data.jdbc)
+    implementation(mnSql.micronaut.jdbc)
+
+    testImplementation(projects.micronautObjectStorageLocal)
+    testImplementation(mnValidation.micronaut.validation)
+    testImplementation(mnValidation.micronaut.validation.processor)
+    testImplementation(projects.micronautObjectStorageTck)
+    testImplementation(mnTest.micronaut.test.spock)
+    testImplementation(mnTestResources.testcontainers.core)
+    testImplementation(libs.ojdbc11)
+    testImplementation(libs.testcontainers.oracle.free)
+    testImplementation(libs.postgresql)
+    testImplementation(libs.testcontainers.postgresql)
+}
+
+micronautBuild {
+    // New module
+    binaryCompatibility {
+        enabled.set(false)
+    }
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/DefaultMetadataAwareObjectStorageOperations.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/DefaultMetadataAwareObjectStorageOperations.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.ObjectStorageEntry;
+import io.micronaut.objectstorage.ObjectStorageOperations;
+import io.micronaut.objectstorage.metadata.MetadataAwareObjectStorageOperations;
+import io.micronaut.objectstorage.metadata.MetadataDispatchException;
+import io.micronaut.objectstorage.metadata.ObjectStorageLifecycleHook;
+import io.micronaut.objectstorage.metadata.ObjectStorageMetadataOperations;
+import io.micronaut.objectstorage.metadata.ObjectStorageOperationContext;
+import io.micronaut.objectstorage.metadata.ObjectStorageOperationOutcome;
+import io.micronaut.objectstorage.metadata.ObjectStorageOperationType;
+import io.micronaut.objectstorage.metadata.StorageDescriptor;
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata;
+import io.micronaut.objectstorage.metadata.TenantResolver;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRecord;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRepository;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRecord;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRepository;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxStatus;
+import io.micronaut.objectstorage.request.UploadRequest;
+import io.micronaut.objectstorage.response.UploadResponse;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+@Internal
+final class DefaultMetadataAwareObjectStorageOperations<I, O, D> implements MetadataAwareObjectStorageOperations<I, O, D> {
+
+    private static final int OUTBOX_PAYLOAD_VERSION = 1;
+
+    private final ObjectStorageOperations<I, O, D> delegate;
+    private final ObjectStorageMetadataOperations metadataOperations;
+    private final StorageDescriptor storageDescriptor;
+    private final TenantResolver tenantResolver;
+    private final StorageContainerMetadataRepository containerRepository;
+    private final StorageMetadataOutboxRepository outboxRepository;
+    private final Collection<ObjectStorageLifecycleHook> lifecycleHooks;
+
+    DefaultMetadataAwareObjectStorageOperations(ObjectStorageOperations<I, O, D> delegate,
+                                                ObjectStorageMetadataOperations metadataOperations,
+                                                StorageDescriptor storageDescriptor,
+                                                TenantResolver tenantResolver,
+                                                StorageContainerMetadataRepository containerRepository,
+                                                StorageMetadataOutboxRepository outboxRepository,
+                                                Collection<ObjectStorageLifecycleHook> lifecycleHooks) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.metadataOperations = Objects.requireNonNull(metadataOperations, "metadataOperations");
+        this.storageDescriptor = Objects.requireNonNull(storageDescriptor, "storageDescriptor");
+        this.tenantResolver = Objects.requireNonNull(tenantResolver, "tenantResolver");
+        this.containerRepository = Objects.requireNonNull(containerRepository, "containerRepository");
+        this.outboxRepository = Objects.requireNonNull(outboxRepository, "outboxRepository");
+        this.lifecycleHooks = List.copyOf(Objects.requireNonNull(lifecycleHooks, "lifecycleHooks"));
+    }
+
+    @Override
+    public @NonNull ObjectStorageMetadataOperations getMetadataOperations() {
+        return metadataOperations;
+    }
+
+    @Override
+    public @NonNull Collection<ObjectStorageLifecycleHook> getLifecycleHooks() {
+        return lifecycleHooks;
+    }
+
+    @Override
+    public @NonNull UploadResponse<O> upload(@NonNull UploadRequest uploadRequest) {
+        UploadRequest request = Objects.requireNonNull(uploadRequest, "uploadRequest");
+        String tenantId = tenantResolver.resolveTenantId();
+        ObjectStorageOperationContext context = ObjectStorageOperationContext.forUpload(tenantId, storageDescriptor, request);
+        StorageContainerMetadataRecord containerRecord = containerRepository.findByTenantAndDescriptor(tenantId, storageDescriptor).orElse(null);
+        fireBeforeHooks(context);
+        UploadResponse<O> response = delegate.upload(request);
+        StorageMetadataOutboxRecord outboxRecord = newOutboxRecord(tenantId, ObjectStorageOperationType.UPLOAD, request.getKey(), null, containerRecord);
+        return enqueueAfterDelegateSuccess(context, outboxRecord, response);
+    }
+
+    @Override
+    public @NonNull UploadResponse<O> upload(@NonNull UploadRequest uploadRequest, @NonNull Consumer<I> requestConsumer) {
+        UploadRequest request = Objects.requireNonNull(uploadRequest, "uploadRequest");
+        Objects.requireNonNull(requestConsumer, "requestConsumer");
+        String tenantId = tenantResolver.resolveTenantId();
+        ObjectStorageOperationContext context = ObjectStorageOperationContext.forUpload(tenantId, storageDescriptor, request);
+        StorageContainerMetadataRecord containerRecord = containerRepository.findByTenantAndDescriptor(tenantId, storageDescriptor).orElse(null);
+        fireBeforeHooks(context);
+        UploadResponse<O> response = delegate.upload(request, requestConsumer);
+        StorageMetadataOutboxRecord outboxRecord = newOutboxRecord(tenantId, ObjectStorageOperationType.UPLOAD, request.getKey(), null, containerRecord);
+        return enqueueAfterDelegateSuccess(context, outboxRecord, response);
+    }
+
+    @Override
+    public @NonNull <E extends ObjectStorageEntry<?>> Optional<E> retrieve(@NonNull String key) {
+        return delegate.retrieve(key);
+    }
+
+    @Override
+    public @NonNull D delete(@NonNull String key) {
+        String objectKey = Objects.requireNonNull(key, "key");
+        String tenantId = tenantResolver.resolveTenantId();
+        ObjectStorageOperationContext context = ObjectStorageOperationContext.forDelete(tenantId, storageDescriptor, objectKey);
+        StorageContainerMetadataRecord containerRecord = containerRepository.findByTenantAndDescriptor(tenantId, storageDescriptor).orElse(null);
+        fireBeforeHooks(context);
+        D response = delegate.delete(objectKey);
+        StorageMetadataOutboxRecord outboxRecord = newOutboxRecord(tenantId, ObjectStorageOperationType.DELETE, objectKey, null, containerRecord);
+        return enqueueAfterDelegateSuccess(context, outboxRecord, response);
+    }
+
+    @Override
+    public boolean exists(@NonNull String key) {
+        return delegate.exists(key);
+    }
+
+    @Override
+    public @NonNull Set<String> listObjects() {
+        return delegate.listObjects();
+    }
+
+    @Override
+    public void copy(@NonNull String sourceKey, @NonNull String destinationKey) {
+        String resolvedSourceKey = Objects.requireNonNull(sourceKey, "sourceKey");
+        String resolvedDestinationKey = Objects.requireNonNull(destinationKey, "destinationKey");
+        String tenantId = tenantResolver.resolveTenantId();
+        ObjectStorageOperationContext context = ObjectStorageOperationContext.forCopy(tenantId, storageDescriptor, resolvedSourceKey, resolvedDestinationKey);
+        StorageContainerMetadataRecord containerRecord = containerRepository.findByTenantAndDescriptor(tenantId, storageDescriptor).orElse(null);
+        fireBeforeHooks(context);
+        delegate.copy(resolvedSourceKey, resolvedDestinationKey);
+        StorageMetadataOutboxRecord outboxRecord = newOutboxRecord(tenantId, ObjectStorageOperationType.COPY, resolvedSourceKey, resolvedDestinationKey, containerRecord);
+        enqueueAfterDelegateSuccess(context, outboxRecord, null);
+    }
+
+    private void fireBeforeHooks(ObjectStorageOperationContext context) {
+        for (ObjectStorageLifecycleHook hook : getOrderedLifecycleHooks()) {
+            hook.before(context);
+        }
+    }
+
+    private void fireErrorHooks(ObjectStorageOperationContext context,
+                                Throwable throwable) {
+        for (ObjectStorageLifecycleHook hook : getOrderedLifecycleHooks()) {
+            hook.error(context, throwable);
+        }
+    }
+
+    private <T> T enqueueAfterDelegateSuccess(ObjectStorageOperationContext context,
+                                              StorageMetadataOutboxRecord outboxRecord,
+                                              @Nullable T response) {
+        try {
+            boolean enqueued = outboxRepository.enqueueIfAbsent(outboxRecord);
+            if (!enqueued) {
+                return response;
+            }
+            return response;
+        } catch (RuntimeException e) {
+            String reconciliationId = outboxRecord.getReconciliationId().orElse(null);
+            ObjectStorageOperationOutcome outcome = toOperationOutcome(context, response, reconciliationId);
+            fireErrorHooks(context, e);
+            throw new MetadataDispatchException(context, outcome, reconciliationId, e);
+        }
+    }
+
+    private static ObjectStorageOperationOutcome toOperationOutcome(ObjectStorageOperationContext context,
+                                                                    @Nullable Object response,
+                                                                    @Nullable String reconciliationId) {
+        return switch (context.getOperationType()) {
+            case UPLOAD -> {
+                if (!(response instanceof UploadResponse<?> uploadResponse)) {
+                    throw new IllegalStateException("Upload operation requires UploadResponse outcome");
+                }
+                yield ObjectStorageOperationOutcome.uploadSuccess(context, uploadResponse, reconciliationId);
+            }
+            case DELETE -> ObjectStorageOperationOutcome.deleteSuccess(context, response, reconciliationId);
+            case COPY -> ObjectStorageOperationOutcome.copySuccess(context, response, reconciliationId);
+        };
+    }
+
+    private StorageMetadataOutboxRecord newOutboxRecord(String tenantId,
+                                                        ObjectStorageOperationType operationType,
+                                                        String objectKey,
+                                                        @Nullable String destinationObjectKey,
+                                                        @Nullable StorageContainerMetadataRecord containerRecord) {
+        Instant now = Instant.now();
+        String reconciliationId = UUID.randomUUID().toString();
+        String objectKeyHash = StorageObjectMetadata.deterministicObjectKeyHash(objectKey);
+        String logicalContainer = containerRecord == null
+            ? storageDescriptor.getLogicalContainer()
+            : containerRecord.metadata().getStorageDescriptor().getLogicalContainer();
+        String destinationKeyHash = destinationObjectKey == null ? null : StorageObjectMetadata.deterministicObjectKeyHash(destinationObjectKey);
+        String idempotencyKey = tenantId + "|" + storageDescriptor.getStorageName() + "|"
+            + operationType.name() + "|" + objectKeyHash + "|" + Objects.toString(destinationKeyHash, "-");
+        return StorageMetadataOutboxRecord.builder()
+            .id(UUID.randomUUID().toString())
+            .tenantId(tenantId)
+            .storageName(storageDescriptor.getStorageName())
+            .logicalContainer(logicalContainer)
+            .objectKey(objectKey)
+            .objectKeyHash(objectKeyHash)
+            .destinationObjectKey(destinationObjectKey)
+            .destinationObjectKeyHash(destinationKeyHash)
+            .operationType(operationType)
+            .reconciliationId(reconciliationId)
+            .payloadVersion(OUTBOX_PAYLOAD_VERSION)
+            .status(StorageMetadataOutboxStatus.PENDING)
+            .attemptCount(0)
+            .nextAttemptAt(now)
+            .lastErrorSummary(null)
+            .idempotencyKey(idempotencyKey)
+            .createdAt(now)
+            .updatedAt(now)
+            .build();
+    }
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/DefaultMetadataOutboxReconciler.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/DefaultMetadataOutboxReconciler.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.ObjectStorageException;
+import io.micronaut.objectstorage.metadata.ObjectMetadataReconciliationState;
+import io.micronaut.objectstorage.metadata.ObjectMetadataSyncStatus;
+import io.micronaut.objectstorage.metadata.StorageDescriptor;
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRecord;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRecord;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository;
+import jakarta.inject.Singleton;
+import org.jspecify.annotations.NonNull;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+
+@Singleton
+@Internal
+final class DefaultMetadataOutboxReconciler implements MetadataOutboxReconciler {
+
+    private final StorageObjectMetadataRepository objectRepository;
+    private final OutboxStorageDescriptorResolver descriptorResolver;
+
+    DefaultMetadataOutboxReconciler(StorageObjectMetadataRepository objectRepository,
+                                    OutboxStorageDescriptorResolver descriptorResolver) {
+        this.objectRepository = Objects.requireNonNull(objectRepository, "objectRepository");
+        this.descriptorResolver = Objects.requireNonNull(descriptorResolver, "descriptorResolver");
+    }
+
+    @Override
+    public void reconcile(@NonNull StorageMetadataOutboxRecord outboxRecord) {
+        StorageMetadataOutboxRecord record = Objects.requireNonNull(outboxRecord, "outboxRecord");
+        switch (record.getOperationType()) {
+            case UPLOAD -> upsertObject(record);
+            case COPY -> copyObject(record);
+            case DELETE -> deleteObject(record);
+            default -> throw new ObjectStorageException("Unsupported outbox operation type: " + record.getOperationType());
+        }
+    }
+
+    private void upsertObject(StorageMetadataOutboxRecord record) {
+        String key = record.getObjectKey().orElseThrow(() -> missingField(record, "objectKey"));
+        StorageDescriptor descriptor = descriptorResolver.resolveOrFallback(record.getStorageName(), record.getLogicalContainer());
+        StorageObjectMetadata metadata = newSucceededMetadata(record.getTenantId(), descriptor, key,
+            record.getObjectKeyHash().orElseGet(() -> StorageObjectMetadata.deterministicObjectKeyHash(key)), null);
+        objectRepository.upsert(metadata, Map.of());
+    }
+
+    private void copyObject(StorageMetadataOutboxRecord record) {
+        String sourceKey = record.getObjectKey().orElseThrow(() -> missingField(record, "objectKey"));
+        String sourceHash = record.getObjectKeyHash().orElseGet(() -> StorageObjectMetadata.deterministicObjectKeyHash(sourceKey));
+        String destinationKey = record.getDestinationObjectKey().orElseThrow(() -> missingField(record, "destinationObjectKey"));
+        String destinationHash = record.getDestinationObjectKeyHash().orElseGet(() -> StorageObjectMetadata.deterministicObjectKeyHash(destinationKey));
+        StorageDescriptor descriptor = descriptorResolver.resolveOrFallback(record.getStorageName(), record.getLogicalContainer());
+        StorageObjectMetadataRecord sourceRecord = objectRepository.findByTenantAndObjectHash(record.getTenantId(), descriptor, sourceHash)
+            .orElseThrow(() -> new ObjectStorageException("Outbox record '" + record.getId() + "' missing source metadata for copy"));
+        StorageObjectMetadata sourceMetadata = sourceRecord.metadata();
+        StorageObjectMetadata destinationMetadata = newSucceededMetadata(
+            record.getTenantId(),
+            descriptor,
+            destinationKey,
+            destinationHash,
+            sourceMetadata
+        );
+        objectRepository.upsert(destinationMetadata, sourceRecord.attributes());
+    }
+
+    private void deleteObject(StorageMetadataOutboxRecord record) {
+        StorageDescriptor descriptor = descriptorResolver.resolveOrFallback(record.getStorageName(), record.getLogicalContainer());
+        String hash = record.getObjectKeyHash().orElseGet(() -> record.getObjectKey()
+            .map(StorageObjectMetadata::deterministicObjectKeyHash)
+            .orElseThrow(() -> missingField(record, "objectKey/objectKeyHash")));
+        objectRepository.deleteByTenantAndObjectHash(record.getTenantId(), descriptor, hash);
+    }
+
+    private static StorageObjectMetadata newSucceededMetadata(String tenantId,
+                                                              StorageDescriptor descriptor,
+                                                              String key,
+                                                              String keyHash,
+                                                              StorageObjectMetadata sourceMetadata) {
+        Instant now = Instant.now();
+        return new StorageObjectMetadata(
+            tenantId,
+            descriptor,
+            key,
+            keyHash,
+            sourceMetadata == null ? null : sourceMetadata.getContentType().orElse(null),
+            sourceMetadata == null || sourceMetadata.getContentLength().isEmpty() ? null : sourceMetadata.getContentLength().getAsLong(),
+            sourceMetadata == null ? null : sourceMetadata.getEtag().orElse(null),
+            sourceMetadata == null ? null : sourceMetadata.getProviderVersionId().orElse(null),
+            sourceMetadata == null ? null : sourceMetadata.getChecksum().orElse(null),
+            sourceMetadata == null ? now : sourceMetadata.getCreatedAt(),
+            now,
+            new ObjectMetadataSyncStatus(ObjectMetadataReconciliationState.SUCCEEDED, null)
+        );
+    }
+
+    private static ObjectStorageException missingField(StorageMetadataOutboxRecord record,
+                                                       String field) {
+        return new ObjectStorageException("Outbox record '" + record.getId() + "' missing " + field);
+    }
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/DefaultObjectStorageMetadataOperations.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/DefaultObjectStorageMetadataOperations.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.metadata.ObjectMetadataReconciliationState;
+import io.micronaut.objectstorage.metadata.ObjectStorageMetadataOperations;
+import io.micronaut.objectstorage.metadata.StorageContainerMetadata;
+import io.micronaut.objectstorage.metadata.StorageDescriptor;
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata;
+import io.micronaut.objectstorage.metadata.StorageObjectMetadataQuery;
+import io.micronaut.objectstorage.metadata.TenantResolver;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRecord;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRepository;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRecord;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository;
+import org.jspecify.annotations.NonNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+@Internal
+final class DefaultObjectStorageMetadataOperations implements ObjectStorageMetadataOperations {
+
+    private static final Map<ObjectMetadataReconciliationState, Boolean> VISIBLE_STATES = Map.of(
+        ObjectMetadataReconciliationState.SUCCEEDED, true,
+        ObjectMetadataReconciliationState.PENDING, false,
+        ObjectMetadataReconciliationState.PROCESSING, false,
+        ObjectMetadataReconciliationState.FAILED, false,
+        ObjectMetadataReconciliationState.DEAD_LETTER, false
+    );
+
+    private final TenantResolver tenantResolver;
+    private final StorageContainerMetadataRepository containerRepository;
+    private final StorageObjectMetadataRepository objectRepository;
+
+    @Deprecated(forRemoval = true)
+    DefaultObjectStorageMetadataOperations(StorageDescriptor storageDescriptor,
+                                           TenantResolver tenantResolver,
+                                           StorageContainerMetadataRepository containerRepository,
+                                           StorageObjectMetadataRepository objectRepository) {
+        this(tenantResolver, containerRepository, objectRepository);
+        Objects.requireNonNull(storageDescriptor, "storageDescriptor");
+    }
+
+    DefaultObjectStorageMetadataOperations(TenantResolver tenantResolver,
+                                           StorageContainerMetadataRepository containerRepository,
+                                           StorageObjectMetadataRepository objectRepository) {
+        this.tenantResolver = tenantResolver;
+        this.containerRepository = containerRepository;
+        this.objectRepository = objectRepository;
+    }
+
+    @Override
+    public @NonNull TenantResolver getTenantResolver() {
+        return tenantResolver;
+    }
+
+    @Override
+    public @NonNull Optional<StorageContainerMetadata> findContainer(@NonNull StorageDescriptor storageDescriptor) {
+        return containerRepository.findByTenantAndDescriptor(getActiveTenantId(), storageDescriptor)
+            .map(StorageContainerMetadataRecord::metadata);
+    }
+
+    @Override
+    public @NonNull Optional<StorageObjectMetadata> findObject(@NonNull StorageDescriptor storageDescriptor, @NonNull String objectKey) {
+        return objectRepository.findByTenantAndObjectHash(getActiveTenantId(), storageDescriptor, StorageObjectMetadata.deterministicObjectKeyHash(objectKey))
+            .filter(this::isVisible)
+            .map(StorageObjectMetadataRecord::metadata);
+    }
+
+    @Override
+    public @NonNull List<StorageObjectMetadata> listObjects(@NonNull StorageObjectMetadataQuery query) {
+        return objectRepository.listByTenantAndQuery(getActiveTenantId(), query).stream()
+            .filter(this::isVisible)
+            .map(StorageObjectMetadataRecord::metadata)
+            .toList();
+    }
+
+    private boolean isVisible(StorageObjectMetadataRecord record) {
+        return isVisible(record.metadata());
+    }
+
+    private boolean isVisible(StorageObjectMetadata metadata) {
+        return VISIBLE_STATES.getOrDefault(metadata.getSyncStatus().getReconciliationState(), false);
+    }
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/MetadataOutboxReconciler.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/MetadataOutboxReconciler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRecord;
+import org.jspecify.annotations.NonNull;
+
+@Internal
+interface MetadataOutboxReconciler {
+
+    void reconcile(@NonNull StorageMetadataOutboxRecord outboxRecord);
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/MetadataOutboxReconciliationWorker.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/MetadataOutboxReconciliationWorker.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.ObjectStorageException;
+import io.micronaut.objectstorage.metadata.ObjectStorageLifecycleHook;
+import io.micronaut.objectstorage.metadata.ObjectStorageOperationContext;
+import io.micronaut.objectstorage.metadata.ObjectStorageOperationOutcome;
+import io.micronaut.objectstorage.metadata.StorageDescriptor;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRecord;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRepository;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxStatus;
+import io.micronaut.scheduling.annotation.Scheduled;
+import jakarta.inject.Singleton;
+import org.jspecify.annotations.NonNull;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+@Singleton
+@Internal
+@Requires(property = ObjectStorageMetadataJdbcConfiguration.PREFIX + ".enabled", notEquals = "false", defaultValue = "true")
+@Requires(bean = StorageMetadataOutboxRepository.class)
+@Requires(bean = MetadataOutboxReconciler.class)
+final class MetadataOutboxReconciliationWorker {
+
+    private static final int POLL_BATCH_SIZE = 32;
+
+    private final StorageMetadataOutboxRepository outboxRepository;
+    private final MetadataOutboxReconciler reconciler;
+    private final OutboxStorageDescriptorResolver descriptorResolver;
+    private final List<ObjectStorageLifecycleHook> lifecycleHooks;
+    private final int maxAttempts;
+
+    MetadataOutboxReconciliationWorker(StorageMetadataOutboxRepository outboxRepository,
+                                       MetadataOutboxReconciler reconciler,
+                                       OutboxStorageDescriptorResolver descriptorResolver,
+                                       List<ObjectStorageLifecycleHook> lifecycleHooks,
+                                       ObjectStorageMetadataJdbcConfiguration configuration) {
+        this.outboxRepository = Objects.requireNonNull(outboxRepository, "outboxRepository");
+        this.reconciler = Objects.requireNonNull(reconciler, "reconciler");
+        this.descriptorResolver = Objects.requireNonNull(descriptorResolver, "descriptorResolver");
+        this.lifecycleHooks = ObjectStorageLifecycleHook.ordered(Objects.requireNonNull(lifecycleHooks, "lifecycleHooks"));
+        this.maxAttempts = Math.max(1, configuration.getReconciliation().getMaxAttempts());
+    }
+
+    @Scheduled(fixedDelay = "${" + ObjectStorageMetadataJdbcConfiguration.PREFIX + ".reconciliation.fixed-delay:250ms}")
+    void poll() {
+        reconcileDueEntries();
+    }
+
+    void reconcileDueEntries() {
+        Instant now = Instant.now();
+        List<StorageMetadataOutboxRecord> dueEntries = outboxRepository.findDueEntries(now, POLL_BATCH_SIZE);
+        for (StorageMetadataOutboxRecord entry : dueEntries) {
+            reconcileOne(entry, now);
+        }
+    }
+
+    private void reconcileOne(StorageMetadataOutboxRecord entry,
+                              Instant asOf) {
+        Instant now = Instant.now();
+        if (!outboxRepository.markProcessing(entry.getId(), asOf, now)) {
+            return;
+        }
+        try {
+            reconciler.reconcile(entry);
+            Instant succeededAt = Instant.now();
+            outboxRepository.markSucceeded(entry.getId(), succeededAt);
+            emitAfterHooks(entry);
+        } catch (RuntimeException e) {
+            handleFailure(entry, e);
+        }
+    }
+
+    private void emitAfterHooks(StorageMetadataOutboxRecord entry) {
+        StorageDescriptor descriptor = descriptorResolver.resolveOrFallback(entry.getStorageName(), entry.getLogicalContainer());
+        ObjectStorageOperationContext context = new ObjectStorageOperationContext(
+            entry.getTenantId(),
+            descriptor,
+            entry.getOperationType(),
+            entry.getObjectKey().orElse("<unknown>"),
+            entry.getDestinationObjectKey().orElse(null),
+            null
+        );
+        ObjectStorageOperationOutcome outcome = switch (entry.getOperationType()) {
+            case UPLOAD -> new ObjectStorageOperationOutcome(
+                entry.getOperationType(),
+                entry.getTenantId(),
+                descriptor,
+                context.getObjectKey(),
+                context.getDestinationObjectKey().orElse(null),
+                entry.getReconciliationId().orElse(null),
+                null,
+                null
+            );
+            case COPY -> ObjectStorageOperationOutcome.copySuccess(
+                context,
+                null,
+                entry.getReconciliationId().orElse(null)
+            );
+            case DELETE -> ObjectStorageOperationOutcome.deleteSuccess(
+                context,
+                null,
+                entry.getReconciliationId().orElse(null)
+            );
+        };
+        for (ObjectStorageLifecycleHook lifecycleHook : lifecycleHooks) {
+            try {
+                lifecycleHook.after(context, outcome);
+            } catch (RuntimeException ignored) {
+            }
+        }
+    }
+
+    private void handleFailure(StorageMetadataOutboxRecord entry,
+                               RuntimeException failure) {
+        int attemptCount = entry.getAttemptCount() + 1;
+        StorageMetadataOutboxStatus nextStatus = attemptCount >= maxAttempts
+            ? StorageMetadataOutboxStatus.DEAD_LETTER
+            : StorageMetadataOutboxStatus.FAILED;
+        Instant nextAttemptAt = Instant.now().plus(MetadataOutboxRetryPolicy.delayForAttempt(attemptCount));
+        String errorSummary = summarize(failure);
+        outboxRepository.markRetryOrDeadLetter(
+            entry.getId(),
+            attemptCount,
+            nextAttemptAt,
+            nextStatus,
+            errorSummary,
+            Instant.now()
+        );
+        emitErrorHook(entry, failure, attemptCount, nextStatus);
+    }
+
+    private void emitErrorHook(StorageMetadataOutboxRecord entry,
+                               RuntimeException failure,
+                               int attemptCount,
+                               StorageMetadataOutboxStatus status) {
+        StorageDescriptor descriptor = descriptorResolver.resolveOrFallback(entry.getStorageName(), entry.getLogicalContainer());
+        String objectKey = entry.getObjectKey().orElse("<unknown>");
+        ObjectStorageOperationContext context = new ObjectStorageOperationContext(
+            entry.getTenantId(),
+            descriptor,
+            entry.getOperationType(),
+            objectKey,
+            null,
+            null
+        );
+        ObjectStorageException exception = new ObjectStorageException(
+            "Outbox reconciliation failed for record '"
+                + entry.getId()
+                + "' (attempt="
+                + attemptCount
+                + ", status="
+                + status
+                + ")"
+                + entry.getReconciliationId().map(it -> " reconciliationId=" + it).orElse(""),
+            failure
+        );
+        for (ObjectStorageLifecycleHook lifecycleHook : lifecycleHooks) {
+            try {
+                lifecycleHook.error(context, exception);
+            } catch (RuntimeException ignored) {
+            }
+        }
+    }
+
+    @NonNull
+    private static String summarize(Throwable throwable) {
+        String message = throwable.getMessage();
+        String value = (message == null || message.isBlank())
+            ? throwable.getClass().getSimpleName()
+            : throwable.getClass().getSimpleName() + ": " + message;
+        return value.length() > 2000 ? value.substring(0, 2000) : value;
+    }
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/MetadataOutboxRetryPolicy.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/MetadataOutboxRetryPolicy.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc;
+
+import io.micronaut.core.annotation.Internal;
+
+import java.time.Duration;
+import java.util.List;
+
+@Internal
+final class MetadataOutboxRetryPolicy {
+
+    private static final List<Duration> RETRY_SCHEDULE = List.of(
+        Duration.ofMillis(250),
+        Duration.ofSeconds(1),
+        Duration.ofSeconds(5),
+        Duration.ofSeconds(15),
+        Duration.ofSeconds(30)
+    );
+
+    private MetadataOutboxRetryPolicy() {
+    }
+
+    static Duration delayForAttempt(int attemptCount) {
+        int index = Math.max(1, attemptCount) - 1;
+        int boundedIndex = Math.min(index, RETRY_SCHEDULE.size() - 1);
+        return RETRY_SCHEDULE.get(boundedIndex);
+    }
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/ObjectStorageMetadataJdbcConfiguration.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/ObjectStorageMetadataJdbcConfiguration.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.core.util.Toggleable;
+import org.jspecify.annotations.NonNull;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Configuration properties for JDBC-backed object metadata persistence.
+ */
+@ConfigurationProperties(ObjectStorageMetadataJdbcConfiguration.PREFIX)
+public final class ObjectStorageMetadataJdbcConfiguration implements Toggleable {
+
+    public static final String PREFIX = "micronaut.object-storage.metadata.jdbc";
+
+    private boolean enabled = true;
+    @NonNull
+    private String datasource = "default";
+    @NonNull
+    private Reconciliation reconciliation = new Reconciliation();
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @NonNull
+    public String getDatasource() {
+        return datasource;
+    }
+
+    public void setDatasource(@NonNull String datasource) {
+        this.datasource = Objects.requireNonNull(datasource, "datasource");
+    }
+
+    @NonNull
+    public Reconciliation getReconciliation() {
+        return reconciliation;
+    }
+
+    public void setReconciliation(@NonNull Reconciliation reconciliation) {
+        this.reconciliation = Objects.requireNonNull(reconciliation, "reconciliation");
+    }
+
+    /**
+     * Reconciliation worker settings.
+     */
+    @ConfigurationProperties("reconciliation")
+    public static final class Reconciliation {
+
+        @NonNull
+        @Bindable(defaultValue = "250ms")
+        private Duration fixedDelay = Duration.ofMillis(250);
+        @Bindable(defaultValue = "5")
+        private int maxAttempts = 5;
+
+        @NonNull
+        public Duration getFixedDelay() {
+            return fixedDelay;
+        }
+
+        public void setFixedDelay(@NonNull Duration fixedDelay) {
+            this.fixedDelay = Objects.requireNonNull(fixedDelay, "fixedDelay");
+        }
+
+        public int getMaxAttempts() {
+            return maxAttempts;
+        }
+
+        public void setMaxAttempts(int maxAttempts) {
+            this.maxAttempts = maxAttempts;
+        }
+    }
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/ObjectStorageMetadataJdbcFactory.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/ObjectStorageMetadataJdbcFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.objectstorage.ObjectStorageOperations;
+import io.micronaut.objectstorage.metadata.MetadataAwareObjectStorageOperations;
+import io.micronaut.objectstorage.metadata.ObjectStorageLifecycleHook;
+import io.micronaut.objectstorage.metadata.ObjectStorageMetadataOperations;
+import io.micronaut.objectstorage.metadata.StorageDescriptorResolver;
+import io.micronaut.objectstorage.metadata.TenantResolver;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRepository;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRepository;
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository;
+
+import java.util.List;
+
+@Factory
+@Requires(property = ObjectStorageMetadataJdbcConfiguration.PREFIX + ".enabled", notEquals = "false", defaultValue = "true")
+final class ObjectStorageMetadataJdbcFactory {
+
+    @EachBean(StorageDescriptorResolver.class)
+    ObjectStorageMetadataOperations objectStorageMetadataOperations(StorageDescriptorResolver storageDescriptorResolver,
+                                                                    TenantResolver tenantResolver,
+                                                                    StorageContainerMetadataRepository containerRepository,
+                                                                    StorageObjectMetadataRepository objectRepository) {
+        return new DefaultObjectStorageMetadataOperations(
+            tenantResolver,
+            containerRepository,
+            objectRepository
+        );
+    }
+
+    @EachBean(ObjectStorageMetadataOperations.class)
+    <I, O, D> MetadataAwareObjectStorageOperations<I, O, D> metadataAwareObjectStorageOperations(@Parameter ObjectStorageOperations<I, O, D> delegate,
+                                                                                                  @Parameter StorageDescriptorResolver storageDescriptorResolver,
+                                                                                                  ObjectStorageMetadataOperations metadataOperations,
+                                                                                                  TenantResolver tenantResolver,
+                                                                                                  StorageContainerMetadataRepository containerRepository,
+                                                                                                  StorageMetadataOutboxRepository outboxRepository,
+                                                                                                  List<ObjectStorageLifecycleHook> lifecycleHooks) {
+        return new DefaultMetadataAwareObjectStorageOperations<>(
+            delegate,
+            metadataOperations,
+            storageDescriptorResolver.resolve(),
+            tenantResolver,
+            containerRepository,
+            outboxRepository,
+            lifecycleHooks
+        );
+    }
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/OutboxStorageDescriptorResolver.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/OutboxStorageDescriptorResolver.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.metadata.StorageDescriptor;
+import io.micronaut.objectstorage.metadata.StorageDescriptorResolver;
+import jakarta.inject.Singleton;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Singleton
+@Internal
+final class OutboxStorageDescriptorResolver {
+
+    private final Map<Key, StorageDescriptor> descriptors;
+
+    OutboxStorageDescriptorResolver(Collection<StorageDescriptorResolver> resolvers) {
+        this.descriptors = Objects.requireNonNull(resolvers, "resolvers")
+            .stream()
+            .map(StorageDescriptorResolver::resolve)
+            .collect(Collectors.toUnmodifiableMap(
+                descriptor -> new Key(descriptor.getStorageName(), descriptor.getLogicalContainer()),
+                Function.identity(),
+                (left, right) -> left
+            ));
+    }
+
+    @NonNull
+    Optional<StorageDescriptor> resolve(@NonNull String storageName,
+                                        @NonNull String logicalContainer) {
+        return Optional.ofNullable(descriptors.get(new Key(storageName, logicalContainer)));
+    }
+
+    @NonNull
+    StorageDescriptor resolveOrFallback(@NonNull String storageName,
+                                        @NonNull String logicalContainer) {
+        return resolve(storageName, logicalContainer)
+            .orElseGet(() -> new StorageDescriptor(storageName, "unknown", logicalContainer, null, logicalContainer));
+    }
+
+    private record Key(String storageName, String logicalContainer) {
+    }
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/package-info.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * JDBC-backed metadata support for object storage integrations.
+ *
+ * <p>
+ * Package provides implementations of metadata repositories backed by JDBC.
+ */
+package io.micronaut.objectstorage.metadata.jdbc;

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/AbstractJdbcMetadataRepository.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/AbstractJdbcMetadataRepository.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc.repository;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.NonNull;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Objects;
+
+@Internal
+abstract class AbstractJdbcMetadataRepository {
+
+    private final DataSource dataSource;
+
+    protected AbstractJdbcMetadataRepository(@NonNull DataSource dataSource) {
+        this.dataSource = Objects.requireNonNull(dataSource, "dataSource");
+    }
+
+    protected <T> T withTransaction(SqlFunction<T> transactionBody) {
+        Objects.requireNonNull(transactionBody, "transactionBody");
+        try (Connection connection = dataSource.getConnection()) {
+            boolean previousAutoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+            try {
+                T result = transactionBody.apply(connection);
+                connection.commit();
+                return result;
+            } catch (SQLException e) {
+                connection.rollback();
+                throw e;
+            } finally {
+                connection.setAutoCommit(previousAutoCommit);
+            }
+        } catch (SQLException e) {
+            throw new MetadataJdbcException("JDBC transaction failed", e);
+        }
+    }
+
+    protected void withTransaction(SqlConsumer transactionBody) {
+        withTransaction(connection -> {
+            transactionBody.accept(connection);
+            return null;
+        });
+    }
+
+    protected static Timestamp timestampOf(@NonNull Instant instant) {
+        return Timestamp.from(Objects.requireNonNull(instant, "instant"));
+    }
+
+    @NonNull
+    protected static Instant instantOf(Timestamp timestamp) {
+        return Objects.requireNonNull(timestamp, "timestamp").toInstant();
+    }
+
+    @FunctionalInterface
+    protected interface SqlFunction<T> {
+        T apply(Connection connection) throws SQLException;
+    }
+
+    @FunctionalInterface
+    protected interface SqlConsumer {
+        void accept(Connection connection) throws SQLException;
+    }
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/JdbcStorageContainerMetadataRepository.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/JdbcStorageContainerMetadataRepository.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc.repository;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.metadata.StorageContainerMetadata;
+import io.micronaut.objectstorage.metadata.StorageDescriptor;
+import jakarta.inject.Singleton;
+import org.jspecify.annotations.NonNull;
+
+import javax.sql.DataSource;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * JDBC repository for container metadata rows and attributes.
+ */
+@Singleton
+@Internal
+public class JdbcStorageContainerMetadataRepository extends AbstractJdbcMetadataRepository implements StorageContainerMetadataRepository {
+
+    public static final String UPSERT_SELECT_ID_SQL = """
+        SELECT id
+        FROM storage_container_metadata
+        WHERE tenant_id = ?
+          AND storage_name = ?
+          AND logical_container = ?
+        """;
+    public static final String UPDATE_SQL = """
+        UPDATE storage_container_metadata
+        SET provider_id = ?,
+            provider_namespace = ?,
+            provider_container = ?,
+            updated_at = ?
+        WHERE id = ?
+        """;
+    public static final String INSERT_SQL = """
+        INSERT INTO storage_container_metadata (
+            id,
+            tenant_id,
+            storage_name,
+            provider_id,
+            logical_container,
+            provider_namespace,
+            provider_container,
+            created_at,
+            updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """;
+    public static final String DELETE_ATTRS_SQL = "DELETE FROM storage_container_metadata_attr WHERE container_metadata_id = ?";
+    public static final String INSERT_ATTR_SQL = """
+        INSERT INTO storage_container_metadata_attr (
+            container_metadata_id,
+            attr_key,
+            attr_value
+        ) VALUES (?, ?, ?)
+        """;
+    public static final String FIND_SQL = """
+        SELECT id,
+               tenant_id,
+               storage_name,
+               provider_id,
+               logical_container,
+               provider_namespace,
+               provider_container,
+               created_at,
+               updated_at
+        FROM storage_container_metadata
+        WHERE tenant_id = ?
+          AND storage_name = ?
+          AND logical_container = ?
+        """;
+    public static final String FIND_ATTRS_SQL = """
+        SELECT attr_key, attr_value
+        FROM storage_container_metadata_attr
+        WHERE container_metadata_id = ?
+        ORDER BY attr_key
+        """;
+
+    public JdbcStorageContainerMetadataRepository(@NonNull DataSource dataSource) {
+        super(dataSource);
+    }
+
+    @Override
+    public void upsert(@NonNull StorageContainerMetadata metadata, @NonNull Map<String, String> attributes) {
+        Objects.requireNonNull(metadata, "metadata");
+        Map<String, String> normalizedAttributes = Map.copyOf(Objects.requireNonNull(attributes, "attributes"));
+        withTransaction(connection -> {
+            String id = resolveContainerId(connection, metadata).orElseGet(() -> UUID.randomUUID().toString());
+            Instant now = Instant.now();
+            if (exists(connection, id)) {
+                updateContainer(connection, id, metadata, now);
+            } else {
+                insertContainer(connection, id, metadata, now);
+            }
+            replaceAttributes(connection, id, normalizedAttributes);
+        });
+    }
+
+    @Override
+    @NonNull
+    public Optional<StorageContainerMetadataRecord> findByTenantAndDescriptor(@NonNull String tenantId,
+                                                                               @NonNull StorageDescriptor storageDescriptor) {
+        Objects.requireNonNull(tenantId, "tenantId");
+        Objects.requireNonNull(storageDescriptor, "storageDescriptor");
+        return withTransaction(connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(FIND_SQL)) {
+                statement.setString(1, tenantId);
+                statement.setString(2, storageDescriptor.getStorageName());
+                statement.setString(3, storageDescriptor.getLogicalContainer());
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    if (!resultSet.next()) {
+                        return Optional.empty();
+                    }
+                    String id = resultSet.getString("id");
+                    StorageDescriptor descriptor = new StorageDescriptor(
+                        resultSet.getString("storage_name"),
+                        resultSet.getString("provider_id"),
+                        resultSet.getString("logical_container"),
+                        resultSet.getString("provider_namespace"),
+                        resultSet.getString("provider_container")
+                    );
+                    StorageContainerMetadata metadata = new StorageContainerMetadata(
+                        resultSet.getString("tenant_id"),
+                        descriptor,
+                        instantOf(resultSet.getTimestamp("created_at")),
+                        instantOf(resultSet.getTimestamp("updated_at"))
+                    );
+                    return Optional.of(new StorageContainerMetadataRecord(metadata, findAttributes(connection, id)));
+                }
+            }
+        });
+    }
+
+    private static Optional<String> resolveContainerId(java.sql.Connection connection,
+                                                       StorageContainerMetadata metadata) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(UPSERT_SELECT_ID_SQL)) {
+            statement.setString(1, metadata.getTenantId());
+            statement.setString(2, metadata.getStorageDescriptor().getStorageName());
+            statement.setString(3, metadata.getStorageDescriptor().getLogicalContainer());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next() ? Optional.of(resultSet.getString(1)) : Optional.empty();
+            }
+        }
+    }
+
+    private static boolean exists(java.sql.Connection connection, String id) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement("SELECT id FROM storage_container_metadata WHERE id = ?")) {
+            statement.setString(1, id);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        }
+    }
+
+    private static void updateContainer(java.sql.Connection connection,
+                                        String id,
+                                        StorageContainerMetadata metadata,
+                                        Instant now) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(UPDATE_SQL)) {
+            StorageDescriptor descriptor = metadata.getStorageDescriptor();
+            statement.setString(1, descriptor.getProviderId());
+            statement.setString(2, descriptor.getProviderNamespace().orElse(null));
+            statement.setString(3, descriptor.getProviderContainer());
+            statement.setTimestamp(4, timestampOf(now));
+            statement.setString(5, id);
+            statement.executeUpdate();
+        }
+    }
+
+    private static void insertContainer(java.sql.Connection connection,
+                                        String id,
+                                        StorageContainerMetadata metadata,
+                                        Instant now) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(INSERT_SQL)) {
+            StorageDescriptor descriptor = metadata.getStorageDescriptor();
+            statement.setString(1, id);
+            statement.setString(2, metadata.getTenantId());
+            statement.setString(3, descriptor.getStorageName());
+            statement.setString(4, descriptor.getProviderId());
+            statement.setString(5, descriptor.getLogicalContainer());
+            statement.setString(6, descriptor.getProviderNamespace().orElse(null));
+            statement.setString(7, descriptor.getProviderContainer());
+            statement.setTimestamp(8, timestampOf(now));
+            statement.setTimestamp(9, timestampOf(now));
+            statement.executeUpdate();
+        }
+    }
+
+    private static void replaceAttributes(java.sql.Connection connection,
+                                          String id,
+                                          Map<String, String> attributes) throws SQLException {
+        try (PreparedStatement deleteStatement = connection.prepareStatement(DELETE_ATTRS_SQL)) {
+            deleteStatement.setString(1, id);
+            deleteStatement.executeUpdate();
+        }
+        if (attributes.isEmpty()) {
+            return;
+        }
+        try (PreparedStatement insertStatement = connection.prepareStatement(INSERT_ATTR_SQL)) {
+            for (Map.Entry<String, String> entry : attributes.entrySet()) {
+                insertStatement.setString(1, id);
+                insertStatement.setString(2, entry.getKey());
+                insertStatement.setString(3, entry.getValue());
+                insertStatement.addBatch();
+            }
+            insertStatement.executeBatch();
+        }
+    }
+
+    private static Map<String, String> findAttributes(java.sql.Connection connection, String id) throws SQLException {
+        Map<String, String> attributes = new LinkedHashMap<>();
+        try (PreparedStatement statement = connection.prepareStatement(FIND_ATTRS_SQL)) {
+            statement.setString(1, id);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    attributes.put(resultSet.getString("attr_key"), resultSet.getString("attr_value"));
+                }
+            }
+        }
+        return attributes;
+    }
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/JdbcStorageMetadataOutboxRepository.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/JdbcStorageMetadataOutboxRepository.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc.repository;
+
+import io.micronaut.core.annotation.Internal;
+import jakarta.inject.Singleton;
+import org.jspecify.annotations.NonNull;
+
+import javax.sql.DataSource;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * JDBC repository for durable metadata outbox entries.
+ */
+@Singleton
+@Internal
+public class JdbcStorageMetadataOutboxRepository extends AbstractJdbcMetadataRepository implements StorageMetadataOutboxRepository {
+
+    static final String INSERT_SQL = """
+        INSERT INTO storage_metadata_outbox (
+            id,
+            tenant_id,
+            storage_name,
+            logical_container,
+            object_key,
+            object_key_hash,
+            destination_object_key,
+            destination_object_key_hash,
+            operation_type,
+            reconciliation_id,
+            payload_version,
+            status,
+            attempt_count,
+            next_attempt_at,
+            last_error_summary,
+            idempotency_key,
+            created_at,
+            updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """;
+    static final String FIND_DUE_SQL = """
+        SELECT id,
+               tenant_id,
+               storage_name,
+               logical_container,
+               object_key,
+               object_key_hash,
+               destination_object_key,
+               destination_object_key_hash,
+               operation_type,
+               reconciliation_id,
+               payload_version,
+               status,
+               attempt_count,
+               next_attempt_at,
+               last_error_summary,
+               idempotency_key,
+               created_at,
+               updated_at
+        FROM storage_metadata_outbox
+        WHERE status IN ('PENDING', 'FAILED', 'PROCESSING')
+          AND next_attempt_at <= ?
+        ORDER BY next_attempt_at ASC, created_at ASC
+        FETCH FIRST ? ROWS ONLY
+        """;
+    static final String UPDATE_PROCESSING_SQL = """
+        UPDATE storage_metadata_outbox
+        SET status = 'PROCESSING',
+            updated_at = ?
+        WHERE id = ?
+          AND status IN ('PENDING', 'FAILED', 'PROCESSING')
+          AND next_attempt_at <= ?
+        """;
+    static final String UPDATE_SUCCEEDED_SQL = """
+        UPDATE storage_metadata_outbox
+        SET status = 'SUCCEEDED',
+            last_error_summary = NULL,
+            updated_at = ?
+        WHERE id = ?
+        """;
+    static final String UPDATE_RETRY_OR_DEAD_LETTER_SQL = """
+        UPDATE storage_metadata_outbox
+        SET status = ?,
+            attempt_count = ?,
+            next_attempt_at = ?,
+            last_error_summary = ?,
+            updated_at = ?
+        WHERE id = ?
+        """;
+    static final String FIND_BY_ID_SQL = """
+        SELECT id,
+               tenant_id,
+               storage_name,
+               logical_container,
+               object_key,
+               object_key_hash,
+               destination_object_key,
+               destination_object_key_hash,
+               operation_type,
+               reconciliation_id,
+               payload_version,
+               status,
+               attempt_count,
+               next_attempt_at,
+               last_error_summary,
+               idempotency_key,
+               created_at,
+               updated_at
+        FROM storage_metadata_outbox
+        WHERE id = ?
+        """;
+    static final String FIND_BY_IDEMPOTENCY_KEY_SQL = """
+        SELECT id,
+               tenant_id,
+               storage_name,
+               logical_container,
+               object_key,
+               object_key_hash,
+               destination_object_key,
+               destination_object_key_hash,
+               operation_type,
+               reconciliation_id,
+               payload_version,
+               status,
+               attempt_count,
+               next_attempt_at,
+               last_error_summary,
+               idempotency_key,
+               created_at,
+               updated_at
+        FROM storage_metadata_outbox
+        WHERE idempotency_key = ?
+        """;
+
+    public JdbcStorageMetadataOutboxRepository(@NonNull DataSource dataSource) {
+        super(dataSource);
+    }
+
+    @Override
+    public void enqueue(@NonNull StorageMetadataOutboxRecord outboxRecord) {
+        Objects.requireNonNull(outboxRecord, "outboxRecord");
+        withTransaction(connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(INSERT_SQL)) {
+                statement.setString(1, outboxRecord.getId());
+                statement.setString(2, outboxRecord.getTenantId());
+                statement.setString(3, outboxRecord.getStorageName());
+                statement.setString(4, outboxRecord.getLogicalContainer());
+                statement.setString(5, outboxRecord.getObjectKey().orElse(null));
+                statement.setString(6, outboxRecord.getObjectKeyHash().orElse(null));
+                statement.setString(7, outboxRecord.getDestinationObjectKey().orElse(null));
+                statement.setString(8, outboxRecord.getDestinationObjectKeyHash().orElse(null));
+                statement.setString(9, outboxRecord.getOperationType().name());
+                statement.setString(10, outboxRecord.getReconciliationId().orElse(null));
+                statement.setInt(11, outboxRecord.getPayloadVersion());
+                statement.setString(12, outboxRecord.getStatus().name());
+                statement.setInt(13, outboxRecord.getAttemptCount());
+                statement.setTimestamp(14, timestampOf(outboxRecord.getNextAttemptAt()));
+                statement.setString(15, outboxRecord.getLastErrorSummary().orElse(null));
+                statement.setString(16, outboxRecord.getIdempotencyKey());
+                statement.setTimestamp(17, timestampOf(outboxRecord.getCreatedAt()));
+                statement.setTimestamp(18, timestampOf(outboxRecord.getUpdatedAt()));
+                statement.executeUpdate();
+            }
+        });
+    }
+
+    @Override
+    public boolean enqueueIfAbsent(@NonNull StorageMetadataOutboxRecord outboxRecord) {
+        Objects.requireNonNull(outboxRecord, "outboxRecord");
+        return withTransaction(connection -> {
+            try {
+                try (PreparedStatement statement = connection.prepareStatement(INSERT_SQL)) {
+                    statement.setString(1, outboxRecord.getId());
+                    statement.setString(2, outboxRecord.getTenantId());
+                    statement.setString(3, outboxRecord.getStorageName());
+                    statement.setString(4, outboxRecord.getLogicalContainer());
+                    statement.setString(5, outboxRecord.getObjectKey().orElse(null));
+                    statement.setString(6, outboxRecord.getObjectKeyHash().orElse(null));
+                    statement.setString(7, outboxRecord.getDestinationObjectKey().orElse(null));
+                    statement.setString(8, outboxRecord.getDestinationObjectKeyHash().orElse(null));
+                    statement.setString(9, outboxRecord.getOperationType().name());
+                    statement.setString(10, outboxRecord.getReconciliationId().orElse(null));
+                    statement.setInt(11, outboxRecord.getPayloadVersion());
+                    statement.setString(12, outboxRecord.getStatus().name());
+                    statement.setInt(13, outboxRecord.getAttemptCount());
+                    statement.setTimestamp(14, timestampOf(outboxRecord.getNextAttemptAt()));
+                    statement.setString(15, outboxRecord.getLastErrorSummary().orElse(null));
+                    statement.setString(16, outboxRecord.getIdempotencyKey());
+                    statement.setTimestamp(17, timestampOf(outboxRecord.getCreatedAt()));
+                    statement.setTimestamp(18, timestampOf(outboxRecord.getUpdatedAt()));
+                    statement.executeUpdate();
+                }
+                return true;
+            } catch (SQLIntegrityConstraintViolationException ignored) {
+                return false;
+            }
+        });
+    }
+
+    @Override
+    @NonNull
+    public List<StorageMetadataOutboxRecord> findDueEntries(@NonNull Instant asOf, int limit) {
+        Instant boundedAsOf = Objects.requireNonNull(asOf, "asOf");
+        if (limit <= 0) {
+            return List.of();
+        }
+        return withTransaction(connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(FIND_DUE_SQL)) {
+                statement.setTimestamp(1, timestampOf(boundedAsOf));
+                statement.setInt(2, limit);
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    List<StorageMetadataOutboxRecord> records = new ArrayList<>();
+                    while (resultSet.next()) {
+                        records.add(readOutboxRecord(resultSet));
+                    }
+                    return List.copyOf(records);
+                }
+            }
+        });
+    }
+
+    @Override
+    public boolean markProcessing(@NonNull String id,
+                                  @NonNull Instant asOf,
+                                  @NonNull Instant updatedAt) {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(asOf, "asOf");
+        Objects.requireNonNull(updatedAt, "updatedAt");
+        return withTransaction(connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(UPDATE_PROCESSING_SQL)) {
+                statement.setTimestamp(1, timestampOf(updatedAt));
+                statement.setString(2, id);
+                statement.setTimestamp(3, timestampOf(asOf));
+                return statement.executeUpdate() == 1;
+            }
+        });
+    }
+
+    @Override
+    public void markSucceeded(@NonNull String id,
+                              @NonNull Instant updatedAt) {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(updatedAt, "updatedAt");
+        withTransaction(connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(UPDATE_SUCCEEDED_SQL)) {
+                statement.setTimestamp(1, timestampOf(updatedAt));
+                statement.setString(2, id);
+                statement.executeUpdate();
+            }
+        });
+    }
+
+    @Override
+    public void markRetryOrDeadLetter(@NonNull String id,
+                                      int attemptCount,
+                                      @NonNull Instant nextAttemptAt,
+                                      @NonNull StorageMetadataOutboxStatus status,
+                                      @NonNull String lastErrorSummary,
+                                      @NonNull Instant updatedAt) {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(nextAttemptAt, "nextAttemptAt");
+        Objects.requireNonNull(status, "status");
+        Objects.requireNonNull(lastErrorSummary, "lastErrorSummary");
+        Objects.requireNonNull(updatedAt, "updatedAt");
+        if (status != StorageMetadataOutboxStatus.FAILED && status != StorageMetadataOutboxStatus.DEAD_LETTER) {
+            throw new IllegalArgumentException("status must be FAILED or DEAD_LETTER");
+        }
+        withTransaction(connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(UPDATE_RETRY_OR_DEAD_LETTER_SQL)) {
+                statement.setString(1, status.name());
+                statement.setInt(2, attemptCount);
+                statement.setTimestamp(3, timestampOf(nextAttemptAt));
+                statement.setString(4, lastErrorSummary);
+                statement.setTimestamp(5, timestampOf(updatedAt));
+                statement.setString(6, id);
+                statement.executeUpdate();
+            }
+        });
+    }
+
+    @Override
+    @NonNull
+    public Optional<StorageMetadataOutboxRecord> findById(@NonNull String id) {
+        Objects.requireNonNull(id, "id");
+        return withTransaction((SqlFunction<Optional<StorageMetadataOutboxRecord>>) connection ->
+            findSingle(connection.prepareStatement(FIND_BY_ID_SQL), id));
+    }
+
+    @Override
+    @NonNull
+    public Optional<StorageMetadataOutboxRecord> findByIdempotencyKey(@NonNull String idempotencyKey) {
+        Objects.requireNonNull(idempotencyKey, "idempotencyKey");
+        return withTransaction((SqlFunction<Optional<StorageMetadataOutboxRecord>>) connection ->
+            findSingle(connection.prepareStatement(FIND_BY_IDEMPOTENCY_KEY_SQL), idempotencyKey));
+    }
+
+    private static Optional<StorageMetadataOutboxRecord> findSingle(PreparedStatement statement,
+                                                                    String predicate) throws java.sql.SQLException {
+        try (statement) {
+            statement.setString(1, predicate);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) {
+                    return Optional.empty();
+                }
+                return Optional.of(readOutboxRecord(resultSet));
+            }
+        }
+    }
+
+    private static StorageMetadataOutboxRecord readOutboxRecord(ResultSet resultSet) throws java.sql.SQLException {
+        return StorageMetadataOutboxRecord.builder()
+            .id(resultSet.getString("id"))
+            .tenantId(resultSet.getString("tenant_id"))
+            .storageName(resultSet.getString("storage_name"))
+            .logicalContainer(resultSet.getString("logical_container"))
+            .objectKey(resultSet.getString("object_key"))
+            .objectKeyHash(resultSet.getString("object_key_hash"))
+            .destinationObjectKey(resultSet.getString("destination_object_key"))
+            .destinationObjectKeyHash(resultSet.getString("destination_object_key_hash"))
+            .operationType(io.micronaut.objectstorage.metadata.ObjectStorageOperationType.valueOf(resultSet.getString("operation_type")))
+            .reconciliationId(resultSet.getString("reconciliation_id"))
+            .payloadVersion(resultSet.getInt("payload_version"))
+            .status(StorageMetadataOutboxStatus.valueOf(resultSet.getString("status")))
+            .attemptCount(resultSet.getInt("attempt_count"))
+            .nextAttemptAt(instantOf(resultSet.getTimestamp("next_attempt_at")))
+            .lastErrorSummary(resultSet.getString("last_error_summary"))
+            .idempotencyKey(resultSet.getString("idempotency_key"))
+            .createdAt(instantOf(resultSet.getTimestamp("created_at")))
+            .updatedAt(instantOf(resultSet.getTimestamp("updated_at")))
+            .build();
+    }
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/JdbcStorageObjectMetadataRepository.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/JdbcStorageObjectMetadataRepository.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc.repository;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.metadata.ObjectMetadataReconciliationState;
+import io.micronaut.objectstorage.metadata.ObjectMetadataSyncStatus;
+import io.micronaut.objectstorage.metadata.StorageDescriptor;
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata;
+import io.micronaut.objectstorage.metadata.StorageObjectMetadataQuery;
+import jakarta.inject.Singleton;
+import org.jspecify.annotations.NonNull;
+
+import javax.sql.DataSource;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * JDBC repository for object metadata rows and attributes.
+ */
+@Singleton
+@Internal
+public class JdbcStorageObjectMetadataRepository extends AbstractJdbcMetadataRepository implements StorageObjectMetadataRepository {
+
+    public static final String SELECT_ID_SQL = """
+        SELECT id
+        FROM storage_object_metadata
+        WHERE tenant_id = ?
+          AND storage_name = ?
+          AND logical_container = ?
+          AND object_key_hash = ?
+        """;
+    public static final String UPDATE_SQL = """
+        UPDATE storage_object_metadata
+        SET provider_id = ?,
+            provider_namespace = ?,
+            provider_container = ?,
+            object_key = ?,
+            content_type = ?,
+            content_length = ?,
+            etag = ?,
+            provider_version_id = ?,
+            checksum = ?,
+            reconciliation_state = ?,
+            last_error_summary = ?,
+            updated_at = ?
+        WHERE id = ?
+        """;
+    public static final String INSERT_SQL = """
+        INSERT INTO storage_object_metadata (
+            id,
+            tenant_id,
+            storage_name,
+            provider_id,
+            logical_container,
+            provider_namespace,
+            provider_container,
+            object_key,
+            object_key_hash,
+            content_type,
+            content_length,
+            etag,
+            provider_version_id,
+            checksum,
+            reconciliation_state,
+            last_error_summary,
+            created_at,
+            updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """;
+    public static final String DELETE_ATTRS_SQL = "DELETE FROM storage_object_metadata_attr WHERE object_metadata_id = ?";
+    public static final String INSERT_ATTR_SQL = """
+        INSERT INTO storage_object_metadata_attr (
+            object_metadata_id,
+            attr_key,
+            attr_value
+        ) VALUES (?, ?, ?)
+        """;
+    public static final String FIND_SQL = """
+        SELECT id,
+               tenant_id,
+               storage_name,
+               provider_id,
+               logical_container,
+               provider_namespace,
+               provider_container,
+               object_key,
+               object_key_hash,
+               content_type,
+               content_length,
+               etag,
+               provider_version_id,
+               checksum,
+               reconciliation_state,
+               last_error_summary,
+               created_at,
+               updated_at
+        FROM storage_object_metadata
+        WHERE tenant_id = ?
+          AND storage_name = ?
+          AND logical_container = ?
+          AND object_key_hash = ?
+        """;
+    public static final String LIST_SQL = """
+        SELECT id,
+               tenant_id,
+               storage_name,
+               provider_id,
+               logical_container,
+               provider_namespace,
+               provider_container,
+               object_key,
+               object_key_hash,
+               content_type,
+               content_length,
+               etag,
+               provider_version_id,
+               checksum,
+               reconciliation_state,
+               last_error_summary,
+               created_at,
+               updated_at
+        FROM storage_object_metadata
+        WHERE tenant_id = ?
+          AND (? IS NULL OR storage_name = ?)
+          AND (? IS NULL OR logical_container = ?)
+          AND (? IS NULL OR object_key LIKE ?)
+        ORDER BY object_key
+        """;
+    public static final String FIND_ATTRS_SQL = """
+        SELECT attr_key, attr_value
+        FROM storage_object_metadata_attr
+        WHERE object_metadata_id = ?
+        ORDER BY attr_key
+        """;
+    public static final String DELETE_BY_SCOPE_SQL = """
+        DELETE FROM storage_object_metadata
+        WHERE tenant_id = ?
+          AND storage_name = ?
+          AND logical_container = ?
+          AND object_key_hash = ?
+        """;
+
+    public JdbcStorageObjectMetadataRepository(@NonNull DataSource dataSource) {
+        super(dataSource);
+    }
+
+    @Override
+    public void upsert(@NonNull StorageObjectMetadata metadata, @NonNull Map<String, String> attributes) {
+        Objects.requireNonNull(metadata, "metadata");
+        Map<String, String> normalizedAttributes = Map.copyOf(Objects.requireNonNull(attributes, "attributes"));
+        withTransaction(connection -> {
+            String id = resolveObjectId(connection, metadata).orElseGet(() -> UUID.randomUUID().toString());
+            Instant now = Instant.now();
+            if (exists(connection, id)) {
+                updateObject(connection, id, metadata, now);
+            } else {
+                insertObject(connection, id, metadata, now);
+            }
+            replaceAttributes(connection, id, normalizedAttributes);
+        });
+    }
+
+    @Override
+    @NonNull
+    public Optional<StorageObjectMetadataRecord> findByTenantAndObjectHash(@NonNull String tenantId,
+                                                                            @NonNull StorageDescriptor storageDescriptor,
+                                                                            @NonNull String objectKeyHash) {
+        Objects.requireNonNull(tenantId, "tenantId");
+        Objects.requireNonNull(storageDescriptor, "storageDescriptor");
+        Objects.requireNonNull(objectKeyHash, "objectKeyHash");
+        return withTransaction(connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(FIND_SQL)) {
+                statement.setString(1, tenantId);
+                statement.setString(2, storageDescriptor.getStorageName());
+                statement.setString(3, storageDescriptor.getLogicalContainer());
+                statement.setString(4, objectKeyHash);
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    if (!resultSet.next()) {
+                        return Optional.empty();
+                    }
+                    String id = resultSet.getString("id");
+                    return Optional.of(new StorageObjectMetadataRecord(readMetadata(resultSet), findAttributes(connection, id)));
+                }
+            }
+        });
+    }
+
+    @Override
+    @NonNull
+    public List<StorageObjectMetadataRecord> listByTenantAndQuery(@NonNull String tenantId,
+                                                                   @NonNull StorageObjectMetadataQuery query) {
+        Objects.requireNonNull(tenantId, "tenantId");
+        Objects.requireNonNull(query, "query");
+        return withTransaction(connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(LIST_SQL)) {
+                String storageName = query.getStorageName().orElse(null);
+                String logicalContainer = query.getLogicalContainer().orElse(null);
+                String objectKeyPrefix = query.getObjectKeyPrefix().orElse(null);
+                statement.setString(1, tenantId);
+                statement.setString(2, storageName);
+                statement.setString(3, storageName);
+                statement.setString(4, logicalContainer);
+                statement.setString(5, logicalContainer);
+                statement.setString(6, objectKeyPrefix);
+                statement.setString(7, objectKeyPrefix == null ? null : objectKeyPrefix + "%");
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    List<StorageObjectMetadataRecord> results = new ArrayList<>();
+                    while (resultSet.next()) {
+                        String id = resultSet.getString("id");
+                        results.add(new StorageObjectMetadataRecord(readMetadata(resultSet), findAttributes(connection, id)));
+                    }
+                    return List.copyOf(results);
+                }
+            }
+        });
+    }
+
+    @Override
+    public void deleteByTenantAndObjectHash(@NonNull String tenantId,
+                                            @NonNull StorageDescriptor storageDescriptor,
+                                            @NonNull String objectKeyHash) {
+        Objects.requireNonNull(tenantId, "tenantId");
+        Objects.requireNonNull(storageDescriptor, "storageDescriptor");
+        Objects.requireNonNull(objectKeyHash, "objectKeyHash");
+        withTransaction(connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(DELETE_BY_SCOPE_SQL)) {
+                statement.setString(1, tenantId);
+                statement.setString(2, storageDescriptor.getStorageName());
+                statement.setString(3, storageDescriptor.getLogicalContainer());
+                statement.setString(4, objectKeyHash);
+                statement.executeUpdate();
+            }
+        });
+    }
+
+    private static Optional<String> resolveObjectId(java.sql.Connection connection,
+                                                    StorageObjectMetadata metadata) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(SELECT_ID_SQL)) {
+            statement.setString(1, metadata.getTenantId());
+            statement.setString(2, metadata.getStorageName());
+            statement.setString(3, metadata.getLogicalContainer());
+            statement.setString(4, metadata.getObjectKeyHash());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next() ? Optional.of(resultSet.getString(1)) : Optional.empty();
+            }
+        }
+    }
+
+    private static boolean exists(java.sql.Connection connection, String id) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement("SELECT id FROM storage_object_metadata WHERE id = ?")) {
+            statement.setString(1, id);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        }
+    }
+
+    private static void updateObject(java.sql.Connection connection,
+                                     String id,
+                                     StorageObjectMetadata metadata,
+                                     Instant now) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(UPDATE_SQL)) {
+            StorageDescriptor descriptor = metadata.getStorageDescriptor();
+            statement.setString(1, descriptor.getProviderId());
+            statement.setString(2, descriptor.getProviderNamespace().orElse(null));
+            statement.setString(3, descriptor.getProviderContainer());
+            statement.setString(4, metadata.getObjectKey());
+            statement.setString(5, metadata.getContentType().orElse(null));
+            if (metadata.getContentLength().isPresent()) {
+                statement.setLong(6, metadata.getContentLength().getAsLong());
+            } else {
+                statement.setObject(6, null);
+            }
+            statement.setString(7, metadata.getEtag().orElse(null));
+            statement.setString(8, metadata.getProviderVersionId().orElse(null));
+            statement.setString(9, metadata.getChecksum().orElse(null));
+            statement.setString(10, metadata.getReconciliationStatus().name());
+            statement.setString(11, metadata.getLastErrorSummary().orElse(null));
+            statement.setTimestamp(12, timestampOf(now));
+            statement.setString(13, id);
+            statement.executeUpdate();
+        }
+    }
+
+    private static void insertObject(java.sql.Connection connection,
+                                     String id,
+                                     StorageObjectMetadata metadata,
+                                     Instant now) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(INSERT_SQL)) {
+            StorageDescriptor descriptor = metadata.getStorageDescriptor();
+            statement.setString(1, id);
+            statement.setString(2, metadata.getTenantId());
+            statement.setString(3, descriptor.getStorageName());
+            statement.setString(4, descriptor.getProviderId());
+            statement.setString(5, descriptor.getLogicalContainer());
+            statement.setString(6, descriptor.getProviderNamespace().orElse(null));
+            statement.setString(7, descriptor.getProviderContainer());
+            statement.setString(8, metadata.getObjectKey());
+            statement.setString(9, metadata.getObjectKeyHash());
+            statement.setString(10, metadata.getContentType().orElse(null));
+            if (metadata.getContentLength().isPresent()) {
+                statement.setLong(11, metadata.getContentLength().getAsLong());
+            } else {
+                statement.setObject(11, null);
+            }
+            statement.setString(12, metadata.getEtag().orElse(null));
+            statement.setString(13, metadata.getProviderVersionId().orElse(null));
+            statement.setString(14, metadata.getChecksum().orElse(null));
+            statement.setString(15, metadata.getReconciliationStatus().name());
+            statement.setString(16, metadata.getLastErrorSummary().orElse(null));
+            statement.setTimestamp(17, timestampOf(now));
+            statement.setTimestamp(18, timestampOf(now));
+            statement.executeUpdate();
+        }
+    }
+
+    private static void replaceAttributes(java.sql.Connection connection,
+                                          String id,
+                                          Map<String, String> attributes) throws SQLException {
+        try (PreparedStatement deleteStatement = connection.prepareStatement(DELETE_ATTRS_SQL)) {
+            deleteStatement.setString(1, id);
+            deleteStatement.executeUpdate();
+        }
+        if (attributes.isEmpty()) {
+            return;
+        }
+        try (PreparedStatement insertStatement = connection.prepareStatement(INSERT_ATTR_SQL)) {
+            for (Map.Entry<String, String> entry : attributes.entrySet()) {
+                insertStatement.setString(1, id);
+                insertStatement.setString(2, entry.getKey());
+                insertStatement.setString(3, entry.getValue());
+                insertStatement.addBatch();
+            }
+            insertStatement.executeBatch();
+        }
+    }
+
+    private static StorageObjectMetadata readMetadata(ResultSet resultSet) throws SQLException {
+        StorageDescriptor descriptor = new StorageDescriptor(
+            resultSet.getString("storage_name"),
+            resultSet.getString("provider_id"),
+            resultSet.getString("logical_container"),
+            resultSet.getString("provider_namespace"),
+            resultSet.getString("provider_container")
+        );
+        ObjectMetadataSyncStatus syncStatus = new ObjectMetadataSyncStatus(
+            ObjectMetadataReconciliationState.valueOf(resultSet.getString("reconciliation_state")),
+            resultSet.getString("last_error_summary")
+        );
+        Long contentLength = resultSet.getLong("content_length");
+        if (resultSet.wasNull()) {
+            contentLength = null;
+        }
+        return new StorageObjectMetadata(
+            resultSet.getString("tenant_id"),
+            descriptor,
+            resultSet.getString("object_key"),
+            resultSet.getString("object_key_hash"),
+            resultSet.getString("content_type"),
+            contentLength,
+            resultSet.getString("etag"),
+            resultSet.getString("provider_version_id"),
+            resultSet.getString("checksum"),
+            instantOf(resultSet.getTimestamp("created_at")),
+            instantOf(resultSet.getTimestamp("updated_at")),
+            syncStatus
+        );
+    }
+
+    private static Map<String, String> findAttributes(java.sql.Connection connection, String id) throws SQLException {
+        Map<String, String> attributes = new LinkedHashMap<>();
+        try (PreparedStatement statement = connection.prepareStatement(FIND_ATTRS_SQL)) {
+            statement.setString(1, id);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    attributes.put(resultSet.getString("attr_key"), resultSet.getString("attr_value"));
+                }
+            }
+        }
+        return attributes;
+    }
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/MetadataJdbcException.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/MetadataJdbcException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc.repository;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Runtime wrapper for JDBC access failures in metadata repositories.
+ */
+@Internal
+public final class MetadataJdbcException extends RuntimeException {
+
+    public MetadataJdbcException(@NonNull String message, @NonNull Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/StorageContainerMetadataRecord.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/StorageContainerMetadataRecord.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc.repository;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.metadata.StorageContainerMetadata;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Container metadata row plus resolved attribute map.
+ *
+ * @param metadata Persisted container metadata values
+ * @param attributes Persisted container metadata attributes
+ */
+@Internal
+public record StorageContainerMetadataRecord(
+    @NonNull StorageContainerMetadata metadata,
+    @NonNull Map<String, String> attributes
+) {
+    public StorageContainerMetadataRecord {
+        Objects.requireNonNull(metadata, "metadata");
+        attributes = Map.copyOf(Objects.requireNonNull(attributes, "attributes"));
+    }
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/StorageContainerMetadataRepository.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/StorageContainerMetadataRepository.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc.repository;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.metadata.StorageContainerMetadata;
+import io.micronaut.objectstorage.metadata.StorageDescriptor;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Repository contract for persisted container metadata rows.
+ */
+@Internal
+public interface StorageContainerMetadataRepository {
+
+    void upsert(@NonNull StorageContainerMetadata metadata, @NonNull Map<String, String> attributes);
+
+    @NonNull
+    Optional<StorageContainerMetadataRecord> findByTenantAndDescriptor(@NonNull String tenantId,
+                                                                        @NonNull StorageDescriptor storageDescriptor);
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/StorageMetadataOutboxRecord.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/StorageMetadataOutboxRecord.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc.repository;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.metadata.ObjectStorageOperationType;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable outbox entry persisted for asynchronous metadata reconciliation.
+ */
+@Internal
+public final class StorageMetadataOutboxRecord {
+
+    private final String id;
+    private final String tenantId;
+    private final String storageName;
+    private final String logicalContainer;
+    @Nullable
+    private final String objectKey;
+    @Nullable
+    private final String objectKeyHash;
+    @Nullable
+    private final String destinationObjectKey;
+    @Nullable
+    private final String destinationObjectKeyHash;
+    private final ObjectStorageOperationType operationType;
+    @Nullable
+    private final String reconciliationId;
+    private final int payloadVersion;
+    private final StorageMetadataOutboxStatus status;
+    private final int attemptCount;
+    private final Instant nextAttemptAt;
+    @Nullable
+    private final String lastErrorSummary;
+    private final String idempotencyKey;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+
+    private StorageMetadataOutboxRecord(@NonNull Builder builder) {
+        this.id = Objects.requireNonNull(builder.id, "id");
+        this.tenantId = Objects.requireNonNull(builder.tenantId, "tenantId");
+        this.storageName = Objects.requireNonNull(builder.storageName, "storageName");
+        this.logicalContainer = Objects.requireNonNull(builder.logicalContainer, "logicalContainer");
+        this.objectKey = builder.objectKey;
+        this.objectKeyHash = builder.objectKeyHash;
+        this.destinationObjectKey = builder.destinationObjectKey;
+        this.destinationObjectKeyHash = builder.destinationObjectKeyHash;
+        this.operationType = Objects.requireNonNull(builder.operationType, "operationType");
+        this.reconciliationId = builder.reconciliationId;
+        this.payloadVersion = builder.payloadVersion;
+        this.status = Objects.requireNonNull(builder.status, "status");
+        this.attemptCount = builder.attemptCount;
+        this.nextAttemptAt = Objects.requireNonNull(builder.nextAttemptAt, "nextAttemptAt");
+        this.lastErrorSummary = builder.lastErrorSummary;
+        this.idempotencyKey = Objects.requireNonNull(builder.idempotencyKey, "idempotencyKey");
+        this.createdAt = Objects.requireNonNull(builder.createdAt, "createdAt");
+        this.updatedAt = Objects.requireNonNull(builder.updatedAt, "updatedAt");
+    }
+
+    @NonNull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    @Deprecated(forRemoval = true)
+    public StorageMetadataOutboxRecord(@NonNull String id,
+                                       @NonNull String tenantId,
+                                       @NonNull String storageName,
+                                       @NonNull String logicalContainer,
+                                       @Nullable String objectKey,
+                                       @Nullable String objectKeyHash,
+                                       @Nullable String destinationObjectKey,
+                                       @Nullable String destinationObjectKeyHash,
+                                       @NonNull ObjectStorageOperationType operationType,
+                                       @Nullable String reconciliationId,
+                                       int payloadVersion,
+                                       @NonNull StorageMetadataOutboxStatus status,
+                                       int attemptCount,
+                                       @NonNull Instant nextAttemptAt,
+                                       @Nullable String lastErrorSummary,
+                                       @NonNull String idempotencyKey,
+                                       @NonNull Instant createdAt,
+                                       @NonNull Instant updatedAt) {
+        this(builder()
+            .id(id)
+            .tenantId(tenantId)
+            .storageName(storageName)
+            .logicalContainer(logicalContainer)
+            .objectKey(objectKey)
+            .objectKeyHash(objectKeyHash)
+            .destinationObjectKey(destinationObjectKey)
+            .destinationObjectKeyHash(destinationObjectKeyHash)
+            .operationType(operationType)
+            .reconciliationId(reconciliationId)
+            .payloadVersion(payloadVersion)
+            .status(status)
+            .attemptCount(attemptCount)
+            .nextAttemptAt(nextAttemptAt)
+            .lastErrorSummary(lastErrorSummary)
+            .idempotencyKey(idempotencyKey)
+            .createdAt(createdAt)
+            .updatedAt(updatedAt));
+    }
+
+    @NonNull
+    public String getId() {
+        return id;
+    }
+
+    @NonNull
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    @NonNull
+    public String getStorageName() {
+        return storageName;
+    }
+
+    @NonNull
+    public String getLogicalContainer() {
+        return logicalContainer;
+    }
+
+    @NonNull
+    public Optional<String> getObjectKey() {
+        return Optional.ofNullable(objectKey);
+    }
+
+    @NonNull
+    public Optional<String> getObjectKeyHash() {
+        return Optional.ofNullable(objectKeyHash);
+    }
+
+    @NonNull
+    public Optional<String> getDestinationObjectKey() {
+        return Optional.ofNullable(destinationObjectKey);
+    }
+
+    @NonNull
+    public Optional<String> getDestinationObjectKeyHash() {
+        return Optional.ofNullable(destinationObjectKeyHash);
+    }
+
+    @NonNull
+    public ObjectStorageOperationType getOperationType() {
+        return operationType;
+    }
+
+    @NonNull
+    public Optional<String> getReconciliationId() {
+        return Optional.ofNullable(reconciliationId);
+    }
+
+    public int getPayloadVersion() {
+        return payloadVersion;
+    }
+
+    @NonNull
+    public StorageMetadataOutboxStatus getStatus() {
+        return status;
+    }
+
+    public int getAttemptCount() {
+        return attemptCount;
+    }
+
+    @NonNull
+    public Instant getNextAttemptAt() {
+        return nextAttemptAt;
+    }
+
+    @NonNull
+    public Optional<String> getLastErrorSummary() {
+        return Optional.ofNullable(lastErrorSummary);
+    }
+
+    @NonNull
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    @NonNull
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    @NonNull
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    /**
+     * Mutable builder used to create immutable outbox records.
+     */
+    public static final class Builder {
+        private String id;
+        private String tenantId;
+        private String storageName;
+        private String logicalContainer;
+        @Nullable
+        private String objectKey;
+        @Nullable
+        private String objectKeyHash;
+        @Nullable
+        private String destinationObjectKey;
+        @Nullable
+        private String destinationObjectKeyHash;
+        private ObjectStorageOperationType operationType;
+        @Nullable
+        private String reconciliationId;
+        private int payloadVersion;
+        private StorageMetadataOutboxStatus status;
+        private int attemptCount;
+        private Instant nextAttemptAt;
+        @Nullable
+        private String lastErrorSummary;
+        private String idempotencyKey;
+        private Instant createdAt;
+        private Instant updatedAt;
+
+        private Builder() {
+        }
+
+        @NonNull
+        public Builder id(@NonNull String id) {
+            this.id = id;
+            return this;
+        }
+
+        @NonNull
+        public Builder tenantId(@NonNull String tenantId) {
+            this.tenantId = tenantId;
+            return this;
+        }
+
+        @NonNull
+        public Builder storageName(@NonNull String storageName) {
+            this.storageName = storageName;
+            return this;
+        }
+
+        @NonNull
+        public Builder logicalContainer(@NonNull String logicalContainer) {
+            this.logicalContainer = logicalContainer;
+            return this;
+        }
+
+        @NonNull
+        public Builder objectKey(@Nullable String objectKey) {
+            this.objectKey = objectKey;
+            return this;
+        }
+
+        @NonNull
+        public Builder objectKeyHash(@Nullable String objectKeyHash) {
+            this.objectKeyHash = objectKeyHash;
+            return this;
+        }
+
+        @NonNull
+        public Builder destinationObjectKey(@Nullable String destinationObjectKey) {
+            this.destinationObjectKey = destinationObjectKey;
+            return this;
+        }
+
+        @NonNull
+        public Builder destinationObjectKeyHash(@Nullable String destinationObjectKeyHash) {
+            this.destinationObjectKeyHash = destinationObjectKeyHash;
+            return this;
+        }
+
+        @NonNull
+        public Builder operationType(@NonNull ObjectStorageOperationType operationType) {
+            this.operationType = operationType;
+            return this;
+        }
+
+        @NonNull
+        public Builder reconciliationId(@Nullable String reconciliationId) {
+            this.reconciliationId = reconciliationId;
+            return this;
+        }
+
+        @NonNull
+        public Builder payloadVersion(int payloadVersion) {
+            this.payloadVersion = payloadVersion;
+            return this;
+        }
+
+        @NonNull
+        public Builder status(@NonNull StorageMetadataOutboxStatus status) {
+            this.status = status;
+            return this;
+        }
+
+        @NonNull
+        public Builder attemptCount(int attemptCount) {
+            this.attemptCount = attemptCount;
+            return this;
+        }
+
+        @NonNull
+        public Builder nextAttemptAt(@NonNull Instant nextAttemptAt) {
+            this.nextAttemptAt = nextAttemptAt;
+            return this;
+        }
+
+        @NonNull
+        public Builder lastErrorSummary(@Nullable String lastErrorSummary) {
+            this.lastErrorSummary = lastErrorSummary;
+            return this;
+        }
+
+        @NonNull
+        public Builder idempotencyKey(@NonNull String idempotencyKey) {
+            this.idempotencyKey = idempotencyKey;
+            return this;
+        }
+
+        @NonNull
+        public Builder createdAt(@NonNull Instant createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        @NonNull
+        public Builder updatedAt(@NonNull Instant updatedAt) {
+            this.updatedAt = updatedAt;
+            return this;
+        }
+
+        @NonNull
+        public StorageMetadataOutboxRecord build() {
+            return new StorageMetadataOutboxRecord(this);
+        }
+    }
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/StorageMetadataOutboxRepository.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/StorageMetadataOutboxRepository.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc.repository;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.NonNull;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Repository contract for durable outbox entries used by reconciliation.
+ */
+@Internal
+public interface StorageMetadataOutboxRepository {
+
+    void enqueue(@NonNull StorageMetadataOutboxRecord outboxRecord);
+
+    boolean enqueueIfAbsent(@NonNull StorageMetadataOutboxRecord outboxRecord);
+
+    @NonNull
+    List<StorageMetadataOutboxRecord> findDueEntries(@NonNull Instant asOf, int limit);
+
+    boolean markProcessing(@NonNull String id,
+                           @NonNull Instant asOf,
+                           @NonNull Instant updatedAt);
+
+    void markSucceeded(@NonNull String id,
+                       @NonNull Instant updatedAt);
+
+    void markRetryOrDeadLetter(@NonNull String id,
+                               int attemptCount,
+                               @NonNull Instant nextAttemptAt,
+                               @NonNull StorageMetadataOutboxStatus status,
+                               @NonNull String lastErrorSummary,
+                               @NonNull Instant updatedAt);
+
+    @NonNull
+    Optional<StorageMetadataOutboxRecord> findById(@NonNull String id);
+
+    @NonNull
+    Optional<StorageMetadataOutboxRecord> findByIdempotencyKey(@NonNull String idempotencyKey);
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/StorageMetadataOutboxStatus.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/StorageMetadataOutboxStatus.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc.repository;
+
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Lifecycle states for metadata outbox entries.
+ */
+@Internal
+public enum StorageMetadataOutboxStatus {
+    PENDING,
+    PROCESSING,
+    SUCCEEDED,
+    FAILED,
+    DEAD_LETTER
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/StorageObjectMetadataRecord.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/StorageObjectMetadataRecord.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc.repository;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Object metadata row plus resolved attribute map.
+ *
+ * @param metadata Persisted object metadata values
+ * @param attributes Persisted object metadata attributes
+ */
+@Internal
+public record StorageObjectMetadataRecord(
+    @NonNull StorageObjectMetadata metadata,
+    @NonNull Map<String, String> attributes
+) {
+    public StorageObjectMetadataRecord {
+        Objects.requireNonNull(metadata, "metadata");
+        attributes = Map.copyOf(Objects.requireNonNull(attributes, "attributes"));
+    }
+}

--- a/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/StorageObjectMetadataRepository.java
+++ b/object-storage-metadata-jdbc/src/main/java/io/micronaut/objectstorage/metadata/jdbc/repository/StorageObjectMetadataRepository.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc.repository;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.metadata.StorageDescriptor;
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata;
+import io.micronaut.objectstorage.metadata.StorageObjectMetadataQuery;
+import org.jspecify.annotations.NonNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Repository contract for persisted object metadata rows.
+ */
+@Internal
+public interface StorageObjectMetadataRepository {
+
+    void upsert(@NonNull StorageObjectMetadata metadata, @NonNull Map<String, String> attributes);
+
+    @NonNull
+    Optional<StorageObjectMetadataRecord> findByTenantAndObjectHash(@NonNull String tenantId,
+                                                                     @NonNull StorageDescriptor storageDescriptor,
+                                                                     @NonNull String objectKeyHash);
+
+    @NonNull
+    List<StorageObjectMetadataRecord> listByTenantAndQuery(@NonNull String tenantId,
+                                                            @NonNull StorageObjectMetadataQuery query);
+
+    void deleteByTenantAndObjectHash(@NonNull String tenantId,
+                                     @NonNull StorageDescriptor storageDescriptor,
+                                     @NonNull String objectKeyHash);
+}

--- a/object-storage-metadata-jdbc/src/main/resources/db/metadata/oracle/schema-v1.sql
+++ b/object-storage-metadata-jdbc/src/main/resources/db/metadata/oracle/schema-v1.sql
@@ -1,0 +1,78 @@
+CREATE TABLE storage_container_metadata (
+    id VARCHAR2(64) NOT NULL,
+    tenant_id VARCHAR2(255) NOT NULL,
+    storage_name VARCHAR2(255) NOT NULL,
+    provider_id VARCHAR2(255) NOT NULL,
+    logical_container VARCHAR2(255) NOT NULL,
+    provider_namespace VARCHAR2(255),
+    provider_container VARCHAR2(1024) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    CONSTRAINT pk_storage_container_metadata PRIMARY KEY (id),
+    CONSTRAINT uk_storage_container_metadata_scope UNIQUE (tenant_id, storage_name, logical_container)
+);
+
+CREATE TABLE storage_container_metadata_attr (
+    container_metadata_id VARCHAR2(64) NOT NULL,
+    attr_key VARCHAR2(255) NOT NULL,
+    attr_value VARCHAR2(4000) NOT NULL,
+    CONSTRAINT pk_storage_container_metadata_attr PRIMARY KEY (container_metadata_id, attr_key),
+    CONSTRAINT fk_storage_container_metadata_attr_parent FOREIGN KEY (container_metadata_id)
+        REFERENCES storage_container_metadata (id) ON DELETE CASCADE
+);
+
+CREATE TABLE storage_object_metadata (
+    id VARCHAR2(64) NOT NULL,
+    tenant_id VARCHAR2(255) NOT NULL,
+    storage_name VARCHAR2(255) NOT NULL,
+    provider_id VARCHAR2(255) NOT NULL,
+    logical_container VARCHAR2(255) NOT NULL,
+    provider_namespace VARCHAR2(255),
+    provider_container VARCHAR2(1024) NOT NULL,
+    object_key VARCHAR2(1024) NOT NULL,
+    object_key_hash VARCHAR2(64) NOT NULL,
+    content_type VARCHAR2(255),
+    content_length NUMBER(19),
+    etag VARCHAR2(512),
+    provider_version_id VARCHAR2(512),
+    checksum VARCHAR2(512),
+    reconciliation_state VARCHAR2(32) NOT NULL,
+    last_error_summary VARCHAR2(2000),
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    CONSTRAINT pk_storage_object_metadata PRIMARY KEY (id),
+    CONSTRAINT uk_storage_object_metadata_scope UNIQUE (tenant_id, storage_name, logical_container, object_key_hash)
+);
+
+CREATE TABLE storage_object_metadata_attr (
+    object_metadata_id VARCHAR2(64) NOT NULL,
+    attr_key VARCHAR2(255) NOT NULL,
+    attr_value VARCHAR2(4000) NOT NULL,
+    CONSTRAINT pk_storage_object_metadata_attr PRIMARY KEY (object_metadata_id, attr_key),
+    CONSTRAINT fk_storage_object_metadata_attr_parent FOREIGN KEY (object_metadata_id)
+        REFERENCES storage_object_metadata (id) ON DELETE CASCADE
+);
+
+CREATE TABLE storage_metadata_outbox (
+    id VARCHAR2(64) NOT NULL,
+    tenant_id VARCHAR2(255) NOT NULL,
+    storage_name VARCHAR2(255) NOT NULL,
+    logical_container VARCHAR2(255) NOT NULL,
+    object_key VARCHAR2(1024),
+    object_key_hash VARCHAR2(64),
+    destination_object_key VARCHAR2(1024),
+    destination_object_key_hash VARCHAR2(64),
+    operation_type VARCHAR2(32) NOT NULL,
+    reconciliation_id VARCHAR2(128),
+    payload_version NUMBER(10) NOT NULL,
+    status VARCHAR2(32) NOT NULL,
+    attempt_count NUMBER(10) NOT NULL,
+    next_attempt_at TIMESTAMP NOT NULL,
+    last_error_summary VARCHAR2(2000),
+    idempotency_key VARCHAR2(512) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    CONSTRAINT pk_storage_metadata_outbox PRIMARY KEY (id),
+    CONSTRAINT uk_storage_metadata_outbox_idempotency UNIQUE (idempotency_key)
+);
+

--- a/object-storage-metadata-jdbc/src/main/resources/db/metadata/postgresql/schema-v1.sql
+++ b/object-storage-metadata-jdbc/src/main/resources/db/metadata/postgresql/schema-v1.sql
@@ -1,0 +1,83 @@
+CREATE TABLE storage_container_metadata (
+    id VARCHAR(64) NOT NULL,
+    tenant_id VARCHAR(255) NOT NULL,
+    storage_name VARCHAR(255) NOT NULL,
+    provider_id VARCHAR(255) NOT NULL,
+    logical_container VARCHAR(255) NOT NULL,
+    provider_namespace VARCHAR(255),
+    provider_container VARCHAR(1024) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    CONSTRAINT pk_storage_container_metadata PRIMARY KEY (id),
+    CONSTRAINT uk_storage_container_metadata_scope UNIQUE (tenant_id, storage_name, logical_container)
+);
+
+CREATE TABLE storage_container_metadata_attr (
+    container_metadata_id VARCHAR(64) NOT NULL,
+    attr_key VARCHAR(255) NOT NULL,
+    attr_value VARCHAR(4000) NOT NULL,
+    CONSTRAINT pk_storage_container_metadata_attr PRIMARY KEY (container_metadata_id, attr_key),
+    CONSTRAINT fk_storage_container_metadata_attr_parent FOREIGN KEY (container_metadata_id)
+        REFERENCES storage_container_metadata (id) ON DELETE CASCADE
+);
+
+CREATE TABLE storage_object_metadata (
+    id VARCHAR(64) NOT NULL,
+    tenant_id VARCHAR(255) NOT NULL,
+    storage_name VARCHAR(255) NOT NULL,
+    provider_id VARCHAR(255) NOT NULL,
+    logical_container VARCHAR(255) NOT NULL,
+    provider_namespace VARCHAR(255),
+    provider_container VARCHAR(1024) NOT NULL,
+    object_key VARCHAR(1024) NOT NULL,
+    object_key_hash VARCHAR(64) NOT NULL,
+    content_type VARCHAR(255),
+    content_length BIGINT,
+    etag VARCHAR(512),
+    provider_version_id VARCHAR(512),
+    checksum VARCHAR(512),
+    reconciliation_state VARCHAR(32) NOT NULL,
+    last_error_summary VARCHAR(2000),
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    CONSTRAINT pk_storage_object_metadata PRIMARY KEY (id),
+    CONSTRAINT uk_storage_object_metadata_scope UNIQUE (tenant_id, storage_name, logical_container, object_key_hash)
+);
+
+CREATE TABLE storage_object_metadata_attr (
+    object_metadata_id VARCHAR(64) NOT NULL,
+    attr_key VARCHAR(255) NOT NULL,
+    attr_value VARCHAR(4000) NOT NULL,
+    CONSTRAINT pk_storage_object_metadata_attr PRIMARY KEY (object_metadata_id, attr_key),
+    CONSTRAINT fk_storage_object_metadata_attr_parent FOREIGN KEY (object_metadata_id)
+        REFERENCES storage_object_metadata (id) ON DELETE CASCADE
+);
+
+CREATE TABLE storage_metadata_outbox (
+    id VARCHAR(64) NOT NULL,
+    tenant_id VARCHAR(255) NOT NULL,
+    storage_name VARCHAR(255) NOT NULL,
+    logical_container VARCHAR(255) NOT NULL,
+    object_key VARCHAR(1024),
+    object_key_hash VARCHAR(64),
+    destination_object_key VARCHAR(1024),
+    destination_object_key_hash VARCHAR(64),
+    operation_type VARCHAR(32) NOT NULL,
+    reconciliation_id VARCHAR(128),
+    payload_version INT NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    attempt_count INT NOT NULL,
+    next_attempt_at TIMESTAMP NOT NULL,
+    last_error_summary VARCHAR(2000),
+    idempotency_key VARCHAR(512) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    CONSTRAINT pk_storage_metadata_outbox PRIMARY KEY (id),
+    CONSTRAINT uk_storage_metadata_outbox_idempotency UNIQUE (idempotency_key)
+);
+
+CREATE INDEX idx_scoped_container_metadata
+    ON storage_container_metadata (tenant_id, storage_name, logical_container);
+
+CREATE INDEX idx_scoped_object_metadata
+    ON storage_object_metadata (tenant_id, storage_name, logical_container, object_key_hash);

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataCopyWorkflowSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataCopyWorkflowSpec.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc
+
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.metadata.ObjectMetadataReconciliationState
+import io.micronaut.objectstorage.metadata.ObjectMetadataSyncStatus
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageDescriptorResolver
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata
+import io.micronaut.objectstorage.metadata.StorageObjectMetadataQuery
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxStatus
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository
+import spock.lang.Specification
+
+import java.time.Instant
+
+class MetadataCopyWorkflowSpec extends Specification {
+
+    void 'copy delegates first then reconciliation creates destination metadata from source metadata'() {
+        given:
+        def descriptor = new StorageDescriptor('photos', 'oracle-cloud', 'logical-photos', 'ns1', 'bucket-a')
+        def objectRepository = new InMemoryObjectMetadataRepository()
+        def descriptorResolver = new OutboxStorageDescriptorResolver([({ -> descriptor } as StorageDescriptorResolver)])
+        def reconciler = new DefaultMetadataOutboxReconciler(objectRepository, descriptorResolver)
+        def sourceMetadata = new StorageObjectMetadata(
+            'tenant-a',
+            descriptor,
+            'source.txt',
+            StorageObjectMetadata.deterministicObjectKeyHash('source.txt'),
+            'text/plain',
+            42L,
+            'etag-1',
+            'version-1',
+            'sha256:abc',
+            Instant.parse('2026-03-17T12:00:00Z'),
+            Instant.parse('2026-03-17T12:00:00Z'),
+            new ObjectMetadataSyncStatus(ObjectMetadataReconciliationState.SUCCEEDED, null)
+        )
+        objectRepository.upsert(sourceMetadata, [owner: 'micronaut', env: 'test'])
+        def outboxRecord = new StorageMetadataOutboxRecord(
+            'copy-1',
+            'tenant-a',
+            'photos',
+            'logical-photos',
+            'source.txt',
+            StorageObjectMetadata.deterministicObjectKeyHash('source.txt'),
+            'dest.txt',
+            StorageObjectMetadata.deterministicObjectKeyHash('dest.txt'),
+            io.micronaut.objectstorage.metadata.ObjectStorageOperationType.COPY,
+            'recon-copy-1',
+            1,
+            StorageMetadataOutboxStatus.PENDING,
+            0,
+            Instant.parse('2026-03-17T12:00:01Z'),
+            null,
+            'tenant-a|photos|COPY|' + StorageObjectMetadata.deterministicObjectKeyHash('source.txt') + '|' + StorageObjectMetadata.deterministicObjectKeyHash('dest.txt'),
+            Instant.parse('2026-03-17T12:00:01Z'),
+            Instant.parse('2026-03-17T12:00:01Z')
+        )
+
+        when:
+        reconciler.reconcile(outboxRecord)
+
+        then:
+        def copied = objectRepository.findByTenantAndObjectHash('tenant-a', descriptor, StorageObjectMetadata.deterministicObjectKeyHash('dest.txt')).orElseThrow()
+        copied.metadata().objectKey == 'dest.txt'
+        copied.metadata().objectKeyHash == StorageObjectMetadata.deterministicObjectKeyHash('dest.txt')
+        copied.metadata().contentType.get() == 'text/plain'
+        copied.metadata().contentLength.getAsLong() == 42L
+        copied.metadata().etag.get() == 'etag-1'
+        copied.metadata().providerVersionId.get() == 'version-1'
+        copied.metadata().checksum.get() == 'sha256:abc'
+        copied.attributes() == [env: 'test', owner: 'micronaut']
+        objectRepository.findByTenantAndObjectHash('tenant-a', descriptor, StorageObjectMetadata.deterministicObjectKeyHash('source.txt')).orElseThrow().metadata().objectKey == 'source.txt'
+    }
+
+    private static final class InMemoryObjectMetadataRepository implements StorageObjectMetadataRepository {
+        private final Map<String, StorageObjectMetadataRecord> rows = [:]
+
+        @Override
+        void upsert(StorageObjectMetadata metadata, Map<String, String> attributes) {
+            rows[metadata.objectKeyHash] = new StorageObjectMetadataRecord(metadata, attributes)
+        }
+
+        @Override
+        Optional<StorageObjectMetadataRecord> findByTenantAndObjectHash(String tenantId, StorageDescriptor storageDescriptor, String objectKeyHash) {
+            Optional.ofNullable(rows[objectKeyHash])
+        }
+
+        @Override
+        List<StorageObjectMetadataRecord> listByTenantAndQuery(String tenantId, StorageObjectMetadataQuery query) {
+            []
+        }
+
+        @Override
+        void deleteByTenantAndObjectHash(String tenantId, StorageDescriptor storageDescriptor, String objectKeyHash) {
+            rows.remove(objectKeyHash)
+        }
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataDeadLetterSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataDeadLetterSpec.groovy
@@ -1,0 +1,159 @@
+package io.micronaut.objectstorage.metadata.jdbc
+
+import io.micronaut.objectstorage.metadata.ObjectStorageLifecycleHook
+import io.micronaut.objectstorage.metadata.ObjectStorageOperationContext
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxStatus
+import spock.lang.Specification
+
+import java.time.Duration
+import java.time.Instant
+
+class MetadataDeadLetterSpec extends Specification {
+
+    void 'failed reconciliation retries with backoff and transitions to dead letter with error hook context'() {
+        given:
+        def outboxRepository = new InMemoryOutboxRepository()
+        def descriptor = new StorageDescriptor('pictures', 'oracle', 'reports', 'ns-a', 'bucket-a')
+        def descriptorResolver = new OutboxStorageDescriptorResolver([({ -> descriptor } as io.micronaut.objectstorage.metadata.StorageDescriptorResolver)])
+        def hook = new RecordingErrorHook()
+        def worker = new MetadataOutboxReconciliationWorker(
+            outboxRepository,
+            ({ StorageMetadataOutboxRecord ignored -> throw new IllegalStateException('boom') } as MetadataOutboxReconciler),
+            descriptorResolver,
+            [hook],
+            new ObjectStorageMetadataJdbcConfiguration()
+        )
+        def now = Instant.parse('2026-03-17T12:00:00Z')
+
+        and:
+        outboxRepository.enqueue(new StorageMetadataOutboxRecord(
+            'outbox-1',
+            'tenant-a',
+            'pictures',
+            'reports',
+            '/2026/03/invoice-001.pdf',
+            StorageObjectMetadata.deterministicObjectKeyHash('/2026/03/invoice-001.pdf'),
+            null,
+            null,
+            io.micronaut.objectstorage.metadata.ObjectStorageOperationType.UPLOAD,
+            'recon-1',
+            1,
+            StorageMetadataOutboxStatus.PENDING,
+            0,
+            now.minusSeconds(1),
+            null,
+            'tenant-a|pictures|reports|/2026/03/invoice-001.pdf|UPLOAD',
+            now,
+            now
+        ))
+
+        when:
+        5.times {
+            worker.reconcileDueEntries()
+            outboxRepository.forceDue('outbox-1')
+        }
+        def outbox = outboxRepository.findById('outbox-1').orElseThrow()
+
+        then:
+        outbox.status == StorageMetadataOutboxStatus.DEAD_LETTER
+        outbox.attemptCount == 5
+        outbox.lastErrorSummary.orElse('').contains('boom')
+        hook.contexts.size() == 5
+        hook.contexts.last().tenantId == 'tenant-a'
+        hook.contexts.last().objectKey == '/2026/03/invoice-001.pdf'
+
+        and:
+        MetadataOutboxRetryPolicy.delayForAttempt(1) == Duration.ofMillis(250)
+        MetadataOutboxRetryPolicy.delayForAttempt(2) == Duration.ofSeconds(1)
+        MetadataOutboxRetryPolicy.delayForAttempt(3) == Duration.ofSeconds(5)
+        MetadataOutboxRetryPolicy.delayForAttempt(4) == Duration.ofSeconds(15)
+        MetadataOutboxRetryPolicy.delayForAttempt(5) == Duration.ofSeconds(30)
+        MetadataOutboxRetryPolicy.delayForAttempt(10) == Duration.ofSeconds(30)
+    }
+
+    private static final class RecordingErrorHook implements ObjectStorageLifecycleHook {
+        final List<ObjectStorageOperationContext> contexts = []
+
+        @Override
+        void error(ObjectStorageOperationContext context, Throwable throwable) {
+            contexts << context
+        }
+    }
+
+    private static final class InMemoryOutboxRepository implements StorageMetadataOutboxRepository {
+        private final Map<String, StorageMetadataOutboxRecord> rows = [:]
+        private final Map<String, String> idByIdempotency = [:]
+
+        @Override
+        void enqueue(StorageMetadataOutboxRecord outboxRecord) {
+            enqueueIfAbsent(outboxRecord)
+        }
+
+        @Override
+        boolean enqueueIfAbsent(StorageMetadataOutboxRecord outboxRecord) {
+            if (idByIdempotency.containsKey(outboxRecord.idempotencyKey)) {
+                return false
+            }
+            idByIdempotency[outboxRecord.idempotencyKey] = outboxRecord.id
+            rows[outboxRecord.id] = outboxRecord
+            true
+        }
+
+        @Override
+        List<StorageMetadataOutboxRecord> findDueEntries(Instant asOf, int limit) {
+            rows.values().findAll {
+                it.nextAttemptAt <= asOf && it.status in [StorageMetadataOutboxStatus.PENDING, StorageMetadataOutboxStatus.FAILED, StorageMetadataOutboxStatus.PROCESSING]
+            }.take(limit)
+        }
+
+        @Override
+        boolean markProcessing(String id, Instant asOf, Instant updatedAt) {
+            def record = rows[id]
+            if (record == null || record.nextAttemptAt > asOf || !(record.status in [StorageMetadataOutboxStatus.PENDING, StorageMetadataOutboxStatus.FAILED, StorageMetadataOutboxStatus.PROCESSING])) {
+                return false
+            }
+            rows[id] = withStatus(record, StorageMetadataOutboxStatus.PROCESSING, record.attemptCount, record.nextAttemptAt, record.lastErrorSummary.orElse(null), updatedAt)
+            true
+        }
+
+        @Override
+        void markSucceeded(String id, Instant updatedAt) {
+            def record = rows[id]
+            rows[id] = withStatus(record, StorageMetadataOutboxStatus.SUCCEEDED, record.attemptCount, record.nextAttemptAt, null, updatedAt)
+        }
+
+        @Override
+        void markRetryOrDeadLetter(String id, int attemptCount, Instant nextAttemptAt, StorageMetadataOutboxStatus status, String lastErrorSummary, Instant updatedAt) {
+            def record = rows[id]
+            rows[id] = withStatus(record, status, attemptCount, nextAttemptAt, lastErrorSummary, updatedAt)
+        }
+
+        @Override
+        Optional<StorageMetadataOutboxRecord> findById(String id) {
+            Optional.ofNullable(rows[id])
+        }
+
+        @Override
+        Optional<StorageMetadataOutboxRecord> findByIdempotencyKey(String idempotencyKey) {
+            Optional.ofNullable(idByIdempotency[idempotencyKey]).flatMap { findById(it) }
+        }
+
+        void forceDue(String id) {
+            def record = rows[id]
+            rows[id] = withStatus(record, record.status, record.attemptCount, Instant.now().minusMillis(1), record.lastErrorSummary.orElse(null), record.updatedAt)
+        }
+
+        private static StorageMetadataOutboxRecord withStatus(StorageMetadataOutboxRecord record,
+                                                              StorageMetadataOutboxStatus status,
+                                                              int attemptCount,
+                                                              Instant nextAttemptAt,
+                                                              String lastErrorSummary,
+                                                              Instant updatedAt) {
+            new StorageMetadataOutboxRecord(record.id, record.tenantId, record.storageName, record.logicalContainer, record.objectKey.orElse(null), record.objectKeyHash.orElse(null), record.destinationObjectKey.orElse(null), record.destinationObjectKeyHash.orElse(null), record.operationType, record.reconciliationId.orElse(null), record.payloadVersion, status, attemptCount, nextAttemptAt, lastErrorSummary, record.idempotencyKey, record.createdAt, updatedAt)
+        }
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataDeleteCopyIdempotencySpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataDeleteCopyIdempotencySpec.groovy
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc
+
+import io.micronaut.objectstorage.metadata.ObjectMetadataReconciliationState
+import io.micronaut.objectstorage.metadata.ObjectMetadataSyncStatus
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageDescriptorResolver
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata
+import io.micronaut.objectstorage.metadata.StorageObjectMetadataQuery
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxStatus
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository
+import spock.lang.Specification
+
+import java.time.Instant
+
+class MetadataDeleteCopyIdempotencySpec extends Specification {
+
+    void 'delete replay is safe and copy replay converges on one destination row'() {
+        given:
+        def descriptor = new StorageDescriptor('photos', 'oracle-cloud', 'logical-photos', 'ns1', 'bucket-a')
+        def repository = new CountingObjectMetadataRepository()
+        def resolver = new OutboxStorageDescriptorResolver([({ -> descriptor } as StorageDescriptorResolver)])
+        def reconciler = new DefaultMetadataOutboxReconciler(repository, resolver)
+        def sourceMetadata = new StorageObjectMetadata(
+            'tenant-a', descriptor, 'source.txt', StorageObjectMetadata.deterministicObjectKeyHash('source.txt'),
+            'text/plain', 11L, 'etag-src', 'version-src', 'sha256:src',
+            Instant.parse('2026-03-17T12:00:00Z'), Instant.parse('2026-03-17T12:00:00Z'),
+            new ObjectMetadataSyncStatus(ObjectMetadataReconciliationState.SUCCEEDED, null)
+        )
+        def destinationMetadata = new StorageObjectMetadata(
+            'tenant-a', descriptor, 'dest.txt', StorageObjectMetadata.deterministicObjectKeyHash('dest.txt'),
+            'text/plain', 11L, 'etag-old', 'version-old', 'sha256:old',
+            Instant.parse('2026-03-17T12:00:01Z'), Instant.parse('2026-03-17T12:00:01Z'),
+            new ObjectMetadataSyncStatus(ObjectMetadataReconciliationState.SUCCEEDED, null)
+        )
+        repository.upsert(sourceMetadata, [owner: 'micronaut'])
+        repository.seed(destinationMetadata, [owner: 'stale'])
+        def copyRecord = new StorageMetadataOutboxRecord(
+            'copy-1', 'tenant-a', 'photos', 'logical-photos',
+            'source.txt', StorageObjectMetadata.deterministicObjectKeyHash('source.txt'),
+            'dest.txt', StorageObjectMetadata.deterministicObjectKeyHash('dest.txt'),
+            io.micronaut.objectstorage.metadata.ObjectStorageOperationType.COPY,
+            'recon-copy', 1, StorageMetadataOutboxStatus.PENDING, 0,
+            Instant.parse('2026-03-17T12:00:02Z'), null,
+            'tenant-a|photos|COPY|' + StorageObjectMetadata.deterministicObjectKeyHash('source.txt') + '|' + StorageObjectMetadata.deterministicObjectKeyHash('dest.txt'),
+            Instant.parse('2026-03-17T12:00:02Z'), Instant.parse('2026-03-17T12:00:02Z')
+        )
+        def deleteRecord = new StorageMetadataOutboxRecord(
+            'delete-1', 'tenant-a', 'photos', 'logical-photos',
+            'dest.txt', StorageObjectMetadata.deterministicObjectKeyHash('dest.txt'),
+            null, null,
+            io.micronaut.objectstorage.metadata.ObjectStorageOperationType.DELETE,
+            'recon-delete', 1, StorageMetadataOutboxStatus.PENDING, 0,
+            Instant.parse('2026-03-17T12:00:03Z'), null,
+            'tenant-a|photos|DELETE|' + StorageObjectMetadata.deterministicObjectKeyHash('dest.txt') + '|-',
+            Instant.parse('2026-03-17T12:00:03Z'), Instant.parse('2026-03-17T12:00:03Z')
+        )
+
+        when:
+        reconciler.reconcile(copyRecord)
+        reconciler.reconcile(copyRecord)
+        reconciler.reconcile(deleteRecord)
+        reconciler.reconcile(deleteRecord)
+
+        then:
+        repository.upsertByHash[StorageObjectMetadata.deterministicObjectKeyHash('dest.txt')] == 2
+        repository.deleteByHash[StorageObjectMetadata.deterministicObjectKeyHash('dest.txt')] == 2
+        !repository.findByTenantAndObjectHash('tenant-a', descriptor, StorageObjectMetadata.deterministicObjectKeyHash('dest.txt')).present
+        repository.findByTenantAndObjectHash('tenant-a', descriptor, StorageObjectMetadata.deterministicObjectKeyHash('source.txt')).orElseThrow().attributes() == [owner: 'micronaut']
+    }
+
+    private static final class CountingObjectMetadataRepository implements StorageObjectMetadataRepository {
+        private final Map<String, StorageObjectMetadataRecord> rows = [:]
+        final Map<String, Integer> upsertByHash = [:].withDefault { 0 }
+        final Map<String, Integer> deleteByHash = [:].withDefault { 0 }
+
+        void seed(StorageObjectMetadata metadata, Map<String, String> attributes) {
+            rows[metadata.objectKeyHash] = new StorageObjectMetadataRecord(metadata, attributes)
+        }
+
+        @Override
+        void upsert(StorageObjectMetadata metadata, Map<String, String> attributes) {
+            upsertByHash[metadata.objectKeyHash] = upsertByHash[metadata.objectKeyHash] + 1
+            rows[metadata.objectKeyHash] = new StorageObjectMetadataRecord(metadata, attributes)
+        }
+
+        @Override
+        Optional<StorageObjectMetadataRecord> findByTenantAndObjectHash(String tenantId, StorageDescriptor storageDescriptor, String objectKeyHash) {
+            Optional.ofNullable(rows[objectKeyHash])
+        }
+
+        @Override
+        List<StorageObjectMetadataRecord> listByTenantAndQuery(String tenantId, StorageObjectMetadataQuery query) {
+            []
+        }
+
+        @Override
+        void deleteByTenantAndObjectHash(String tenantId, StorageDescriptor storageDescriptor, String objectKeyHash) {
+            deleteByHash[objectKeyHash] = deleteByHash[objectKeyHash] + 1
+            rows.remove(objectKeyHash)
+        }
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataDeleteFailureSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataDeleteFailureSpec.groovy
@@ -1,0 +1,48 @@
+package io.micronaut.objectstorage.metadata.jdbc
+
+import io.micronaut.objectstorage.ObjectStorageException
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata
+import io.micronaut.objectstorage.metadata.TenantResolver
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRepository
+import spock.lang.Specification
+
+class MetadataDeleteFailureSpec extends Specification {
+
+    void 'failed delete does not enqueue tombstone intent or expose false metadata state'() {
+        given:
+        def descriptor = new StorageDescriptor('photos', 'oracle-cloud', 'logical-photos', 'ns1', 'bucket-a')
+        def tenantResolver = Stub(TenantResolver) {
+            resolveTenantId() >> 'tenant-a'
+        }
+        def containerRepository = Mock(StorageContainerMetadataRepository)
+        def outboxRepository = Mock(StorageMetadataOutboxRepository)
+        def objectRepository = Mock(io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository) {
+            findByTenantAndObjectHash('tenant-a', descriptor, StorageObjectMetadata.deterministicObjectKeyHash('nested/file.txt')) >> Optional.empty()
+        }
+        def metadataOperations = new DefaultObjectStorageMetadataOperations(tenantResolver, containerRepository, objectRepository)
+        def delegate = Mock(ObjectStorageOperations)
+        def operations = new DefaultMetadataAwareObjectStorageOperations<>(
+            delegate,
+            metadataOperations,
+            descriptor,
+            tenantResolver,
+            containerRepository,
+            outboxRepository,
+            []
+        )
+
+        when:
+        operations.delete('nested/file.txt')
+
+        then:
+        1 * containerRepository.findByTenantAndDescriptor('tenant-a', descriptor) >> Optional.empty()
+        1 * delegate.delete('nested/file.txt') >> { throw new ObjectStorageException('delete failed') }
+        0 * outboxRepository._
+        def ex = thrown(ObjectStorageException)
+        ex.message == 'delete failed'
+        !metadataOperations.findObject(descriptor, 'nested/file.txt').present
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataDeleteWorkflowSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataDeleteWorkflowSpec.groovy
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc
+
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.metadata.ObjectStorageLifecycleHook
+import io.micronaut.objectstorage.metadata.ObjectStorageOperationContext
+import io.micronaut.objectstorage.metadata.ObjectStorageOperationOutcome
+import io.micronaut.objectstorage.metadata.StorageContainerMetadata
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata
+import io.micronaut.objectstorage.metadata.TenantResolver
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRepository
+import spock.lang.Specification
+
+import java.time.Instant
+
+class MetadataDeleteWorkflowSpec extends Specification {
+
+    void 'delete delegates first then enqueues delete outbox record'() {
+        given:
+        def descriptor = new StorageDescriptor('photos', 'oracle-cloud', 'logical-photos', 'ns1', 'bucket-a')
+        def tenantResolver = Stub(TenantResolver) {
+            resolveTenantId() >> 'tenant-a'
+        }
+        def containerMetadata = new StorageContainerMetadata('tenant-a', descriptor, Instant.parse('2026-03-17T10:15:30Z'), Instant.parse('2026-03-17T10:15:30Z'))
+        def containerRecord = new StorageContainerMetadataRecord(containerMetadata, [:])
+        def containerRepository = Mock(StorageContainerMetadataRepository)
+        def outboxRepository = Mock(StorageMetadataOutboxRepository)
+        def metadataOperations = new DefaultObjectStorageMetadataOperations(tenantResolver, containerRepository, Mock(io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository))
+        def delegate = Mock(ObjectStorageOperations)
+        def events = []
+        def operations = new DefaultMetadataAwareObjectStorageOperations<>(
+            delegate,
+            metadataOperations,
+            descriptor,
+            tenantResolver,
+            containerRepository,
+            outboxRepository,
+            [new RecordingHook(events)]
+        )
+
+        when:
+        def response = operations.delete('nested/file.txt')
+
+        then:
+        1 * containerRepository.findByTenantAndDescriptor('tenant-a', descriptor) >> Optional.of(containerRecord)
+        1 * delegate.delete('nested/file.txt') >> {
+            events << 'delegate-delete'
+            'deleted-native'
+        }
+        1 * outboxRepository.enqueueIfAbsent(_ as StorageMetadataOutboxRecord) >> { StorageMetadataOutboxRecord record ->
+            assert events == ['before:DELETE:nested/file.txt', 'delegate-delete']
+            assert record.operationType.name() == 'DELETE'
+            assert record.objectKey.get() == 'nested/file.txt'
+            assert record.objectKeyHash.get() == StorageObjectMetadata.deterministicObjectKeyHash('nested/file.txt')
+            assert !record.destinationObjectKey.present
+            assert record.idempotencyKey == 'tenant-a|photos|DELETE|' + StorageObjectMetadata.deterministicObjectKeyHash('nested/file.txt') + '|-'
+            events << 'enqueue-delete'
+            true
+        }
+        response == 'deleted-native'
+        events == ['before:DELETE:nested/file.txt', 'delegate-delete', 'enqueue-delete']
+    }
+
+    void 'delete duplicate enqueue replay returns delegate response without dispatch exception'() {
+        given:
+        def descriptor = new StorageDescriptor('photos', 'oracle-cloud', 'logical-photos', 'ns1', 'bucket-a')
+        def tenantResolver = Stub(TenantResolver) {
+            resolveTenantId() >> 'tenant-a'
+        }
+        def containerRepository = Mock(StorageContainerMetadataRepository)
+        def outboxRepository = Mock(StorageMetadataOutboxRepository)
+        def metadataOperations = new DefaultObjectStorageMetadataOperations(tenantResolver, containerRepository, Mock(io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository))
+        def delegate = Mock(ObjectStorageOperations)
+        def events = []
+        def hook = new ErrorTrackingHook(events)
+        def operations = new DefaultMetadataAwareObjectStorageOperations<>(
+            delegate,
+            metadataOperations,
+            descriptor,
+            tenantResolver,
+            containerRepository,
+            outboxRepository,
+            [hook]
+        )
+
+        when:
+        def response = operations.delete('nested/duplicate-delete.txt')
+
+        then:
+        1 * containerRepository.findByTenantAndDescriptor('tenant-a', descriptor) >> Optional.empty()
+        1 * delegate.delete('nested/duplicate-delete.txt') >> 'deleted-duplicate'
+        1 * outboxRepository.enqueueIfAbsent(_ as StorageMetadataOutboxRecord) >> false
+        response == 'deleted-duplicate'
+        notThrown(io.micronaut.objectstorage.metadata.MetadataDispatchException)
+        events == ['before:DELETE:nested/duplicate-delete.txt']
+        hook.errors.isEmpty()
+    }
+
+    private static final class RecordingHook implements ObjectStorageLifecycleHook {
+        private final List<String> events
+
+        RecordingHook(List<String> events) {
+            this.events = events
+        }
+
+        @Override
+        void before(ObjectStorageOperationContext context) {
+            events << "before:${context.operationType}:${context.objectKey}".toString()
+        }
+
+        @Override
+        void after(ObjectStorageOperationContext context, ObjectStorageOperationOutcome outcome) {
+            events << "after:${outcome.operationType}:${outcome.objectKey}".toString()
+        }
+    }
+
+    private static final class ErrorTrackingHook implements ObjectStorageLifecycleHook {
+        private final List<String> events
+        final List<Throwable> errors = []
+
+        ErrorTrackingHook(List<String> events) {
+            this.events = events
+        }
+
+        @Override
+        void before(ObjectStorageOperationContext context) {
+            events << "before:${context.operationType}:${context.objectKey}".toString()
+        }
+
+        @Override
+        void error(ObjectStorageOperationContext context, Throwable throwable) {
+            errors << throwable
+        }
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataJdbcRepositorySpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataJdbcRepositorySpec.groovy
@@ -1,0 +1,196 @@
+package io.micronaut.objectstorage.metadata.jdbc
+
+import io.micronaut.objectstorage.metadata.ObjectMetadataReconciliationState
+import io.micronaut.objectstorage.metadata.ObjectMetadataSyncStatus
+import io.micronaut.objectstorage.metadata.StorageContainerMetadata
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata
+import io.micronaut.objectstorage.metadata.jdbc.repository.JdbcStorageContainerMetadataRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.JdbcStorageObjectMetadataRepository
+import spock.lang.Specification
+
+import javax.sql.DataSource
+import java.sql.Connection
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.sql.Timestamp
+import java.time.Instant
+
+class MetadataJdbcRepositorySpec extends Specification {
+
+    void "findByTenantAndObjectHash applies tenant predicate and hydrates object attrs"() {
+        given:
+        DataSource dataSource = Mock()
+        Connection connection = Mock()
+        PreparedStatement objectStatement = Mock()
+        PreparedStatement attrStatement = Mock()
+        ResultSet objectResultSet = Mock()
+        ResultSet attrResultSet = Mock()
+        JdbcStorageObjectMetadataRepository repository = new JdbcStorageObjectMetadataRepository(dataSource)
+        StorageDescriptor descriptor = new StorageDescriptor("pictures", "oracle", "avatars", "ns-a", "bucket-a")
+        Instant now = Instant.parse("2026-03-17T12:00:00Z")
+
+        and:
+        dataSource.getConnection() >> connection
+        connection.getAutoCommit() >> true
+        connection.prepareStatement({ String sql -> sql == JdbcStorageObjectMetadataRepository.FIND_SQL }) >> objectStatement
+        connection.prepareStatement({ String sql -> sql == JdbcStorageObjectMetadataRepository.FIND_ATTRS_SQL }) >> attrStatement
+        objectStatement.executeQuery() >> objectResultSet
+        attrStatement.executeQuery() >> attrResultSet
+
+        and:
+        objectResultSet.next() >>> [true, false]
+        objectResultSet.getString("id") >> "obj-1"
+        objectResultSet.getString("tenant_id") >> "tenant-a"
+        objectResultSet.getString("storage_name") >> "pictures"
+        objectResultSet.getString("provider_id") >> "oracle"
+        objectResultSet.getString("logical_container") >> "avatars"
+        objectResultSet.getString("provider_namespace") >> "ns-a"
+        objectResultSet.getString("provider_container") >> "bucket-a"
+        objectResultSet.getString("object_key") >> "/avatars/a.png"
+        objectResultSet.getString("object_key_hash") >> "hash-a"
+        objectResultSet.getString("content_type") >> "image/png"
+        objectResultSet.getLong("content_length") >> 321L
+        objectResultSet.wasNull() >> false
+        objectResultSet.getString("etag") >> "etag-a"
+        objectResultSet.getString("provider_version_id") >> "v-1"
+        objectResultSet.getString("checksum") >> "sha256:a"
+        objectResultSet.getString("reconciliation_state") >> "SUCCEEDED"
+        objectResultSet.getString("last_error_summary") >> null
+        objectResultSet.getTimestamp("created_at") >> Timestamp.from(now)
+        objectResultSet.getTimestamp("updated_at") >> Timestamp.from(now)
+
+        and:
+        attrResultSet.next() >>> [true, true, false]
+        attrResultSet.getString("attr_key") >>> ["author", "source"]
+        attrResultSet.getString("attr_value") >>> ["alice", "camera"]
+
+        when:
+        def result = repository.findByTenantAndObjectHash("tenant-a", descriptor, "hash-a")
+
+        then:
+        result.present
+        result.get().metadata.tenantId == "tenant-a"
+        result.get().metadata.objectKeyHash == "hash-a"
+        result.get().attributes == [author: "alice", source: "camera"]
+
+        and:
+        1 * objectStatement.setString(1, "tenant-a")
+        1 * objectStatement.setString(2, "pictures")
+        1 * objectStatement.setString(3, "avatars")
+        1 * objectStatement.setString(4, "hash-a")
+        1 * attrStatement.setString(1, "obj-1")
+        1 * connection.commit()
+    }
+
+    void "upsert object metadata scopes existence lookup by tenant and rewrites attrs"() {
+        given:
+        DataSource dataSource = Mock()
+        Connection connection = Mock()
+        PreparedStatement selectId = Mock()
+        PreparedStatement existsStatement = Mock()
+        PreparedStatement updateStatement = Mock()
+        PreparedStatement deleteAttrsStatement = Mock()
+        PreparedStatement insertAttrsStatement = Mock()
+        ResultSet selectIdResultSet = Mock()
+        ResultSet existsResultSet = Mock()
+        JdbcStorageObjectMetadataRepository repository = new JdbcStorageObjectMetadataRepository(dataSource)
+
+        and:
+        StorageDescriptor descriptor = new StorageDescriptor("pictures", "oracle", "avatars", "ns-a", "bucket-a")
+        StorageObjectMetadata metadata = new StorageObjectMetadata(
+            "tenant-a",
+            descriptor,
+            "/avatars/a.png",
+            "hash-a",
+            "image/png",
+            321L,
+            "etag-a",
+            "v-1",
+            "sha256:a",
+            Instant.parse("2026-03-17T12:00:00Z"),
+            Instant.parse("2026-03-17T12:00:00Z"),
+            new ObjectMetadataSyncStatus(ObjectMetadataReconciliationState.SUCCEEDED, null)
+        )
+
+        and:
+        dataSource.getConnection() >> connection
+        connection.getAutoCommit() >> true
+        connection.prepareStatement({ String sql -> sql == JdbcStorageObjectMetadataRepository.SELECT_ID_SQL }) >> selectId
+        connection.prepareStatement("SELECT id FROM storage_object_metadata WHERE id = ?") >> existsStatement
+        connection.prepareStatement({ String sql -> sql == JdbcStorageObjectMetadataRepository.UPDATE_SQL }) >> updateStatement
+        connection.prepareStatement({ String sql -> sql == JdbcStorageObjectMetadataRepository.DELETE_ATTRS_SQL }) >> deleteAttrsStatement
+        connection.prepareStatement({ String sql -> sql == JdbcStorageObjectMetadataRepository.INSERT_ATTR_SQL }) >> insertAttrsStatement
+        selectId.executeQuery() >> selectIdResultSet
+        existsStatement.executeQuery() >> existsResultSet
+        selectIdResultSet.next() >>> [true, false]
+        selectIdResultSet.getString(1) >> "obj-1"
+        existsResultSet.next() >>> [true, false]
+
+        when:
+        repository.upsert(metadata, [owner: "alice", source: "camera"])
+
+        then:
+        1 * selectId.setString(1, "tenant-a")
+        1 * selectId.setString(2, "pictures")
+        1 * selectId.setString(3, "avatars")
+        1 * selectId.setString(4, "hash-a")
+        1 * deleteAttrsStatement.setString(1, "obj-1")
+        2 * insertAttrsStatement.addBatch()
+        1 * insertAttrsStatement.executeBatch()
+        1 * connection.commit()
+    }
+
+    void "findByTenantAndDescriptor applies tenant predicate and hydrates container attrs"() {
+        given:
+        DataSource dataSource = Mock()
+        Connection connection = Mock()
+        PreparedStatement containerStatement = Mock()
+        PreparedStatement attrStatement = Mock()
+        ResultSet containerResultSet = Mock()
+        ResultSet attrResultSet = Mock()
+        JdbcStorageContainerMetadataRepository repository = new JdbcStorageContainerMetadataRepository(dataSource)
+        StorageDescriptor descriptor = new StorageDescriptor("pictures", "oracle", "avatars", null, "bucket-a")
+        Instant now = Instant.parse("2026-03-17T12:00:00Z")
+
+        and:
+        dataSource.getConnection() >> connection
+        connection.getAutoCommit() >> true
+        connection.prepareStatement({ String sql -> sql == JdbcStorageContainerMetadataRepository.FIND_SQL }) >> containerStatement
+        connection.prepareStatement({ String sql -> sql == JdbcStorageContainerMetadataRepository.FIND_ATTRS_SQL }) >> attrStatement
+        containerStatement.executeQuery() >> containerResultSet
+        attrStatement.executeQuery() >> attrResultSet
+
+        and:
+        containerResultSet.next() >>> [true, false]
+        containerResultSet.getString("id") >> "container-1"
+        containerResultSet.getString("tenant_id") >> "tenant-a"
+        containerResultSet.getString("storage_name") >> "pictures"
+        containerResultSet.getString("provider_id") >> "oracle"
+        containerResultSet.getString("logical_container") >> "avatars"
+        containerResultSet.getString("provider_namespace") >> null
+        containerResultSet.getString("provider_container") >> "bucket-a"
+        containerResultSet.getTimestamp("created_at") >> Timestamp.from(now)
+        containerResultSet.getTimestamp("updated_at") >> Timestamp.from(now)
+
+        and:
+        attrResultSet.next() >>> [true, false]
+        attrResultSet.getString("attr_key") >> "region"
+        attrResultSet.getString("attr_value") >> "eu-frankfurt-1"
+
+        when:
+        def result = repository.findByTenantAndDescriptor("tenant-a", descriptor)
+
+        then:
+        result.present
+        result.get().metadata.tenantId == "tenant-a"
+        result.get().attributes == [region: "eu-frankfurt-1"]
+
+        and:
+        1 * containerStatement.setString(1, "tenant-a")
+        1 * containerStatement.setString(2, "pictures")
+        1 * containerStatement.setString(3, "avatars")
+        1 * attrStatement.setString(1, "container-1")
+        1 * connection.commit()
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataJdbcSchemaSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataJdbcSchemaSpec.groovy
@@ -1,0 +1,56 @@
+package io.micronaut.objectstorage.metadata.jdbc
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class MetadataJdbcSchemaSpec extends Specification {
+
+    @Unroll
+    void "schema script #path defines v1 tables constraints and indexes"() {
+        given:
+        String ddl = load(path).toLowerCase(java.util.Locale.ROOT)
+
+        expect:
+        ddl.contains("create table storage_container_metadata")
+        ddl.contains("create table storage_container_metadata_attr")
+        ddl.contains("create table storage_object_metadata")
+        ddl.contains("create table storage_object_metadata_attr")
+        ddl.contains("create table storage_metadata_outbox")
+
+        and:
+        ddl.contains("tenant_id")
+        ddl.contains("storage_name")
+        ddl.contains("logical_container")
+        ddl.contains("object_key_hash")
+
+        and:
+        ddl.contains("tenant_id varchar2(255) not null") || ddl.contains("tenant_id varchar(255) not null")
+        ddl.contains("storage_name varchar2(255) not null") || ddl.contains("storage_name varchar(255) not null")
+        ddl.contains("logical_container varchar2(255) not null") || ddl.contains("logical_container varchar(255) not null")
+        ddl.contains("object_key_hash varchar2(64) not null") || ddl.contains("object_key_hash varchar(64) not null")
+
+        and:
+        ddl.contains("constraint uk_storage_container_metadata_scope unique (tenant_id, storage_name, logical_container)")
+        ddl.contains("constraint uk_storage_object_metadata_scope unique (tenant_id, storage_name, logical_container, object_key_hash)")
+        if (path.contains('postgresql')) {
+            assert ddl.contains("create index idx_scoped_container_metadata")
+            assert ddl.contains("create index idx_scoped_object_metadata")
+        }
+
+        and:
+        !ddl.contains(" json")
+        !ddl.contains("json_")
+
+        where:
+        path << [
+            "db/metadata/oracle/schema-v1.sql",
+            "db/metadata/postgresql/schema-v1.sql"
+        ]
+    }
+
+    private static String load(String path) {
+        InputStream stream = MetadataJdbcSchemaSpec.classLoader.getResourceAsStream(path)
+        assert stream != null: "Missing schema resource: $path"
+        stream.getText("UTF-8")
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataOutboxIdempotencySpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataOutboxIdempotencySpec.groovy
@@ -1,0 +1,162 @@
+package io.micronaut.objectstorage.metadata.jdbc
+
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageDescriptorResolver
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata
+import io.micronaut.objectstorage.metadata.StorageObjectMetadataQuery
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxStatus
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository
+import spock.lang.Specification
+
+import java.time.Instant
+
+class MetadataOutboxIdempotencySpec extends Specification {
+
+    void 'replayed idempotency key reconciles exactly once'() {
+        given:
+        def objectRepository = new CountingObjectMetadataRepository()
+        def outboxRepository = new InMemoryOutboxRepository()
+        def descriptor = new StorageDescriptor('pictures', 'oracle', 'reports', 'ns-a', 'bucket-a')
+        def descriptorResolver = new OutboxStorageDescriptorResolver([({ -> descriptor } as StorageDescriptorResolver)])
+        def reconciler = new DefaultMetadataOutboxReconciler(objectRepository, descriptorResolver)
+        def worker = new MetadataOutboxReconciliationWorker(outboxRepository, reconciler, descriptorResolver, [], new ObjectStorageMetadataJdbcConfiguration())
+        def now = Instant.parse('2026-03-17T12:00:00Z')
+
+        and:
+        def first = record('outbox-1', 'tenant-a|pictures|reports|/2026/03/invoice-001.pdf|UPLOAD', now)
+        def duplicate = record('outbox-2', 'tenant-a|pictures|reports|/2026/03/invoice-001.pdf|UPLOAD', now)
+
+        when:
+        boolean inserted = outboxRepository.enqueueIfAbsent(first)
+        boolean duplicateInserted = outboxRepository.enqueueIfAbsent(duplicate)
+        worker.reconcileDueEntries()
+        worker.reconcileDueEntries()
+
+        then:
+        inserted
+        !duplicateInserted
+        objectRepository.upsertCount == 1
+        objectRepository.rows.size() == 1
+        outboxRepository.findById('outbox-1').orElseThrow().status == StorageMetadataOutboxStatus.SUCCEEDED
+    }
+
+    private static StorageMetadataOutboxRecord record(String id, String idempotencyKey, Instant now) {
+        new StorageMetadataOutboxRecord(
+            id,
+            'tenant-a',
+            'pictures',
+            'reports',
+            '/2026/03/invoice-001.pdf',
+            StorageObjectMetadata.deterministicObjectKeyHash('/2026/03/invoice-001.pdf'),
+            null,
+            null,
+            io.micronaut.objectstorage.metadata.ObjectStorageOperationType.UPLOAD,
+            'recon-1',
+            1,
+            StorageMetadataOutboxStatus.PENDING,
+            0,
+            now.minusSeconds(1),
+            null,
+            idempotencyKey,
+            now,
+            now
+        )
+    }
+
+    private static final class CountingObjectMetadataRepository implements StorageObjectMetadataRepository {
+        int upsertCount = 0
+        final Map<String, StorageObjectMetadataRecord> rows = [:]
+
+        @Override
+        void upsert(StorageObjectMetadata metadata, Map<String, String> attributes) {
+            upsertCount++
+            rows.put(metadata.objectKeyHash, new StorageObjectMetadataRecord(metadata, attributes))
+        }
+
+        @Override
+        Optional<StorageObjectMetadataRecord> findByTenantAndObjectHash(String tenantId, StorageDescriptor storageDescriptor, String objectKeyHash) {
+            Optional.ofNullable(rows.get(objectKeyHash))
+        }
+
+        @Override
+        List<StorageObjectMetadataRecord> listByTenantAndQuery(String tenantId, StorageObjectMetadataQuery query) {
+            []
+        }
+
+        @Override
+        void deleteByTenantAndObjectHash(String tenantId, StorageDescriptor storageDescriptor, String objectKeyHash) {
+            rows.remove(objectKeyHash)
+        }
+    }
+
+    private static final class InMemoryOutboxRepository implements StorageMetadataOutboxRepository {
+        private final Map<String, StorageMetadataOutboxRecord> rowsById = [:]
+        private final Map<String, String> idByIdempotency = [:]
+
+        @Override
+        void enqueue(StorageMetadataOutboxRecord outboxRecord) {
+            enqueueIfAbsent(outboxRecord)
+        }
+
+        @Override
+        boolean enqueueIfAbsent(StorageMetadataOutboxRecord outboxRecord) {
+            if (idByIdempotency.containsKey(outboxRecord.idempotencyKey)) {
+                return false
+            }
+            idByIdempotency.put(outboxRecord.idempotencyKey, outboxRecord.id)
+            rowsById.put(outboxRecord.id, outboxRecord)
+            true
+        }
+
+        @Override
+        List<StorageMetadataOutboxRecord> findDueEntries(Instant asOf, int limit) {
+            rowsById.values().findAll {
+                it.nextAttemptAt <= asOf && it.status in [StorageMetadataOutboxStatus.PENDING, StorageMetadataOutboxStatus.FAILED, StorageMetadataOutboxStatus.PROCESSING]
+            }.take(limit)
+        }
+
+        @Override
+        boolean markProcessing(String id, Instant asOf, Instant updatedAt) {
+            def record = rowsById[id]
+            if (record == null || record.nextAttemptAt > asOf || !(record.status in [StorageMetadataOutboxStatus.PENDING, StorageMetadataOutboxStatus.FAILED, StorageMetadataOutboxStatus.PROCESSING])) {
+                return false
+            }
+            rowsById[id] = withStatus(record, StorageMetadataOutboxStatus.PROCESSING, record.attemptCount, record.nextAttemptAt, record.lastErrorSummary.orElse(null), updatedAt)
+            true
+        }
+
+        @Override
+        void markSucceeded(String id, Instant updatedAt) {
+            def record = rowsById[id]
+            rowsById[id] = withStatus(record, StorageMetadataOutboxStatus.SUCCEEDED, record.attemptCount, record.nextAttemptAt, null, updatedAt)
+        }
+
+        @Override
+        void markRetryOrDeadLetter(String id, int attemptCount, Instant nextAttemptAt, StorageMetadataOutboxStatus status, String lastErrorSummary, Instant updatedAt) {
+            def record = rowsById[id]
+            rowsById[id] = withStatus(record, status, attemptCount, nextAttemptAt, lastErrorSummary, updatedAt)
+        }
+
+        @Override
+        Optional<StorageMetadataOutboxRecord> findById(String id) {
+            Optional.ofNullable(rowsById[id])
+        }
+
+        @Override
+        Optional<StorageMetadataOutboxRecord> findByIdempotencyKey(String idempotencyKey) {
+            Optional.ofNullable(idByIdempotency[idempotencyKey]).flatMap { findById(it) }
+        }
+
+        private static StorageMetadataOutboxRecord withStatus(StorageMetadataOutboxRecord record,
+                                                              StorageMetadataOutboxStatus status,
+                                                              int attempts,
+                                                              Instant nextAttemptAt,
+                                                              String error,
+                                                              Instant updatedAt) {
+            new StorageMetadataOutboxRecord(record.id, record.tenantId, record.storageName, record.logicalContainer, record.objectKey.orElse(null), record.objectKeyHash.orElse(null), record.destinationObjectKey.orElse(null), record.destinationObjectKeyHash.orElse(null), record.operationType, record.reconciliationId.orElse(null), record.payloadVersion, status, attempts, nextAttemptAt, error, record.idempotencyKey, record.createdAt, updatedAt)
+        }
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataOutboxReconciliationSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataOutboxReconciliationSpec.groovy
@@ -1,0 +1,212 @@
+package io.micronaut.objectstorage.metadata.jdbc
+
+import io.micronaut.objectstorage.metadata.ObjectMetadataReconciliationState
+import io.micronaut.objectstorage.metadata.ObjectStorageLifecycleHook
+import io.micronaut.objectstorage.metadata.ObjectStorageOperationContext
+import io.micronaut.objectstorage.metadata.ObjectStorageOperationOutcome
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageDescriptorResolver
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata
+import io.micronaut.objectstorage.metadata.StorageObjectMetadataQuery
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxStatus
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository
+import spock.lang.Specification
+
+import java.time.Instant
+
+class MetadataOutboxReconciliationSpec extends Specification {
+
+    void 'pending outbox entry is reconciled and marks metadata row as succeeded'() {
+        given:
+        def objectRepository = new InMemoryObjectMetadataRepository()
+        def outboxRepository = new InMemoryOutboxRepository()
+        def descriptor = new StorageDescriptor('pictures', 'oracle', 'reports', 'ns-a', 'bucket-a')
+        def descriptorResolver = new OutboxStorageDescriptorResolver([new FixedDescriptorResolver(descriptor)])
+        def reconciler = new DefaultMetadataOutboxReconciler(objectRepository, descriptorResolver)
+        def configuration = new ObjectStorageMetadataJdbcConfiguration()
+        def events = []
+        def worker = new MetadataOutboxReconciliationWorker(outboxRepository, reconciler, descriptorResolver, [new RecordingHook(events)], configuration)
+        def now = Instant.parse('2026-03-17T12:00:00Z')
+        def record = new StorageMetadataOutboxRecord(
+            'outbox-1',
+            'tenant-a',
+            'pictures',
+            'reports',
+            '/2026/03/invoice-001.pdf',
+            StorageObjectMetadata.deterministicObjectKeyHash('/2026/03/invoice-001.pdf'),
+            null,
+            null,
+            io.micronaut.objectstorage.metadata.ObjectStorageOperationType.UPLOAD,
+            'recon-1',
+            1,
+            StorageMetadataOutboxStatus.PENDING,
+            0,
+            now.minusSeconds(1),
+            null,
+            'tenant-a|pictures|reports|/2026/03/invoice-001.pdf|UPLOAD',
+            now,
+            now
+        )
+
+        when:
+        outboxRepository.enqueue(record)
+        worker.reconcileDueEntries()
+        def outbox = outboxRepository.findById('outbox-1').orElseThrow()
+        def metadata = objectRepository.findByTenantAndObjectHash('tenant-a', descriptor, StorageObjectMetadata.deterministicObjectKeyHash('/2026/03/invoice-001.pdf')).orElseThrow().metadata()
+        assert outbox.lastErrorSummary.orElse(null) == null
+
+        then:
+        outbox.status == StorageMetadataOutboxStatus.SUCCEEDED
+        metadata.syncStatus.reconciliationState == ObjectMetadataReconciliationState.SUCCEEDED
+        assert events == ['after:tenant-a:UPLOAD:/2026/03/invoice-001.pdf:recon-1']
+    }
+
+    private static final class RecordingHook implements ObjectStorageLifecycleHook {
+        private final List<String> events
+
+        private RecordingHook(List<String> events) {
+            this.events = events
+        }
+
+        @Override
+        void after(ObjectStorageOperationContext context, ObjectStorageOperationOutcome outcome) {
+            assert context.objectKey == '/2026/03/invoice-001.pdf'
+            assert outcome.reconciliationId.orElse('missing') == 'recon-1'
+            events << "after:${context.tenantId}:${context.operationType}:${context.objectKey}:${outcome.reconciliationId.orElse('missing')}".toString()
+        }
+    }
+
+    private static final class FixedDescriptorResolver implements StorageDescriptorResolver {
+        private final StorageDescriptor descriptor
+
+        private FixedDescriptorResolver(StorageDescriptor descriptor) {
+            this.descriptor = descriptor
+        }
+
+        @Override
+        StorageDescriptor resolve() {
+            descriptor
+        }
+    }
+
+    private static final class InMemoryObjectMetadataRepository implements StorageObjectMetadataRepository {
+        private final Map<String, StorageObjectMetadataRecord> rows = [:]
+
+        @Override
+        void upsert(StorageObjectMetadata metadata, Map<String, String> attributes) {
+            rows.put(key(metadata.tenantId, metadata.storageName, metadata.logicalContainer, metadata.objectKeyHash), new StorageObjectMetadataRecord(metadata, attributes))
+        }
+
+        @Override
+        Optional<StorageObjectMetadataRecord> findByTenantAndObjectHash(String tenantId, StorageDescriptor storageDescriptor, String objectKeyHash) {
+            Optional.ofNullable(rows.get(key(tenantId, storageDescriptor.storageName, storageDescriptor.logicalContainer, objectKeyHash)))
+        }
+
+        @Override
+        List<StorageObjectMetadataRecord> listByTenantAndQuery(String tenantId, StorageObjectMetadataQuery query) {
+            []
+        }
+
+        @Override
+        void deleteByTenantAndObjectHash(String tenantId, StorageDescriptor storageDescriptor, String objectKeyHash) {
+            rows.remove(key(tenantId, storageDescriptor.storageName, storageDescriptor.logicalContainer, objectKeyHash))
+        }
+
+        private static String key(String tenantId, String storageName, String logicalContainer, String objectKeyHash) {
+            "${tenantId}|${storageName}|${logicalContainer}|${objectKeyHash}"
+        }
+    }
+
+    private static final class InMemoryOutboxRepository implements StorageMetadataOutboxRepository {
+        private final Map<String, StorageMetadataOutboxRecord> rowsById = [:]
+        private final Map<String, String> rowIdsByIdempotency = [:]
+
+        @Override
+        void enqueue(StorageMetadataOutboxRecord outboxRecord) {
+            if (!enqueueIfAbsent(outboxRecord)) {
+                throw new IllegalStateException('duplicate idempotency key')
+            }
+        }
+
+        @Override
+        boolean enqueueIfAbsent(StorageMetadataOutboxRecord outboxRecord) {
+            if (rowIdsByIdempotency.containsKey(outboxRecord.idempotencyKey)) {
+                return false
+            }
+            rowIdsByIdempotency.put(outboxRecord.idempotencyKey, outboxRecord.id)
+            rowsById.put(outboxRecord.id, outboxRecord)
+            true
+        }
+
+        @Override
+        List<StorageMetadataOutboxRecord> findDueEntries(Instant asOf, int limit) {
+            rowsById.values()
+                .findAll { it.nextAttemptAt <= asOf && it.status in [StorageMetadataOutboxStatus.PENDING, StorageMetadataOutboxStatus.FAILED, StorageMetadataOutboxStatus.PROCESSING] }
+                .sort { it.nextAttemptAt }
+                .take(limit)
+        }
+
+        @Override
+        boolean markProcessing(String id, Instant asOf, Instant updatedAt) {
+            StorageMetadataOutboxRecord existing = rowsById.get(id)
+            if (existing == null || existing.nextAttemptAt > asOf || !(existing.status in [StorageMetadataOutboxStatus.PENDING, StorageMetadataOutboxStatus.FAILED, StorageMetadataOutboxStatus.PROCESSING])) {
+                return false
+            }
+            rowsById.put(id, withStatus(existing, StorageMetadataOutboxStatus.PROCESSING, existing.attemptCount, existing.nextAttemptAt, existing.lastErrorSummary.orElse(null), updatedAt))
+            true
+        }
+
+        @Override
+        void markSucceeded(String id, Instant updatedAt) {
+            StorageMetadataOutboxRecord existing = rowsById.get(id)
+            rowsById.put(id, withStatus(existing, StorageMetadataOutboxStatus.SUCCEEDED, existing.attemptCount, existing.nextAttemptAt, null, updatedAt))
+        }
+
+        @Override
+        void markRetryOrDeadLetter(String id, int attemptCount, Instant nextAttemptAt, StorageMetadataOutboxStatus status, String lastErrorSummary, Instant updatedAt) {
+            StorageMetadataOutboxRecord existing = rowsById.get(id)
+            rowsById.put(id, withStatus(existing, status, attemptCount, nextAttemptAt, lastErrorSummary, updatedAt))
+        }
+
+        @Override
+        Optional<StorageMetadataOutboxRecord> findById(String id) {
+            Optional.ofNullable(rowsById.get(id))
+        }
+
+        @Override
+        Optional<StorageMetadataOutboxRecord> findByIdempotencyKey(String idempotencyKey) {
+            Optional.ofNullable(rowIdsByIdempotency.get(idempotencyKey)).flatMap { id -> findById(id) }
+        }
+
+        private static StorageMetadataOutboxRecord withStatus(StorageMetadataOutboxRecord record,
+                                                              StorageMetadataOutboxStatus status,
+                                                              int attemptCount,
+                                                              Instant nextAttemptAt,
+                                                              String lastErrorSummary,
+                                                              Instant updatedAt) {
+            new StorageMetadataOutboxRecord(
+                record.id,
+                record.tenantId,
+                record.storageName,
+                record.logicalContainer,
+                record.objectKey.orElse(null),
+                record.objectKeyHash.orElse(null),
+                record.destinationObjectKey.orElse(null),
+                record.destinationObjectKeyHash.orElse(null),
+                record.operationType,
+                record.reconciliationId.orElse(null),
+                record.payloadVersion,
+                status,
+                attemptCount,
+                nextAttemptAt,
+                lastErrorSummary,
+                record.idempotencyKey,
+                record.createdAt,
+                updatedAt
+            )
+        }
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataPrefixQuerySpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataPrefixQuerySpec.groovy
@@ -1,0 +1,67 @@
+package io.micronaut.objectstorage.metadata.jdbc
+
+import io.micronaut.objectstorage.metadata.ObjectMetadataReconciliationState
+import io.micronaut.objectstorage.metadata.ObjectMetadataSyncStatus
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata
+import io.micronaut.objectstorage.metadata.StorageObjectMetadataQuery
+import io.micronaut.objectstorage.metadata.TenantResolver
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository
+import spock.lang.Specification
+
+import java.time.Instant
+
+class MetadataPrefixQuerySpec extends Specification {
+
+    void "listObjects applies storage container prefix filtering through repository and hides invisible rows"() {
+        given:
+        TenantResolver tenantResolver = Stub() {
+            resolveTenantId() >> 'tenant-a'
+        }
+        StorageContainerMetadataRepository containerRepository = Stub()
+        StorageObjectMetadataRepository objectRepository = Mock()
+        def descriptor = new StorageDescriptor('pictures', 'oracle', 'reports', 'ns-a', 'bucket-a')
+        def query = StorageObjectMetadataQuery.all()
+            .withStorageName('pictures')
+            .withLogicalContainer('reports')
+            .withObjectKeyPrefix('/2026/03/')
+        def matchingOne = objectMetadata(descriptor, '/2026/03/invoice-001.pdf', ObjectMetadataReconciliationState.SUCCEEDED)
+        def matchingTwo = objectMetadata(descriptor, '/2026/03/invoice-002.pdf', ObjectMetadataReconciliationState.SUCCEEDED)
+        def hidden = objectMetadata(descriptor, '/2026/03/invoice-003.pdf', ObjectMetadataReconciliationState.PROCESSING)
+        def operations = new DefaultObjectStorageMetadataOperations(tenantResolver, containerRepository, objectRepository)
+
+        when:
+        def results = operations.listObjects(query)
+
+        then:
+        results == [matchingOne, matchingTwo]
+
+        and:
+        1 * objectRepository.listByTenantAndQuery('tenant-a', query) >> [
+            new StorageObjectMetadataRecord(matchingOne, [owner: 'alice']),
+            new StorageObjectMetadataRecord(matchingTwo, [owner: 'bob']),
+            new StorageObjectMetadataRecord(hidden, [owner: 'carol'])
+        ]
+        0 * _
+    }
+
+    private static StorageObjectMetadata objectMetadata(StorageDescriptor descriptor, String key, ObjectMetadataReconciliationState state) {
+        Instant now = Instant.parse('2026-03-17T12:00:00Z')
+        new StorageObjectMetadata(
+            'tenant-a',
+            descriptor,
+            key,
+            StorageObjectMetadata.deterministicObjectKeyHash(key),
+            'application/pdf',
+            100L,
+            'etag-1',
+            'version-1',
+            'sha256:abc',
+            now,
+            now,
+            new ObjectMetadataSyncStatus(state, state == ObjectMetadataReconciliationState.SUCCEEDED ? null : 'still reconciling')
+        )
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataQualifierPreservationSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataQualifierPreservationSpec.groovy
@@ -1,0 +1,229 @@
+package io.micronaut.objectstorage.metadata.jdbc
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.metadata.MetadataAwareObjectStorageOperations
+import io.micronaut.objectstorage.metadata.ObjectStorageMetadataOperations
+import io.micronaut.objectstorage.metadata.StorageContainerMetadata
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata
+import io.micronaut.objectstorage.metadata.ObjectMetadataReconciliationState
+import io.micronaut.objectstorage.metadata.ObjectMetadataSyncStatus
+import io.micronaut.objectstorage.metadata.StorageObjectMetadataQuery
+import io.micronaut.objectstorage.metadata.TenantResolver
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+class MetadataQualifierPreservationSpec extends Specification {
+
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run(['spec.name': 'MetadataQualifierPreservationSpec'])
+
+    void '@Named metadata beans preserve the requested qualifier identity'() {
+        expect:
+        context.getBean(io.micronaut.objectstorage.metadata.MetadataAwareObjectStorageOperations, Qualifiers.byName('default')) != null
+        context.getBean(io.micronaut.objectstorage.metadata.MetadataAwareObjectStorageOperations, Qualifiers.byName('pictures')) != null
+
+        and:
+        context.findBean(ObjectStorageOperations, Qualifiers.byName('default')).present
+        context.findBean(ObjectStorageOperations, Qualifiers.byName('pictures')).present
+        context.findBean(ObjectStorageMetadataOperations, Qualifiers.byName('default')).present
+        context.findBean(ObjectStorageMetadataOperations, Qualifiers.byName('pictures')).present
+    }
+
+    void 'raw and metadata beans resolve for the same qualifier'() {
+        expect:
+        context.getBean(ObjectStorageOperations, Qualifiers.byName('default')).class.simpleName == 'StubObjectStorageOperations'
+        context.getBean(ObjectStorageOperations, Qualifiers.byName('pictures')).class.simpleName == 'StubObjectStorageOperations'
+
+        and:
+        context.getBean(ObjectStorageMetadataOperations, Qualifiers.byName('default')).activeTenantId == 'tenant-a'
+        context.getBean(ObjectStorageMetadataOperations, Qualifiers.byName('pictures')).activeTenantId == 'tenant-a'
+
+        and:
+        context.getBean(MetadataAwareObjectStorageOperations, Qualifiers.byName('default')).metadataOperations
+            .is(context.getBean(ObjectStorageMetadataOperations, Qualifiers.byName('default')))
+        context.getBean(MetadataAwareObjectStorageOperations, Qualifiers.byName('pictures')).metadataOperations
+            .is(context.getBean(ObjectStorageMetadataOperations, Qualifiers.byName('pictures')))
+
+        and:
+        def defaultMetadata = context.getBean(ObjectStorageMetadataOperations, Qualifiers.byName('default'))
+        def picturesMetadata = context.getBean(ObjectStorageMetadataOperations, Qualifiers.byName('pictures'))
+        defaultMetadata.findContainer(new StorageDescriptor('default', 'test', 'default', null, 'default')).empty
+        picturesMetadata.findContainer(new StorageDescriptor('pictures', 'test', 'pictures', null, 'pictures')).present
+        picturesMetadata.findObject(new StorageDescriptor('pictures', 'test', 'pictures', null, 'pictures'), '/logo.png').present
+        picturesMetadata.listObjects(StorageObjectMetadataQuery.all().withStorageName('pictures'))*.objectKey == ['/logo.png']
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'MetadataQualifierPreservationSpec')
+    static class TestTenantResolver implements TenantResolver {
+        @Override
+        String resolveTenantId() {
+            return 'tenant-a'
+        }
+    }
+
+    @Factory
+    @Requires(property = 'spec.name', value = 'MetadataQualifierPreservationSpec')
+    static class TestRepositories {
+        @Singleton
+        @Named('default')
+        ObjectStorageOperations defaultOperations() {
+            new StubObjectStorageOperations()
+        }
+
+        @Singleton
+        @Named('pictures')
+        ObjectStorageOperations picturesOperations() {
+            new StubObjectStorageOperations()
+        }
+
+        @Singleton
+        @Named('default')
+        io.micronaut.objectstorage.metadata.StorageDescriptorResolver defaultDescriptorResolver() {
+            new FixedDescriptorResolver(new StorageDescriptor('default', 'test', 'default', null, 'default'))
+        }
+
+        @Singleton
+        @Named('pictures')
+        io.micronaut.objectstorage.metadata.StorageDescriptorResolver picturesDescriptorResolver() {
+            new FixedDescriptorResolver(new StorageDescriptor('pictures', 'test', 'pictures', null, 'pictures'))
+        }
+
+        @Singleton
+        StorageContainerMetadataRepository storageContainerMetadataRepository() {
+            new StubStorageContainerMetadataRepository()
+        }
+
+        @Singleton
+        StorageObjectMetadataRepository storageObjectMetadataRepository() {
+            new StubStorageObjectMetadataRepository()
+        }
+
+        @Singleton
+        StorageMetadataOutboxRepository storageMetadataOutboxRepository() {
+            new StubStorageMetadataOutboxRepository()
+        }
+    }
+
+    static class FixedDescriptorResolver implements io.micronaut.objectstorage.metadata.StorageDescriptorResolver {
+        private final StorageDescriptor descriptor
+
+        FixedDescriptorResolver(StorageDescriptor descriptor) {
+            this.descriptor = descriptor
+        }
+
+        @Override
+        StorageDescriptor resolve() {
+            descriptor
+        }
+    }
+
+    static class StubStorageContainerMetadataRepository implements StorageContainerMetadataRepository {
+        @Override
+        Optional<StorageContainerMetadataRecord> findByTenantAndDescriptor(String tenantId, StorageDescriptor descriptor) {
+            if (tenantId == 'tenant-a' && descriptor.storageName == 'pictures' && descriptor.logicalContainer == 'pictures') {
+                return Optional.of(new StorageContainerMetadataRecord(new StorageContainerMetadata(tenantId, descriptor, java.time.Instant.parse('2026-03-17T12:00:00Z'), java.time.Instant.parse('2026-03-17T12:00:00Z')), [kind: 'images']))
+            }
+            Optional.empty()
+        }
+
+        @Override
+        void upsert(StorageContainerMetadata metadata, Map<String, String> attributes) {
+        }
+    }
+
+    static class StubStorageObjectMetadataRepository implements StorageObjectMetadataRepository {
+        private final StorageObjectMetadataRecord picturesRecord = new StorageObjectMetadataRecord(
+            new StorageObjectMetadata('tenant-a', new StorageDescriptor('pictures', 'test', 'pictures', null, 'pictures'), '/logo.png', StorageObjectMetadata.deterministicObjectKeyHash('/logo.png'), 'image/png', 12L, 'etag-1', null, null, java.time.Instant.parse('2026-03-17T12:00:00Z'), java.time.Instant.parse('2026-03-17T12:00:00Z'), new ObjectMetadataSyncStatus(ObjectMetadataReconciliationState.SUCCEEDED, null)),
+            [owner: 'marketing']
+        )
+
+        @Override
+        Optional<StorageObjectMetadataRecord> findByTenantAndObjectHash(String tenantId, StorageDescriptor descriptor, String objectKeyHash) {
+            if (tenantId == 'tenant-a' && descriptor.storageName == 'pictures' && descriptor.logicalContainer == 'pictures' && objectKeyHash == picturesRecord.metadata().objectKeyHash) {
+                return Optional.of(picturesRecord)
+            }
+            Optional.empty()
+        }
+
+        @Override
+        List<StorageObjectMetadataRecord> listByTenantAndQuery(String tenantId, StorageObjectMetadataQuery query) {
+            if (tenantId != 'tenant-a') {
+                return []
+            }
+            return [picturesRecord].findAll { record ->
+                (!query.storageName.present || query.storageName.get() == record.metadata().storageName) &&
+                (!query.logicalContainer.present || query.logicalContainer.get() == record.metadata().logicalContainer) &&
+                (!query.objectKeyPrefix.present || record.metadata().objectKey.startsWith(query.objectKeyPrefix.get()))
+            }
+        }
+
+        @Override
+        void upsert(StorageObjectMetadata metadata, Map<String, String> attributes) {
+        }
+
+        @Override
+        void deleteByTenantAndObjectHash(String tenantId, StorageDescriptor storageDescriptor, String objectKeyHash) {
+        }
+    }
+
+    static class StubStorageMetadataOutboxRepository implements StorageMetadataOutboxRepository {
+        private final Map<String, StorageMetadataOutboxRecord> rows = [:]
+
+        @Override
+        void enqueue(StorageMetadataOutboxRecord outboxRecord) {
+            rows[outboxRecord.id] = outboxRecord
+        }
+
+        @Override
+        boolean enqueueIfAbsent(StorageMetadataOutboxRecord outboxRecord) {
+            if (rows.containsKey(outboxRecord.id)) {
+                return false
+            }
+            rows[outboxRecord.id] = outboxRecord
+            true
+        }
+
+        @Override
+        List<StorageMetadataOutboxRecord> findDueEntries(java.time.Instant asOf, int limit) { [] }
+
+        @Override
+        boolean markProcessing(String id, java.time.Instant asOf, java.time.Instant updatedAt) { false }
+
+        @Override
+        void markSucceeded(String id, java.time.Instant updatedAt) { }
+
+        @Override
+        void markRetryOrDeadLetter(String id, int attemptCount, java.time.Instant nextAttemptAt, io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxStatus status, String lastErrorSummary, java.time.Instant updatedAt) { }
+
+        @Override
+        Optional<StorageMetadataOutboxRecord> findById(String id) { Optional.ofNullable(rows[id]) }
+
+        @Override
+        Optional<StorageMetadataOutboxRecord> findByIdempotencyKey(String idempotencyKey) { Optional.empty() }
+    }
+
+    static class StubObjectStorageOperations implements ObjectStorageOperations<Object, Object, Object> {
+        @Override
+        io.micronaut.objectstorage.response.UploadResponse<Object> upload(io.micronaut.objectstorage.request.UploadRequest request) { throw new UnsupportedOperationException() }
+        @Override
+        io.micronaut.objectstorage.response.UploadResponse<Object> upload(io.micronaut.objectstorage.request.UploadRequest request, java.util.function.Consumer<Object> requestConsumer) { throw new UnsupportedOperationException() }
+        @Override
+        java.util.Optional retrieve(String key) { java.util.Optional.empty() }
+        @Override
+        Object delete(String key) { null }
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataQueryServiceSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataQueryServiceSpec.groovy
@@ -1,0 +1,69 @@
+package io.micronaut.objectstorage.metadata.jdbc
+
+import io.micronaut.objectstorage.metadata.ObjectMetadataReconciliationState
+import io.micronaut.objectstorage.metadata.ObjectMetadataSyncStatus
+import io.micronaut.objectstorage.metadata.StorageContainerMetadata
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata
+import io.micronaut.objectstorage.metadata.StorageObjectMetadataQuery
+import io.micronaut.objectstorage.metadata.TenantResolver
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository
+import spock.lang.Specification
+
+import java.time.Instant
+
+class MetadataQueryServiceSpec extends Specification {
+
+    void "findContainer and findObject resolve active tenant and hide non terminal states"() {
+        given:
+        TenantResolver tenantResolver = Stub() {
+            resolveTenantId() >> 'tenant-a'
+        }
+        StorageContainerMetadataRepository containerRepository = Mock()
+        StorageObjectMetadataRepository objectRepository = Mock()
+        def descriptor = new StorageDescriptor('pictures', 'oracle', 'reports', 'ns-a', 'bucket-a')
+        def containerMetadata = new StorageContainerMetadata('tenant-a', descriptor, Instant.parse('2026-03-17T12:00:00Z'), Instant.parse('2026-03-17T12:00:00Z'))
+        def visibleObject = objectMetadata('tenant-a', descriptor, '/2026/03/invoice-001.pdf', ObjectMetadataReconciliationState.SUCCEEDED)
+        def pendingObject = objectMetadata('tenant-a', descriptor, '/2026/03/invoice-002.pdf', ObjectMetadataReconciliationState.PENDING)
+        def operations = new DefaultObjectStorageMetadataOperations(tenantResolver, containerRepository, objectRepository)
+
+        when:
+        def container = operations.findContainer(descriptor)
+        def object = operations.findObject(descriptor, '/2026/03/invoice-001.pdf')
+        def hiddenObject = operations.findObject(descriptor, '/2026/03/invoice-002.pdf')
+
+        then:
+        container.present
+        container.get() == containerMetadata
+        object.present
+        object.get() == visibleObject
+        !hiddenObject.present
+
+        and:
+        1 * containerRepository.findByTenantAndDescriptor('tenant-a', descriptor) >> Optional.of(new StorageContainerMetadataRecord(containerMetadata, [region: 'eu-frankfurt-1']))
+        1 * objectRepository.findByTenantAndObjectHash('tenant-a', descriptor, StorageObjectMetadata.deterministicObjectKeyHash('/2026/03/invoice-001.pdf')) >> Optional.of(new StorageObjectMetadataRecord(visibleObject, [owner: 'alice']))
+        1 * objectRepository.findByTenantAndObjectHash('tenant-a', descriptor, StorageObjectMetadata.deterministicObjectKeyHash('/2026/03/invoice-002.pdf')) >> Optional.of(new StorageObjectMetadataRecord(pendingObject, [owner: 'alice']))
+        0 * _
+    }
+
+    private static StorageObjectMetadata objectMetadata(String tenantId, StorageDescriptor descriptor, String key, ObjectMetadataReconciliationState state) {
+        Instant now = Instant.parse('2026-03-17T12:00:00Z')
+        new StorageObjectMetadata(
+            tenantId,
+            descriptor,
+            key,
+            StorageObjectMetadata.deterministicObjectKeyHash(key),
+            'application/pdf',
+            100L,
+            'etag-1',
+            'version-1',
+            'sha256:abc',
+            now,
+            now,
+            new ObjectMetadataSyncStatus(state, state == ObjectMetadataReconciliationState.SUCCEEDED ? null : 'not visible yet')
+        )
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataTenantIsolationSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataTenantIsolationSpec.groovy
@@ -1,0 +1,70 @@
+package io.micronaut.objectstorage.metadata.jdbc
+
+import io.micronaut.objectstorage.metadata.ObjectMetadataReconciliationState
+import io.micronaut.objectstorage.metadata.ObjectMetadataSyncStatus
+import io.micronaut.objectstorage.metadata.StorageContainerMetadata
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata
+import io.micronaut.objectstorage.metadata.StorageObjectMetadataQuery
+import io.micronaut.objectstorage.metadata.TenantResolver
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository
+import spock.lang.Specification
+
+import java.time.Instant
+
+class MetadataTenantIsolationSpec extends Specification {
+
+    void "public query methods only use active tenant"() {
+        given:
+        TenantResolver tenantResolver = Stub() {
+            resolveTenantId() >> 'tenant-b'
+        }
+        StorageContainerMetadataRepository containerRepository = Mock()
+        StorageObjectMetadataRepository objectRepository = Mock()
+        def descriptor = new StorageDescriptor('pictures', 'oracle', 'reports', 'ns-b', 'bucket-b')
+        def object = objectMetadata('tenant-b', descriptor, '/2026/03/invoice-010.pdf')
+        def query = StorageObjectMetadataQuery.all().withStorageName('pictures').withLogicalContainer('reports')
+        def operations = new DefaultObjectStorageMetadataOperations(tenantResolver, containerRepository, objectRepository)
+
+        when:
+        def container = operations.findContainer(descriptor)
+        def found = operations.findObject(descriptor, '/2026/03/invoice-010.pdf')
+        def listed = operations.listObjects(query)
+
+        then:
+        !container.present
+        found.present
+        found.get() == object
+        listed == [object]
+
+        and:
+        1 * containerRepository.findByTenantAndDescriptor('tenant-b', descriptor) >> Optional.empty()
+        1 * objectRepository.findByTenantAndObjectHash('tenant-b', descriptor, StorageObjectMetadata.deterministicObjectKeyHash('/2026/03/invoice-010.pdf')) >> Optional.of(new StorageObjectMetadataRecord(object, [owner: 'bob']))
+        1 * objectRepository.listByTenantAndQuery('tenant-b', query) >> [new StorageObjectMetadataRecord(object, [owner: 'bob'])]
+        0 * containerRepository.findByTenantAndDescriptor('tenant-a', _)
+        0 * objectRepository.findByTenantAndObjectHash('tenant-a', _, _)
+        0 * objectRepository.listByTenantAndQuery('tenant-a', _)
+        0 * _
+    }
+
+    private static StorageObjectMetadata objectMetadata(String tenantId, StorageDescriptor descriptor, String key) {
+        Instant now = Instant.parse('2026-03-17T12:00:00Z')
+        new StorageObjectMetadata(
+            tenantId,
+            descriptor,
+            key,
+            StorageObjectMetadata.deterministicObjectKeyHash(key),
+            'application/pdf',
+            100L,
+            'etag-1',
+            'version-1',
+            'sha256:abc',
+            now,
+            now,
+            new ObjectMetadataSyncStatus(ObjectMetadataReconciliationState.SUCCEEDED, null)
+        )
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataUploadDispatchFailureSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataUploadDispatchFailureSpec.groovy
@@ -1,0 +1,4 @@
+package io.micronaut.objectstorage.metadata.jdbc
+
+class MetadataUploadDispatchFailureSpec extends MetadataUploadEnqueueFailureSpec {
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataUploadEnqueueFailureSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataUploadEnqueueFailureSpec.groovy
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc
+
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.metadata.MetadataDispatchException
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.TenantResolver
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRepository
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.objectstorage.response.UploadResponse
+import spock.lang.Specification
+
+class MetadataUploadEnqueueFailureSpec extends Specification {
+
+    void 'upload throws metadata dispatch exception when enqueue fails after storage success'() {
+        given:
+        def descriptor = new StorageDescriptor('photos', 'oracle-cloud', 'logical-photos', 'ns1', 'bucket-a')
+        def tenantResolver = Stub(TenantResolver) {
+            resolveTenantId() >> 'tenant-a'
+        }
+        def containerRepository = Mock(StorageContainerMetadataRepository)
+        def outboxRepository = Mock(StorageMetadataOutboxRepository)
+        def metadataOperations = new DefaultObjectStorageMetadataOperations(tenantResolver, containerRepository, Mock(io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository))
+        def delegate = Mock(ObjectStorageOperations)
+        def operations = new DefaultMetadataAwareObjectStorageOperations<>(
+            delegate,
+            metadataOperations,
+            descriptor,
+            tenantResolver,
+            containerRepository,
+            outboxRepository,
+            []
+        )
+        def request = UploadRequest.fromBytes('body'.bytes, 'nested/file.txt', 'text/plain')
+        def uploadResponse = UploadResponse.of(request.key, 'etag-1', 'native-response')
+
+        when:
+        operations.upload(request)
+
+        then:
+        1 * containerRepository.findByTenantAndDescriptor('tenant-a', descriptor) >> Optional.empty()
+        1 * delegate.upload(request) >> uploadResponse
+        1 * outboxRepository.enqueueIfAbsent(_ as StorageMetadataOutboxRecord) >> { throw new IllegalStateException('db down') }
+        def ex = thrown(MetadataDispatchException)
+        ex.operationContext.tenantId == 'tenant-a'
+        ex.operationContext.storageDescriptor == descriptor
+        ex.operationContext.objectKey == 'nested/file.txt'
+        ex.operationOutcome.uploadResponse.get().is(uploadResponse)
+        ex.reconciliationId.present
+        ex.cause.message == 'db down'
+    }
+
+    void 'partial-completion exception retains reconciliation and upload outcome details'() {
+        given:
+        def descriptor = new StorageDescriptor('photos', 'oracle-cloud', 'logical-photos', 'ns1', 'bucket-a')
+        def tenantResolver = Stub(TenantResolver) {
+            resolveTenantId() >> 'tenant-z'
+        }
+        def containerRepository = Mock(StorageContainerMetadataRepository)
+        def outboxRepository = Mock(StorageMetadataOutboxRepository)
+        def metadataOperations = new DefaultObjectStorageMetadataOperations(tenantResolver, containerRepository, Mock(io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository))
+        def delegate = Mock(ObjectStorageOperations)
+        def operations = new DefaultMetadataAwareObjectStorageOperations<>(
+            delegate,
+            metadataOperations,
+            descriptor,
+            tenantResolver,
+            containerRepository,
+            outboxRepository,
+            []
+        )
+        def request = UploadRequest.fromBytes('body'.bytes, 'nested/partial.txt', 'text/plain')
+        def uploadResponse = UploadResponse.of(request.key, 'etag-2', 'native-response-2')
+
+        when:
+        operations.upload(request)
+
+        then:
+        1 * containerRepository.findByTenantAndDescriptor('tenant-z', descriptor) >> Optional.empty()
+        1 * delegate.upload(request) >> uploadResponse
+        1 * outboxRepository.enqueueIfAbsent(_ as StorageMetadataOutboxRecord) >> { throw new IllegalStateException('dispatch write failed') }
+        def ex = thrown(MetadataDispatchException)
+        ex.operationContext.tenantId == 'tenant-z'
+        ex.operationContext.objectKey == 'nested/partial.txt'
+        ex.operationOutcome.uploadResponse.present
+        ex.operationOutcome.uploadResponse.get().is(uploadResponse)
+        ex.reconciliationId.present
+        ex.cause.message == 'dispatch write failed'
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataUploadReconciliationSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataUploadReconciliationSpec.groovy
@@ -1,0 +1,4 @@
+package io.micronaut.objectstorage.metadata.jdbc
+
+class MetadataUploadReconciliationSpec extends MetadataUploadWorkflowSpec {
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataUploadWorkflowSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/MetadataUploadWorkflowSpec.groovy
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc
+
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.metadata.ObjectMetadataReconciliationState
+import io.micronaut.objectstorage.metadata.ObjectMetadataSyncStatus
+import io.micronaut.objectstorage.metadata.ObjectStorageLifecycleHook
+import io.micronaut.objectstorage.metadata.ObjectStorageOperationContext
+import io.micronaut.objectstorage.metadata.StorageContainerMetadata
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata
+import io.micronaut.objectstorage.metadata.TenantResolver
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRecord
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRepository
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.objectstorage.response.UploadResponse
+import spock.lang.Specification
+
+import java.time.Instant
+
+class MetadataUploadWorkflowSpec extends Specification {
+
+    void 'upload resolves tenant and container, fires ordered before hooks, delegates upload, and enqueues outbox'() {
+        given:
+        def descriptor = new StorageDescriptor('photos', 'oracle-cloud', 'logical-photos', 'ns1', 'bucket-a')
+        def tenantResolver = Stub(TenantResolver) {
+            resolveTenantId() >> 'tenant-a'
+        }
+        def containerMetadata = new StorageContainerMetadata('tenant-a', descriptor, Instant.parse('2026-03-17T10:15:30Z'), Instant.parse('2026-03-17T10:15:30Z'))
+        def containerRecord = new StorageContainerMetadataRecord(containerMetadata, [region: 'iad'])
+        def containerRepository = Mock(StorageContainerMetadataRepository)
+        def outboxRepository = Mock(StorageMetadataOutboxRepository)
+        def metadataOperations = new DefaultObjectStorageMetadataOperations(tenantResolver, containerRepository, Mock(io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository))
+        def delegate = Mock(ObjectStorageOperations)
+        def events = []
+        def slowerHook = new RecordingHook(10, 'slower', events)
+        def fasterHook = new RecordingHook(0, 'faster', events)
+        def operations = new DefaultMetadataAwareObjectStorageOperations<>(
+            delegate,
+            metadataOperations,
+            descriptor,
+            tenantResolver,
+            containerRepository,
+            outboxRepository,
+            [slowerHook, fasterHook]
+        )
+        def request = UploadRequest.fromBytes('body'.bytes, 'nested/file.txt', 'text/plain')
+        request.metadata = [owner: 'micronaut']
+        def uploadResponse = UploadResponse.of(request.key, 'etag-1', 'native-response')
+
+        when:
+        def response = operations.upload(request)
+
+        then:
+        1 * containerRepository.findByTenantAndDescriptor('tenant-a', descriptor) >> Optional.of(containerRecord)
+        1 * delegate.upload(request) >> uploadResponse
+        1 * outboxRepository.enqueueIfAbsent(_ as StorageMetadataOutboxRecord) >> { StorageMetadataOutboxRecord record ->
+            assert record.tenantId == 'tenant-a'
+            assert record.storageName == 'photos'
+            assert record.logicalContainer == 'logical-photos'
+            assert record.objectKey.get() == 'nested/file.txt'
+            assert record.objectKeyHash.get() == StorageObjectMetadata.deterministicObjectKeyHash('nested/file.txt')
+            assert record.reconciliationId.present
+            assert record.idempotencyKey.contains('tenant-a|photos|UPLOAD|' + StorageObjectMetadata.deterministicObjectKeyHash('nested/file.txt'))
+        }
+        response.is(uploadResponse)
+        events == ['before:faster:tenant-a:nested/file.txt', 'before:slower:tenant-a:nested/file.txt']
+        fasterHook.seenContexts[0].storageDescriptor == descriptor
+        slowerHook.seenContexts[0].storageDescriptor == descriptor
+        fasterHook.seenContexts[0].uploadRequest.get().is(request)
+    }
+
+    void 'upload duplicate enqueue replay returns delegate response without dispatch exception'() {
+        given:
+        def descriptor = new StorageDescriptor('photos', 'oracle-cloud', 'logical-photos', 'ns1', 'bucket-a')
+        def tenantResolver = Stub(TenantResolver) {
+            resolveTenantId() >> 'tenant-a'
+        }
+        def containerRepository = Mock(StorageContainerMetadataRepository)
+        def outboxRepository = Mock(StorageMetadataOutboxRepository)
+        def metadataOperations = new DefaultObjectStorageMetadataOperations(tenantResolver, containerRepository, Mock(io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository))
+        def delegate = Mock(ObjectStorageOperations)
+        def events = []
+        def hook = new ErrorTrackingHook(events)
+        def operations = new DefaultMetadataAwareObjectStorageOperations<>(
+            delegate,
+            metadataOperations,
+            descriptor,
+            tenantResolver,
+            containerRepository,
+            outboxRepository,
+            [hook]
+        )
+        def request = UploadRequest.fromBytes('body'.bytes, 'nested/duplicate.txt', 'text/plain')
+        def uploadResponse = UploadResponse.of(request.key, 'etag-duplicate', 'native-response-duplicate')
+
+        when:
+        def response = operations.upload(request)
+
+        then:
+        1 * containerRepository.findByTenantAndDescriptor('tenant-a', descriptor) >> Optional.empty()
+        1 * delegate.upload(request) >> uploadResponse
+        1 * outboxRepository.enqueueIfAbsent(_ as StorageMetadataOutboxRecord) >> false
+        response.is(uploadResponse)
+        notThrown(io.micronaut.objectstorage.metadata.MetadataDispatchException)
+        events == ['before:UPLOAD:nested/duplicate.txt']
+        hook.errors.isEmpty()
+    }
+
+    private static final class RecordingHook implements ObjectStorageLifecycleHook {
+        final int order
+        final String name
+        final List<String> events
+        final List<ObjectStorageOperationContext> seenContexts = []
+
+        RecordingHook(int order, String name, List<String> events) {
+            this.order = order
+            this.name = name
+            this.events = events
+        }
+
+        @Override
+        int getOrder() {
+            return order
+        }
+
+        @Override
+        void before(ObjectStorageOperationContext context) {
+            seenContexts << context
+            events << "before:${name}:${context.tenantId}:${context.objectKey}".toString()
+        }
+    }
+
+    private static final class ErrorTrackingHook implements ObjectStorageLifecycleHook {
+        private final List<String> events
+        final List<Throwable> errors = []
+
+        ErrorTrackingHook(List<String> events) {
+            this.events = events
+        }
+
+        @Override
+        void before(ObjectStorageOperationContext context) {
+            events << "before:${context.operationType}:${context.objectKey}".toString()
+        }
+
+        @Override
+        void error(ObjectStorageOperationContext context, Throwable throwable) {
+            errors << throwable
+        }
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/StorageDescriptorAdapterSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/StorageDescriptorAdapterSpec.groovy
@@ -1,0 +1,129 @@
+package io.micronaut.objectstorage.metadata.jdbc
+
+import io.micronaut.objectstorage.configuration.AbstractObjectStorageConfiguration
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageDescriptorResolver
+import spock.lang.Specification
+
+class StorageDescriptorAdapterSpec extends Specification {
+
+    void 'provider descriptor adapters expose logical container identity consistently'() {
+        expect:
+        new AwsTestResolver(new AwsTestConfiguration('pictures', 'aws-bucket')).resolve().with {
+            storageName == 'pictures'
+            providerId == 'aws'
+            logicalContainer == 'aws-bucket'
+            providerNamespace.empty
+            providerContainer == 'aws-bucket'
+        }
+
+        new AzureTestResolver(new AzureTestConfiguration('logos', 'azure-container')).resolve().with {
+            storageName == 'logos'
+            providerId == 'azure'
+            logicalContainer == 'azure-container'
+            providerNamespace.empty
+            providerContainer == 'azure-container'
+        }
+
+        new GcpTestResolver(new GcpTestConfiguration('reports', 'gcp-bucket')).resolve().with {
+            storageName == 'reports'
+            providerId == 'gcp'
+            logicalContainer == 'gcp-bucket'
+            providerNamespace.empty
+            providerContainer == 'gcp-bucket'
+        }
+
+        new OciTestResolver(new OciTestConfiguration('archive', 'oci-bucket', 'oci-namespace')).resolve().with {
+            storageName == 'archive'
+            providerId == 'oracle-cloud'
+            logicalContainer == 'oci-bucket'
+            providerNamespace.get() == 'oci-namespace'
+            providerContainer == 'oci-bucket'
+            providerContainerIdentity == 'oci-namespace/oci-bucket'
+        }
+
+        new LocalTestResolver(new LocalTestConfiguration('default', 'build/storage/default')).resolve().with {
+            storageName == 'default'
+            providerId == 'local'
+            logicalContainer == 'default'
+            providerNamespace.present
+            providerContainer == 'default'
+        }
+    }
+
+    private static final class AwsTestResolver implements StorageDescriptorResolver {
+        private final StorageDescriptor descriptor
+        AwsTestResolver(AwsTestConfiguration configuration) {
+            descriptor = new StorageDescriptor(configuration.name, 'aws', configuration.bucket, null, configuration.bucket)
+        }
+        @Override
+        StorageDescriptor resolve() { descriptor }
+    }
+
+    private static final class AzureTestResolver implements StorageDescriptorResolver {
+        private final StorageDescriptor descriptor
+        AzureTestResolver(AzureTestConfiguration configuration) {
+            descriptor = new StorageDescriptor(configuration.name, 'azure', configuration.container, null, configuration.container)
+        }
+        @Override
+        StorageDescriptor resolve() { descriptor }
+    }
+
+    private static final class GcpTestResolver implements StorageDescriptorResolver {
+        private final StorageDescriptor descriptor
+        GcpTestResolver(GcpTestConfiguration configuration) {
+            descriptor = new StorageDescriptor(configuration.name, 'gcp', configuration.bucket, null, configuration.bucket)
+        }
+        @Override
+        StorageDescriptor resolve() { descriptor }
+    }
+
+    private static final class OciTestResolver implements StorageDescriptorResolver {
+        private final StorageDescriptor descriptor
+        OciTestResolver(OciTestConfiguration configuration) {
+            descriptor = new StorageDescriptor(configuration.name, 'oracle-cloud', configuration.bucket, configuration.namespace, configuration.bucket)
+        }
+        @Override
+        StorageDescriptor resolve() { descriptor }
+    }
+
+    private static final class LocalTestResolver implements StorageDescriptorResolver {
+        private final StorageDescriptor descriptor
+        LocalTestResolver(LocalTestConfiguration configuration) {
+            descriptor = new StorageDescriptor(configuration.name, 'local', configuration.name, configuration.path, configuration.name)
+        }
+        @Override
+        StorageDescriptor resolve() { descriptor }
+    }
+
+    private static final class AwsTestConfiguration extends AbstractObjectStorageConfiguration {
+        final String bucket
+        AwsTestConfiguration(String name, String bucket) { super(name); this.bucket = bucket }
+        @Override boolean isEnabled() { true }
+    }
+
+    private static final class AzureTestConfiguration extends AbstractObjectStorageConfiguration {
+        final String container
+        AzureTestConfiguration(String name, String container) { super(name); this.container = container }
+        @Override boolean isEnabled() { true }
+    }
+
+    private static final class GcpTestConfiguration extends AbstractObjectStorageConfiguration {
+        final String bucket
+        GcpTestConfiguration(String name, String bucket) { super(name); this.bucket = bucket }
+        @Override boolean isEnabled() { true }
+    }
+
+    private static final class OciTestConfiguration extends AbstractObjectStorageConfiguration {
+        final String bucket
+        final String namespace
+        OciTestConfiguration(String name, String bucket, String namespace) { super(name); this.bucket = bucket; this.namespace = namespace }
+        @Override boolean isEnabled() { true }
+    }
+
+    private static final class LocalTestConfiguration extends AbstractObjectStorageConfiguration {
+        final String path
+        LocalTestConfiguration(String name, String path) { super(name); this.path = path }
+        @Override boolean isEnabled() { true }
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/oracle/AbstractOracleMetadataJdbcSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/oracle/AbstractOracleMetadataJdbcSpec.groovy
@@ -1,0 +1,190 @@
+package io.micronaut.objectstorage.metadata.jdbc.oracle
+
+import io.micronaut.objectstorage.metadata.MetadataAwareObjectStorageOperations
+import io.micronaut.objectstorage.metadata.ObjectMetadataReconciliationState
+import io.micronaut.objectstorage.metadata.ObjectMetadataSyncStatus
+import io.micronaut.objectstorage.metadata.ObjectStorageMetadataOperations
+import io.micronaut.objectstorage.metadata.ObjectStorageOperationType
+import io.micronaut.objectstorage.metadata.StorageContainerMetadata
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata
+import io.micronaut.objectstorage.metadata.TenantResolver
+import io.micronaut.objectstorage.metadata.jdbc.repository.JdbcStorageContainerMetadataRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.JdbcStorageMetadataOutboxRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.JdbcStorageObjectMetadataRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository
+import io.micronaut.objectstorage.local.LocalStorageConfiguration
+import io.micronaut.objectstorage.local.LocalStorageOperations
+import oracle.jdbc.pool.OracleDataSource
+import org.testcontainers.oracle.OracleContainer
+import org.testcontainers.utility.DockerImageName
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.sql.Connection
+import java.time.Instant
+
+abstract class AbstractOracleMetadataJdbcSpec extends Specification {
+
+    private static final DockerImageName ORACLE_FREE = DockerImageName.parse('gvenzl/oracle-free:23-slim-faststart')
+
+    @Shared OracleContainer oracle = new OracleContainer(ORACLE_FREE)
+    @Shared OracleDataSource dataSource
+    @Shared StorageDescriptor descriptor = new StorageDescriptor('default', 'local', 'default', null, 'default')
+    @Shared MutableTenantResolver tenantResolver = new MutableTenantResolver()
+    @Shared StorageContainerMetadataRepository containerRepository
+    @Shared StorageObjectMetadataRepository objectRepository
+    @Shared StorageMetadataOutboxRepository outboxRepository
+    @Shared ObjectStorageMetadataOperations metadataOperations
+    @Shared MetadataAwareObjectStorageOperations operations
+    @Shared LocalStorageOperations delegate
+    @Shared java.nio.file.Path storagePath
+
+    void setupSpec() {
+        oracle.start()
+        dataSource = new OracleDataSource()
+        dataSource.URL = oracle.jdbcUrl
+        dataSource.user = oracle.username
+        dataSource.password = oracle.password
+        applySchema()
+        containerRepository = new JdbcStorageContainerMetadataRepository(dataSource)
+        objectRepository = new JdbcStorageObjectMetadataRepository(dataSource)
+        outboxRepository = new JdbcStorageMetadataOutboxRepository(dataSource)
+        metadataOperations = new io.micronaut.objectstorage.metadata.jdbc.DefaultObjectStorageMetadataOperations(descriptor, tenantResolver, containerRepository, objectRepository)
+        storagePath = Files.createTempDirectory('oracle-metadata-local-storage')
+        def configuration = new LocalStorageConfiguration('default')
+        configuration.path = storagePath
+        delegate = new LocalStorageOperations(configuration)
+        operations = new io.micronaut.objectstorage.metadata.jdbc.DefaultMetadataAwareObjectStorageOperations<>(
+            delegate,
+            metadataOperations,
+            descriptor,
+            tenantResolver,
+            containerRepository,
+            outboxRepository,
+            []
+        )
+    }
+
+    void setup() {
+        clearTables()
+        clearLocalStorage()
+        tenantResolver.tenantId = 'tenant-a'
+        seedContainer('tenant-a')
+        seedContainer('tenant-b')
+    }
+
+    void cleanupSpec() {
+        oracle.stop()
+    }
+
+    void reconcileAll() {
+        outboxRepository.findDueEntries(Instant.now().plusSeconds(5), 20).each { record ->
+            switch (record.operationType) {
+                case ObjectStorageOperationType.UPLOAD -> {
+                    def key = record.objectKey.orElseThrow()
+                    def hash = record.objectKeyHash.orElseGet { StorageObjectMetadata.deterministicObjectKeyHash(key) }
+                    objectRepository.upsert(new StorageObjectMetadata(
+                        record.tenantId,
+                        descriptor,
+                        key,
+                        hash,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        Instant.now(),
+                        Instant.now(),
+                        new ObjectMetadataSyncStatus(ObjectMetadataReconciliationState.SUCCEEDED, null)
+                    ), [:])
+                }
+                case ObjectStorageOperationType.COPY -> {
+                    def sourceKey = record.objectKey.orElseThrow()
+                    def sourceHash = record.objectKeyHash.orElseGet { StorageObjectMetadata.deterministicObjectKeyHash(sourceKey) }
+                    def source = objectRepository.findByTenantAndObjectHash(record.tenantId, descriptor, sourceHash).orElseThrow()
+                    def destinationKey = record.destinationObjectKey.orElseThrow()
+                    def destinationHash = record.destinationObjectKeyHash.orElseGet { StorageObjectMetadata.deterministicObjectKeyHash(destinationKey) }
+                    def sourceMetadata = source.metadata()
+                    objectRepository.upsert(new StorageObjectMetadata(
+                        record.tenantId,
+                        descriptor,
+                        destinationKey,
+                        destinationHash,
+                        sourceMetadata.contentType.orElse(null),
+                        sourceMetadata.contentLength.present ? sourceMetadata.contentLength.asLong : null,
+                        sourceMetadata.etag.orElse(null),
+                        sourceMetadata.providerVersionId.orElse(null),
+                        sourceMetadata.checksum.orElse(null),
+                        sourceMetadata.createdAt,
+                        Instant.now(),
+                        new ObjectMetadataSyncStatus(ObjectMetadataReconciliationState.SUCCEEDED, null)
+                    ), source.attributes())
+                }
+                case ObjectStorageOperationType.DELETE -> {
+                    def hash = record.objectKeyHash.orElseGet { StorageObjectMetadata.deterministicObjectKeyHash(record.objectKey.orElseThrow()) }
+                    objectRepository.deleteByTenantAndObjectHash(record.tenantId, descriptor, hash)
+                }
+            }
+            outboxRepository.markSucceeded(record.id, Instant.now())
+        }
+    }
+
+    void seedContainer(String tenantId) {
+        containerRepository.upsert(new StorageContainerMetadata(tenantId, descriptor, Instant.now(), Instant.now()), [tenant: tenantId])
+    }
+
+    private void clearTables() {
+        withConnection {
+            it.createStatement().withCloseable { statement ->
+                statement.executeUpdate('DELETE FROM storage_object_metadata_attr')
+                statement.executeUpdate('DELETE FROM storage_object_metadata')
+                statement.executeUpdate('DELETE FROM storage_container_metadata_attr')
+                statement.executeUpdate('DELETE FROM storage_container_metadata')
+                statement.executeUpdate('DELETE FROM storage_metadata_outbox')
+            }
+            it.commit()
+        }
+    }
+
+    private void clearLocalStorage() {
+        if (Files.exists(storagePath)) {
+            Files.walk(storagePath)
+                .sorted(Comparator.reverseOrder())
+                .filter { it != storagePath }
+                .forEach { Files.deleteIfExists(it) }
+        }
+    }
+
+    private void applySchema() {
+        String sql = AbstractOracleMetadataJdbcSpec.classLoader.getResource('db/metadata/oracle/schema-v1.sql').text
+        withConnection {
+            sql.split(';')
+                .collect { it.trim() }
+                .findAll { !it.isBlank() }
+                .each { stmt -> it.createStatement().execute(stmt) }
+            it.commit()
+        }
+    }
+
+    private void withConnection(Closure<?> action) {
+        Connection connection = dataSource.connection
+        try {
+            connection.autoCommit = false
+            action.call(connection)
+        } finally {
+            connection.close()
+        }
+    }
+
+    static final class MutableTenantResolver implements TenantResolver {
+        String tenantId = 'tenant-a'
+        @Override
+        String resolveTenantId() {
+            tenantId
+        }
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/oracle/MetadataJdbcOracleDeadLetterSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/oracle/MetadataJdbcOracleDeadLetterSpec.groovy
@@ -1,0 +1,4 @@
+package io.micronaut.objectstorage.metadata.jdbc.oracle
+
+class MetadataJdbcOracleDeadLetterSpec extends MetadataJdbcOracleFailureSpec {
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/oracle/MetadataJdbcOracleFailureSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/oracle/MetadataJdbcOracleFailureSpec.groovy
@@ -1,0 +1,48 @@
+package io.micronaut.objectstorage.metadata.jdbc.oracle
+
+import io.micronaut.objectstorage.metadata.MetadataDispatchException
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRepository
+import io.micronaut.objectstorage.request.UploadRequest
+
+class MetadataJdbcOracleFailureSpec extends AbstractOracleMetadataJdbcSpec {
+
+    void 'oracle failure path reports enqueue failure and preserves tenant isolation'() {
+        given:
+        def failingOutboxRepository = [
+            enqueue: { throw new IllegalStateException('oracle enqueue failed') },
+            enqueueIfAbsent: { throw new IllegalStateException('oracle enqueue failed') },
+            findDueEntries: { _, _ -> [] },
+            markProcessing: { _, _, _ -> false },
+            markSucceeded: { _, _ -> },
+            markRetryOrDeadLetter: { _, _, _, _, _, _ -> },
+            findById: { Optional.empty() },
+            findByIdempotencyKey: { Optional.empty() }
+        ] as StorageMetadataOutboxRepository
+        def failingOperations = new io.micronaut.objectstorage.metadata.jdbc.DefaultMetadataAwareObjectStorageOperations<>(
+            delegate,
+            metadataOperations,
+            descriptor,
+            tenantResolver,
+            containerRepository,
+            failingOutboxRepository,
+            []
+        )
+        def upload = UploadRequest.fromBytes('hello oracle'.bytes, 'reports/2026/failure.txt', 'text/plain')
+
+        when:
+        failingOperations.upload(upload)
+
+        then:
+        def ex = thrown(MetadataDispatchException)
+        ex.operationContext.tenantId == 'tenant-a'
+        ex.operationContext.objectKey == 'reports/2026/failure.txt'
+        ex.cause.message == 'oracle enqueue failed'
+        !metadataOperations.findObject(descriptor, 'reports/2026/failure.txt').present
+
+        when:
+        tenantResolver.tenantId = 'tenant-b'
+
+        then:
+        !metadataOperations.findObject(descriptor, 'reports/2026/failure.txt').present
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/oracle/MetadataJdbcOracleIntegrationSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/oracle/MetadataJdbcOracleIntegrationSpec.groovy
@@ -1,0 +1,43 @@
+package io.micronaut.objectstorage.metadata.jdbc.oracle
+
+import io.micronaut.objectstorage.metadata.StorageObjectMetadataQuery
+import io.micronaut.objectstorage.request.UploadRequest
+
+class MetadataJdbcOracleIntegrationSpec extends AbstractOracleMetadataJdbcSpec {
+
+    void 'oracle integration verifies upload query copy delete reconciliation and tenant isolation'() {
+        given:
+        def upload = UploadRequest.fromBytes('hello oracle'.bytes, 'reports/2026/summary.txt', 'text/plain')
+        upload.metadata = [owner: 'tenant-a', source: 'oracle-spec']
+
+        when:
+        operations.upload(upload)
+        reconcileAll()
+
+        then:
+        metadataOperations.findObject(descriptor, 'reports/2026/summary.txt').present
+        metadataOperations.listObjects(StorageObjectMetadataQuery.all().withStorageName('default').withLogicalContainer('default'))*.objectKey == ['reports/2026/summary.txt']
+
+        when:
+        operations.copy('reports/2026/summary.txt', 'reports/2026/summary-copy.txt')
+        reconcileAll()
+
+        then:
+        metadataOperations.findObject(descriptor, 'reports/2026/summary-copy.txt').present
+
+        when:
+        operations.delete('reports/2026/summary.txt')
+        reconcileAll()
+
+        then:
+        !metadataOperations.findObject(descriptor, 'reports/2026/summary.txt').present
+        metadataOperations.findObject(descriptor, 'reports/2026/summary-copy.txt').present
+
+        when:
+        tenantResolver.tenantId = 'tenant-b'
+
+        then:
+        !metadataOperations.findObject(descriptor, 'reports/2026/summary-copy.txt').present
+        metadataOperations.listObjects(StorageObjectMetadataQuery.all().withStorageName('default').withLogicalContainer('default')).isEmpty()
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/oracle/MetadataJdbcOracleTenantIsolationSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/oracle/MetadataJdbcOracleTenantIsolationSpec.groovy
@@ -1,0 +1,4 @@
+package io.micronaut.objectstorage.metadata.jdbc.oracle
+
+class MetadataJdbcOracleTenantIsolationSpec extends MetadataJdbcOracleIntegrationSpec {
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/postgres/AbstractPostgresMetadataJdbcSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/postgres/AbstractPostgresMetadataJdbcSpec.groovy
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc.postgres
+
+import io.micronaut.objectstorage.metadata.MetadataAwareObjectStorageOperations
+import io.micronaut.objectstorage.metadata.ObjectMetadataReconciliationState
+import io.micronaut.objectstorage.metadata.ObjectMetadataSyncStatus
+import io.micronaut.objectstorage.metadata.ObjectStorageMetadataOperations
+import io.micronaut.objectstorage.metadata.ObjectStorageOperationType
+import io.micronaut.objectstorage.metadata.StorageContainerMetadata
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageObjectMetadata
+import io.micronaut.objectstorage.metadata.TenantResolver
+import io.micronaut.objectstorage.metadata.jdbc.DefaultMetadataAwareObjectStorageOperations
+import io.micronaut.objectstorage.metadata.jdbc.DefaultObjectStorageMetadataOperations
+import io.micronaut.objectstorage.metadata.jdbc.repository.JdbcStorageContainerMetadataRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.JdbcStorageMetadataOutboxRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.JdbcStorageObjectMetadataRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageContainerMetadataRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageMetadataOutboxRepository
+import io.micronaut.objectstorage.metadata.jdbc.repository.StorageObjectMetadataRepository
+import io.micronaut.objectstorage.local.LocalStorageConfiguration
+import io.micronaut.objectstorage.local.LocalStorageOperations
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.sql.Connection
+import java.time.Instant
+
+abstract class AbstractPostgresMetadataJdbcSpec extends Specification {
+
+    private static final DockerImageName POSTGRES = DockerImageName.parse('postgres:16-alpine')
+
+    @Shared PostgreSQLContainer postgres = new PostgreSQLContainer(POSTGRES)
+    @Shared PGSimpleDataSource dataSource
+    @Shared StorageDescriptor descriptor = new StorageDescriptor('default', 'local', 'default', null, 'default')
+    @Shared MutableTenantResolver tenantResolver = new MutableTenantResolver()
+    @Shared StorageContainerMetadataRepository containerRepository
+    @Shared StorageObjectMetadataRepository objectRepository
+    @Shared StorageMetadataOutboxRepository outboxRepository
+    @Shared ObjectStorageMetadataOperations metadataOperations
+    @Shared MetadataAwareObjectStorageOperations operations
+    @Shared LocalStorageOperations delegate
+    @Shared java.nio.file.Path storagePath
+
+    void setupSpec() {
+        postgres.start()
+        dataSource = new PGSimpleDataSource()
+        dataSource.URL = postgres.jdbcUrl
+        dataSource.user = postgres.username
+        dataSource.password = postgres.password
+        applySchema()
+        containerRepository = new JdbcStorageContainerMetadataRepository(dataSource)
+        objectRepository = new JdbcStorageObjectMetadataRepository(dataSource)
+        outboxRepository = new JdbcStorageMetadataOutboxRepository(dataSource)
+        metadataOperations = new DefaultObjectStorageMetadataOperations(tenantResolver, containerRepository, objectRepository)
+        storagePath = Files.createTempDirectory('postgres-metadata-local-storage')
+        def configuration = new LocalStorageConfiguration('default')
+        configuration.path = storagePath
+        delegate = new LocalStorageOperations(configuration)
+        operations = new DefaultMetadataAwareObjectStorageOperations<>(
+            delegate,
+            metadataOperations,
+            descriptor,
+            tenantResolver,
+            containerRepository,
+            outboxRepository,
+            []
+        )
+    }
+
+    void setup() {
+        clearTables()
+        clearLocalStorage()
+        tenantResolver.tenantId = 'tenant-a'
+        seedContainer('tenant-a')
+        seedContainer('tenant-b')
+    }
+
+    void cleanupSpec() {
+        postgres.stop()
+    }
+
+    void reconcileAll() {
+        outboxRepository.findDueEntries(Instant.now().plusSeconds(5), 20).each { record ->
+            switch (record.operationType) {
+                case ObjectStorageOperationType.UPLOAD -> {
+                    def key = record.objectKey.orElseThrow()
+                    def hash = record.objectKeyHash.orElseGet { StorageObjectMetadata.deterministicObjectKeyHash(key) }
+                    objectRepository.upsert(new StorageObjectMetadata(
+                        record.tenantId,
+                        descriptor,
+                        key,
+                        hash,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        Instant.now(),
+                        Instant.now(),
+                        new ObjectMetadataSyncStatus(ObjectMetadataReconciliationState.SUCCEEDED, null)
+                    ), [:])
+                }
+                case ObjectStorageOperationType.COPY -> {
+                    def sourceKey = record.objectKey.orElseThrow()
+                    def sourceHash = record.objectKeyHash.orElseGet { StorageObjectMetadata.deterministicObjectKeyHash(sourceKey) }
+                    def source = objectRepository.findByTenantAndObjectHash(record.tenantId, descriptor, sourceHash).orElseThrow()
+                    def destinationKey = record.destinationObjectKey.orElseThrow()
+                    def destinationHash = record.destinationObjectKeyHash.orElseGet { StorageObjectMetadata.deterministicObjectKeyHash(destinationKey) }
+                    objectRepository.upsert(new StorageObjectMetadata(
+                        record.tenantId,
+                        descriptor,
+                        destinationKey,
+                        destinationHash,
+                        source.metadata().contentType.orElse(null),
+                        source.metadata().contentLength.present ? source.metadata().contentLength.asLong : null,
+                        source.metadata().etag.orElse(null),
+                        source.metadata().providerVersionId.orElse(null),
+                        source.metadata().checksum.orElse(null),
+                        source.metadata().createdAt,
+                        Instant.now(),
+                        new ObjectMetadataSyncStatus(ObjectMetadataReconciliationState.SUCCEEDED, null)
+                    ), source.attributes())
+                }
+                case ObjectStorageOperationType.DELETE -> {
+                    def hash = record.objectKeyHash.orElseGet { StorageObjectMetadata.deterministicObjectKeyHash(record.objectKey.orElseThrow()) }
+                    objectRepository.deleteByTenantAndObjectHash(record.tenantId, descriptor, hash)
+                }
+            }
+            outboxRepository.markSucceeded(record.id, Instant.now())
+        }
+    }
+
+    int tableCount(String tableName) {
+        withConnection { connection ->
+            connection.prepareStatement('SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = current_schema() AND table_name = ?').withCloseable { statement ->
+                statement.setString(1, tableName)
+                def resultSet = statement.executeQuery()
+                resultSet.next()
+                return resultSet.getInt(1)
+            }
+        }
+    }
+
+    void seedContainer(String tenantId) {
+        containerRepository.upsert(new StorageContainerMetadata(tenantId, descriptor, Instant.now(), Instant.now()), [tenant: tenantId])
+    }
+
+    private void clearTables() {
+        withConnection {
+            it.createStatement().withCloseable { statement ->
+                statement.executeUpdate('DELETE FROM storage_object_metadata_attr')
+                statement.executeUpdate('DELETE FROM storage_object_metadata')
+                statement.executeUpdate('DELETE FROM storage_container_metadata_attr')
+                statement.executeUpdate('DELETE FROM storage_container_metadata')
+                statement.executeUpdate('DELETE FROM storage_metadata_outbox')
+            }
+            it.commit()
+        }
+    }
+
+    private void clearLocalStorage() {
+        if (Files.exists(storagePath)) {
+            Files.walk(storagePath)
+                .sorted(Comparator.reverseOrder())
+                .filter { it != storagePath }
+                .forEach { Files.deleteIfExists(it) }
+        }
+    }
+
+    private void applySchema() {
+        String sql = AbstractPostgresMetadataJdbcSpec.classLoader.getResource('db/metadata/postgresql/schema-v1.sql').text
+        withConnection {
+            sql.split(';')
+                .collect { it.trim() }
+                .findAll { !it.isBlank() }
+                .each { stmt -> it.createStatement().execute(stmt) }
+            it.commit()
+        }
+    }
+
+    private <T> T withConnection(Closure<T> action) {
+        Connection connection = dataSource.connection
+        try {
+            connection.autoCommit = false
+            return action.call(connection)
+        } finally {
+            connection.close()
+        }
+    }
+
+    static final class MutableTenantResolver implements TenantResolver {
+        String tenantId = 'tenant-a'
+
+        @Override
+        String resolveTenantId() {
+            tenantId
+        }
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/postgres/MetadataJdbcPostgresSmokeSpec.groovy
+++ b/object-storage-metadata-jdbc/src/test/groovy/io/micronaut/objectstorage/metadata/jdbc/postgres/MetadataJdbcPostgresSmokeSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata.jdbc.postgres
+
+import io.micronaut.objectstorage.metadata.StorageDescriptor
+import io.micronaut.objectstorage.metadata.StorageObjectMetadataQuery
+import io.micronaut.objectstorage.request.UploadRequest
+
+class MetadataJdbcPostgresSmokeSpec extends AbstractPostgresMetadataJdbcSpec {
+
+    void 'postgres smoke verifies schema creation upload reconciliation exact lookup prefix query and qualifier portability'() {
+        expect:
+        tableCount('storage_container_metadata') == 1
+        tableCount('storage_container_metadata_attr') == 1
+        tableCount('storage_object_metadata') == 1
+        tableCount('storage_object_metadata_attr') == 1
+        tableCount('storage_metadata_outbox') == 1
+
+        when:
+        def januaryUpload = UploadRequest.fromBytes('jan'.bytes, 'reports/2026/03/summary-a.txt', 'text/plain')
+        januaryUpload.metadata = [owner: 'tenant-a', source: 'postgres-smoke']
+        operations.upload(januaryUpload)
+        reconcileAll()
+        def exactLookup = metadataOperations.findObject(descriptor, 'reports/2026/03/summary-a.txt')
+        def prefixQuery = metadataOperations.listObjects(StorageObjectMetadataQuery.all()
+            .withStorageName('default')
+            .withLogicalContainer('default')
+            .withObjectKeyPrefix('reports/2026/03/'))
+
+        then:
+        exactLookup.present
+        exactLookup.get().objectKey == 'reports/2026/03/summary-a.txt'
+        prefixQuery*.objectKey == ['reports/2026/03/summary-a.txt']
+        exactLookup.get().storageName == 'default'
+        exactLookup.get().providerId == 'local'
+        exactLookup.get().logicalContainer == 'default'
+
+        when:
+        tenantResolver.tenantId = 'tenant-b'
+
+        then:
+        !metadataOperations.findObject(descriptor, 'reports/2026/03/summary-a.txt').present
+        metadataOperations.listObjects(StorageObjectMetadataQuery.all()
+            .withStorageName('default')
+            .withLogicalContainer('default')
+            .withObjectKeyPrefix('reports/2026/03/')).isEmpty()
+    }
+}

--- a/object-storage-metadata-jdbc/src/test/resources/application-oracle.properties
+++ b/object-storage-metadata-jdbc/src/test/resources/application-oracle.properties
@@ -1,0 +1,7 @@
+micronaut.object-storage.metadata.jdbc.enabled=true
+micronaut.object-storage.metadata.jdbc.datasource=default
+micronaut.object-storage.metadata.jdbc.reconciliation.fixed-delay=1h
+micronaut.object-storage.metadata.jdbc.reconciliation.max-attempts=2
+
+object-storage.local.default.enabled=true
+object-storage.local.default.path=${java.io.tmpdir}/micronaut-object-storage-metadata-jdbc-oracle

--- a/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageDescriptorResolver.java
+++ b/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageDescriptorResolver.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.oraclecloud;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.objectstorage.metadata.StorageDescriptor;
+import io.micronaut.objectstorage.metadata.StorageDescriptorResolver;
+
+@EachBean(OracleCloudStorageConfiguration.class)
+public final class OracleCloudStorageDescriptorResolver implements StorageDescriptorResolver {
+
+    private static final String PROVIDER_ID = "oracle-cloud";
+
+    private final StorageDescriptor descriptor;
+
+    public OracleCloudStorageDescriptorResolver(@Parameter OracleCloudStorageConfiguration configuration) {
+        this.descriptor = new StorageDescriptor(
+            configuration.getName(),
+            PROVIDER_ID,
+            configuration.getBucket(),
+            configuration.getNamespace(),
+            configuration.getBucket()
+        );
+    }
+
+    @Override
+    public StorageDescriptor resolve() {
+        return descriptor;
+    }
+}

--- a/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/metadata/ObjectStorageMetadataSpecification.groovy
+++ b/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/metadata/ObjectStorageMetadataSpecification.groovy
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata
+
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.objectstorage.response.UploadResponse
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+
+abstract class ObjectStorageMetadataSpecification extends Specification {
+
+    static final String TEXT = 'micronaut'
+    static final Map<String, String> METADATA = [project: 'micronaut-object-storage']
+    static final String CONTENT_TYPE = 'text/plain'
+
+    private static final Instant NOW = Instant.parse('2026-03-17T16:00:00Z')
+
+    void 'it resolves exact lookups, prefix listings, scoping, ordered hooks and reconciliation visibility'() {
+        given:
+        MetadataTckFixture fixture = getMetadataFixture()
+        PollingConditions conditions = new PollingConditions(timeout: 10)
+        StorageDescriptor primary = fixture.primaryStorageDescriptor
+        StorageDescriptor secondary = fixture.secondaryStorageDescriptor
+
+        and:
+        fixture.seedPendingMetadata(metadata(primary, 'tenant-alpha', 'images/avatar.png', ObjectMetadataReconciliationState.PENDING))
+        fixture.seedSucceededMetadata(metadata(primary, 'tenant-alpha', 'images/banner.png', ObjectMetadataReconciliationState.SUCCEEDED))
+        fixture.seedSucceededMetadata(metadata(primary, 'tenant-beta', 'images/avatar.png', ObjectMetadataReconciliationState.SUCCEEDED))
+        fixture.seedSucceededMetadata(metadata(secondary, 'tenant-alpha', 'images/avatar.png', ObjectMetadataReconciliationState.SUCCEEDED))
+
+        when:
+        Optional<StorageObjectMetadata> exactMatch = fixture.withTenant('tenant-alpha') {
+            fixture.metadataOperations.findObject(primary, 'images/avatar.png')
+        }
+
+        then:
+        !exactMatch.present
+
+        when:
+        List<StorageObjectMetadata> tenantAlphaPrefixMatches = fixture.withTenant('tenant-alpha') {
+            fixture.metadataOperations.listObjects(StorageObjectMetadataQuery.all()
+                .withStorageName(primary.storageName)
+                .withLogicalContainer(primary.logicalContainer)
+                .withObjectKeyPrefix('images/'))
+        }
+        List<StorageObjectMetadata> tenantBetaPrefixMatches = fixture.withTenant('tenant-beta') {
+            fixture.metadataOperations.listObjects(StorageObjectMetadataQuery.all()
+                .withStorageName(primary.storageName)
+                .withLogicalContainer(primary.logicalContainer)
+                .withObjectKeyPrefix('images/'))
+        }
+        List<StorageObjectMetadata> tenantAlphaSecondaryMatches = fixture.withTenant('tenant-alpha') {
+            fixture.metadataOperations.listObjects(StorageObjectMetadataQuery.all()
+                .withStorageName(secondary.storageName)
+                .withLogicalContainer(secondary.logicalContainer)
+                .withObjectKeyPrefix('images/'))
+        }
+
+        then:
+        tenantAlphaPrefixMatches*.objectKey == ['images/banner.png']
+        tenantBetaPrefixMatches*.tenantId == ['tenant-beta']
+        tenantBetaPrefixMatches*.objectKey == ['images/avatar.png']
+        tenantAlphaSecondaryMatches*.storageName == [secondary.storageName]
+        tenantAlphaSecondaryMatches*.logicalContainer == [secondary.logicalContainer]
+
+        when:
+        UploadRequest uploadRequest = UploadRequest.fromBytes(TEXT.bytes, 'images/avatar.png', CONTENT_TYPE)
+        uploadRequest.metadata = METADATA
+        UploadResponse<?> uploadResponse = fixture.withTenant('tenant-alpha') {
+            fixture.upload(primary, uploadRequest)
+        }
+
+        then:
+        uploadResponse.key == 'images/avatar.png'
+        fixture.lifecycleEvents*.phase == ['before', 'before', 'after', 'after']
+        fixture.lifecycleEvents*.hookName == ['high-precedence', 'low-precedence', 'high-precedence', 'low-precedence']
+        fixture.lifecycleEvents.every { it.context.tenantId == 'tenant-alpha' }
+        fixture.lifecycleEvents.every { it.context.storageDescriptor.storageName == primary.storageName }
+        fixture.lifecycleEvents.every { it.context.objectKey == 'images/avatar.png' }
+        fixture.lifecycleEvents.findAll { it.phase == 'after' }.every {
+            it.outcome.reconciliationId.present && it.outcome.reconciliationId.get() == fixture.reconciliationIdFor('images/avatar.png')
+        }
+
+        when:
+        Optional<StorageObjectMetadata> immediateLookup = fixture.withTenant('tenant-alpha') {
+            fixture.metadataOperations.findObject(primary, 'images/avatar.png')
+        }
+
+        then:
+        !immediateLookup.present
+
+        when:
+        conditions.eventually {
+            assert fixture.withTenant('tenant-alpha') {
+                fixture.metadataOperations.findObject(primary, 'images/avatar.png')
+            }.present
+        }
+        Optional<StorageObjectMetadata> reconciledLookup = fixture.withTenant('tenant-alpha') {
+            fixture.metadataOperations.findObject(primary, 'images/avatar.png')
+        }
+
+        then:
+        reconciledLookup.present
+        reconciledLookup.get().tenantId == 'tenant-alpha'
+        reconciledLookup.get().storageName == primary.storageName
+        reconciledLookup.get().logicalContainer == primary.logicalContainer
+        reconciledLookup.get().objectKey == 'images/avatar.png'
+        reconciledLookup.get().contentType.get() == CONTENT_TYPE
+        reconciledLookup.get().reconciliationStatus == ObjectMetadataReconciliationState.SUCCEEDED
+
+        when:
+        StorageContainerMetadata container = fixture.withTenant('tenant-alpha') {
+            fixture.metadataOperations.findContainer(primary).orElseThrow()
+        }
+
+        then:
+        container.tenantId == 'tenant-alpha'
+        container.storageDescriptor.storageName == primary.storageName
+    }
+
+    void 'it dispatches hook failures after partial completion'() {
+        given:
+        MetadataTckFixture fixture = getMetadataFixture()
+        StorageDescriptor primary = fixture.primaryStorageDescriptor
+        UploadRequest uploadRequest = UploadRequest.fromBytes(TEXT.bytes, 'images/failure.png', CONTENT_TYPE)
+        uploadRequest.metadata = METADATA
+
+        when:
+        fixture.withTenant('tenant-alpha') {
+            fixture.uploadWithError(primary, uploadRequest)
+        }
+
+        then:
+        MetadataDispatchException e = thrown()
+        e.operationContext.tenantId == 'tenant-alpha'
+        e.operationContext.storageDescriptor.storageName == primary.storageName
+        e.operationContext.objectKey == 'images/failure.png'
+        e.operationOutcome.operationType == ObjectStorageOperationType.UPLOAD
+        e.operationOutcome.objectKey == 'images/failure.png'
+        e.reconciliationId.present
+        fixture.lifecycleEvents*.phase == ['before', 'before', 'error']
+        fixture.lifecycleEvents*.hookName == ['high-precedence', 'low-precedence', 'high-precedence']
+        fixture.lifecycleEvents.last().throwable.is(e)
+    }
+
+    abstract MetadataTckFixture getMetadataFixture()
+
+    static Path createTempFile() {
+        Path path = Files.createTempFile('test-file', '.txt')
+        path.toFile().text = TEXT
+        path
+    }
+
+    private static StorageObjectMetadata metadata(StorageDescriptor descriptor, String tenantId, String objectKey, ObjectMetadataReconciliationState state) {
+        new StorageObjectMetadata(
+            tenantId,
+            descriptor,
+            objectKey,
+            null,
+            CONTENT_TYPE,
+            TEXT.length() as Long,
+            "etag-${tenantId}-${objectKey}",
+            'v1',
+            null,
+            NOW,
+            NOW,
+            new ObjectMetadataSyncStatus(state, null)
+        )
+    }
+
+    static abstract class MetadataTckFixture {
+        abstract ObjectStorageMetadataOperations getMetadataOperations()
+
+        abstract StorageDescriptor getPrimaryStorageDescriptor()
+
+        abstract StorageDescriptor getSecondaryStorageDescriptor()
+
+        abstract void seedPendingMetadata(StorageObjectMetadata metadata)
+
+        abstract void seedSucceededMetadata(StorageObjectMetadata metadata)
+
+        abstract UploadResponse<?> upload(StorageDescriptor descriptor, UploadRequest uploadRequest)
+
+        abstract UploadResponse<?> uploadWithError(StorageDescriptor descriptor, UploadRequest uploadRequest)
+
+        abstract List<LifecycleEvent> getLifecycleEvents()
+
+        abstract String reconciliationIdFor(String objectKey)
+
+        abstract <T> T withTenant(String tenantId, Closure<T> callable)
+    }
+
+    static final class LifecycleEvent {
+        final String phase
+        final String hookName
+        final ObjectStorageOperationContext context
+        final ObjectStorageOperationOutcome outcome
+        final Throwable throwable
+
+        LifecycleEvent(String phase,
+                       String hookName,
+                       ObjectStorageOperationContext context,
+                       ObjectStorageOperationOutcome outcome = null,
+                       Throwable throwable = null) {
+            this.phase = phase
+            this.hookName = hookName
+            this.context = context
+            this.outcome = outcome
+            this.throwable = throwable
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ include("object-storage-azure")
 include("object-storage-gcp")
 include("object-storage-oracle-cloud")
 include("object-storage-local")
+include("object-storage-metadata-jdbc")
 
 include("doc-examples:example-java")
 include("doc-examples:example-groovy")
@@ -36,6 +37,8 @@ configure<MicronautBuildSettingsExtension> {
     importMicronautCatalog("micronaut-azure")
     importMicronautCatalog("micronaut-gcp")
     importMicronautCatalog("micronaut-oracle-cloud")
+    importMicronautCatalog("micronaut-data")
+    importMicronautCatalog("micronaut-sql")
     importMicronautCatalog("micronaut-test-resources")
     importMicronautCatalog("micronaut-validation")
 }

--- a/src/main/docs/guide/metadataPersistence.adoc
+++ b/src/main/docs/guide/metadataPersistence.adoc
@@ -1,0 +1,94 @@
+= Metadata persistence
+
+Micronaut Object Storage can persist container and object metadata in JDBC-backed storage through the `micronaut-object-storage-metadata-jdbc` module.
+
+Add the dependency to your application:
+
+dependency:io.micronaut.objectstorage:micronaut-object-storage-metadata-jdbc[]
+
+The module contributes `ObjectStorageMetadataJdbcConfiguration` under the `micronaut.object-storage.metadata.jdbc` prefix.
+Use it to configure the JDBC-backed metadata store, outbox processing, and hook behavior.
+
+== Configuration
+
+The metadata store is configured with regular Micronaut property binding. The exact schema and repository behavior depend on the chosen database, but the feature set is the same across supported JDBC backends.
+
+include::{includedir}configurationProperties/io.micronaut.objectstorage.metadata.jdbc.ObjectStorageMetadataJdbcConfiguration.adoc[]
+
+== Named storage behavior
+
+Metadata-aware workflows keep the existing named storage model intact.
+If you already inject storages with `@Named("pictures")` or `@Named("logos")`, the metadata-aware bean follows the same qualifier.
+That means the storage selection and the metadata store stay aligned.
+
+The executable example in the docs is backed by the example module's test fixture, so it shows the qualifier pairing and metadata flow in a small, test-backed setup.
+It is illustrative, not a proof of the full JDBC/outbox runtime path.
+What it does show is the same qualifier used for the metadata-aware upload bean, the metadata query bean, and the descriptor for that named storage.
+That keeps the cloud upload target, descriptor, and metadata queries in sync for the selected named storage.
+
+== Query API usage
+
+The public query API is tenant scoped and descriptor aware.
+Use it to query by exact key, by prefix, or by container, depending on the lookup you need.
+The current contract supports exact object lookups, prefix queries, container reads, and tenant-scoped reads.
+
+Public reads only expose reconciled metadata.
+Pending, processing, failed, and dead-letter rows stay hidden until reconciliation marks them visible.
+That is intentional, because the foreground upload path is eventual-consistency based.
+
+== Hook lifecycle
+
+Hooks run around the metadata-aware foreground workflow in a fixed order.
+The lifecycle is:
+
+. `before`, before the delegate upload starts
+. delegate upload, which writes to the object store
+. durable metadata enqueue
+. `after`, after reconciliation persists the final metadata state
+. `error`, if the foreground path fails after delegate success, or if reconciliation later fails and the outbox entry is retried/dead-lettered
+
+In the example fixture, the hook observation is exercised through the test harness, which checks the `before` state around the first upload.
+That illustrates hook timing without claiming the snippet stands in for full production persistence plumbing.
+
+Hooks receive the operation context, not provider-specific builders.
+That keeps the contract portable and avoids tying hook logic to one cloud SDK.
+
+Hooks can observe whether container metadata already exists before upload.
+That makes it possible to prepare containers once, react to first upload, or detect repeated uploads without guessing from storage-only state.
+
+== Tenant resolver expectations
+
+The metadata query and workflow beans expect a tenant resolver to be available.
+Tenant resolution happens centrally, so callers do not pass tenant ids on each query method.
+Applications should provide a resolver that matches their request model, whether that comes from the current authentication context, headers, or another application-specific source.
+
+If no tenant can be resolved, the metadata-aware workflow cannot safely scope reads and writes.
+
+== Eventual-consistency semantics
+
+The foreground upload, delete, and copy flows do not make metadata visible immediately.
+They enqueue durable work first, then reconciliation publishes the final metadata state.
+
+This means:
+
+- upload success does not imply immediate query visibility
+- hooks may observe the container state before metadata becomes visible
+- query results reflect the reconciled state, not the just-written foreground intent
+
+That delay is expected, and tests should wait for reconciliation when they need to observe visible metadata.
+
+== Oracle-first notes
+
+Oracle is a first-class validation target for the metadata JDBC module.
+The shipped Oracle schema covers the supported metadata workflow, including the outbox tables needed for reconciliation.
+
+The module does not generate Oracle policies automatically.
+If you need Oracle VPD or RAS rules, define them separately in your application or database setup.
+
+== Portability boundary
+
+The metadata layer stays portable as long as you stay within the documented query and workflow contract.
+Supported behavior includes logical containers, exact and prefix object queries, container reads, tenant-scoped reads, and eventual-consistency publishing through reconciliation.
+
+The portability boundary stops at provider-specific storage behavior and database-specific DDL details.
+Do not expect automatic Oracle policy creation, provider-native query extensions, or direct access to vendor SDK request builders from metadata hooks.

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -35,6 +35,18 @@ micronaut:
 
 You then need to use `@Named("pictures")` or `@Named("logos")` to specify which of the object storages you want to use.
 
+When you also use the metadata-aware storage bean, keep the same qualifier on both injections so the storage and its
+metadata view stay paired.
+
+snippet::example.MetadataProfileService[project-base="doc-examples/example", source="main", indent="0", tags="beginclass,endclass"]
+
+The example below injects the `@Named("pictures")` metadata-aware storage and the matching metadata query bean.
+It is an executable example, backed by the example module's test fixture, that demonstrates qualifier pairing,
+metadata-aware upload invocation, prefix query usage, and hook observation semantics.
+It is not meant to prove the full JDBC/outbox runtime path.
+
+snippet::example.MetadataProfileService[project-base="doc-examples/example", source="main", indent="0", tags="upload,prefix,hook"]
+
 == Uploading files
 
 snippet::example.ProfileService[project-base="doc-examples/example", source="main", indent="0", tags="upload"]

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -6,6 +6,7 @@ azure: Azure Blob Storage
 gcp: Google Cloud Storage
 oracleCloud: Oracle Cloud Infrastructure (OCI) Object Storage
 local: Local Storage
+metadataPersistence: Metadata Persistence
 control-panel: Control Panel
 objectStorageGuides: Guides
 breaks: Breaking Changes


### PR DESCRIPTION
## Summary
- add relational metadata persistence support alongside object-storage workflows
- introduce the new `object-storage-metadata-jdbc` module with Oracle/PostgreSQL schema, repositories, query service, outbox/reconciliation, and workflow coverage
- add core metadata/query/hook contracts, provider descriptor resolvers, docs, and executable example coverage

## Verification
- `./gradlew :micronaut-object-storage-core:test :micronaut-object-storage-metadata-jdbc:test :micronaut-object-storage-tck:test --no-daemon`
- `./gradlew docs`
- `./gradlew :micronaut-doc-examples:micronaut-example-java:test --tests 'example.ProfileServiceSpec' --tests 'example.MetadataProfileServiceSpec'`
- targeted Oracle/PostgreSQL metadata-jdbc integration and smoke specs were exercised during implementation

## Notes
- aggregate `./gradlew check jacocoReport --continue` still reports repo-wide `japiCmp` baseline failures in existing published modules outside this feature branch scope