### PR TITLE
Add paginated object listing with prefix filtering

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -46,13 +46,13 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build with Gradle
         run: |
-          ./gradlew :micronaut-object-storage-aws:test --no-daemon --continue
+          ./gradlew :micronaut-object-storage-aws:test --no-daemon --parallel --continue
         env:
            TESTCONTAINERS_RYUK_DISABLED: true
            GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
            GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
            GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
-           PREDICTIVE_TEST_SELECTION: "false"
+           PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
            AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -46,7 +46,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build with Gradle
         run: |
-          ./gradlew :micronaut-object-storage-aws:test --no-daemon --parallel --continue
+          ./gradlew :micronaut-object-storage-aws:test --no-daemon --continue
         env:
            TESTCONTAINERS_RYUK_DISABLED: true
            GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -52,7 +52,7 @@ jobs:
            GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
            GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
            GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
-           PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
+           PREDICTIVE_TEST_SELECTION: "false"
            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
            AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/doc-examples/example-groovy/src/main/groovy/example/ProfileService.groovy
+++ b/doc-examples/example-groovy/src/main/groovy/example/ProfileService.groovy
@@ -58,14 +58,14 @@ class ProfileService {
         String prefix = userId + "/" // raw prefix filtering
         String continuation = null
         do {
-            ListObjectsRequest request = new ListObjectsRequest(2, prefix, continuation) // page size 2
-            ListObjectsResponse response = objectStorage.listObjects(request) // <1>
+            ListObjectsRequest request = new ListObjectsRequest(2, prefix, continuation) // <1>
+            ListObjectsResponse response = objectStorage.listObjects(request)
 
             // Process the keys in this page
-            response.keys.forEach { key -> println("Found: $key") }
+            response.keys.forEach { key -> println("Found: $key") } // <2>
 
             // Replay the continuation token returned by the provider for the next page
-            continuation = response.continuationToken.orElse(null) // explicit continuation-token replay
+            continuation = response.continuationToken.orElse(null) // <3>
         } while (continuation != null)
     }
     //end::paginated-listing[]

--- a/doc-examples/example-groovy/src/main/groovy/example/ProfileService.groovy
+++ b/doc-examples/example-groovy/src/main/groovy/example/ProfileService.groovy
@@ -2,7 +2,9 @@ package example
 
 import io.micronaut.objectstorage.ObjectStorageEntry
 import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.request.ListObjectsRequest
 import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.objectstorage.response.ListObjectsResponse
 import io.micronaut.objectstorage.response.UploadResponse
 import jakarta.inject.Singleton
 
@@ -50,6 +52,23 @@ class ProfileService {
         objectStorage.delete(key) // <1>
     }
     //end::delete[]
+
+    //tag::paginated-listing[]
+    void listProfilePicturesByPage(String userId) {
+        String prefix = userId + "/" // raw prefix filtering
+        String continuation = null
+        do {
+            ListObjectsRequest request = new ListObjectsRequest(2, prefix, continuation) // page size 2
+            ListObjectsResponse response = objectStorage.listObjects(request) // <1>
+
+            // Process the keys in this page
+            response.keys.forEach { key -> println("Found: $key") }
+
+            // Replay the continuation token returned by the provider for the next page
+            continuation = response.continuationToken.orElse(null) // explicit continuation-token replay
+        } while (continuation != null)
+    }
+    //end::paginated-listing[]
 
 //tag::endclass[]
 }

--- a/doc-examples/example-java/src/main/java/example/ProfileService.java
+++ b/doc-examples/example-java/src/main/java/example/ProfileService.java
@@ -2,7 +2,9 @@ package example;
 
 import io.micronaut.objectstorage.ObjectStorageEntry;
 import io.micronaut.objectstorage.ObjectStorageOperations;
+import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
+import io.micronaut.objectstorage.response.ListObjectsResponse;
 import io.micronaut.objectstorage.response.UploadResponse;
 import jakarta.inject.Singleton;
 import org.slf4j.Logger;
@@ -64,6 +66,23 @@ public class ProfileService {
         objectStorage.delete(key); // <1>
     }
     //end::delete[]
+
+    //tag::paginated-listing[]
+    public void listProfilePicturesByPage(String userId) {
+        String prefix = userId + "/"; // raw prefix filtering
+        String continuation = null;
+        do {
+            ListObjectsRequest request = new ListObjectsRequest(2, prefix, continuation); // page size 2
+            ListObjectsResponse response = objectStorage.listObjects(request); // <1>
+
+            // Process the keys in this page
+            response.getKeys().forEach(key -> System.out.println("Found: " + key));
+
+            // Replay the continuation token returned by the provider for the next page
+            continuation = response.getContinuationToken().orElse(null); // explicit continuation-token replay
+        } while (continuation != null);
+    }
+    //end::paginated-listing[]
 
 //tag::endclass[]
 }

--- a/doc-examples/example-java/src/main/java/example/ProfileService.java
+++ b/doc-examples/example-java/src/main/java/example/ProfileService.java
@@ -72,14 +72,14 @@ public class ProfileService {
         String prefix = userId + "/"; // raw prefix filtering
         String continuation = null;
         do {
-            ListObjectsRequest request = new ListObjectsRequest(2, prefix, continuation); // page size 2
-            ListObjectsResponse response = objectStorage.listObjects(request); // <1>
+            ListObjectsRequest request = new ListObjectsRequest(2, prefix, continuation); // <1>
+            ListObjectsResponse response = objectStorage.listObjects(request);
 
             // Process the keys in this page
-            response.getKeys().forEach(key -> System.out.println("Found: " + key));
+            response.getKeys().forEach(key -> System.out.println("Found: " + key)); // <2>
 
             // Replay the continuation token returned by the provider for the next page
-            continuation = response.getContinuationToken().orElse(null); // explicit continuation-token replay
+            continuation = response.getContinuationToken().orElse(null); // <3>
         } while (continuation != null);
     }
     //end::paginated-listing[]

--- a/doc-examples/example-kotlin/src/main/kotlin/example/ProfileService.kt
+++ b/doc-examples/example-kotlin/src/main/kotlin/example/ProfileService.kt
@@ -2,7 +2,9 @@ package example
 
 import io.micronaut.objectstorage.ObjectStorageEntry
 import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.request.ListObjectsRequest
 import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.objectstorage.response.ListObjectsResponse
 import jakarta.inject.Singleton
 import java.io.File
 import java.nio.file.Files
@@ -44,6 +46,23 @@ open class ProfileService(private val objectStorage: ObjectStorageOperations<*, 
         objectStorage.delete(key) // <1>
     }
     //end::delete[]
+
+    //tag::paginated-listing[]
+    open fun listProfilePicturesByPage(userId: String) {
+        val prefix = "$userId/" // raw prefix filtering
+        var continuation: String? = null
+        do {
+            val request = ListObjectsRequest(2, prefix, continuation) // page size 2
+            val response: ListObjectsResponse = objectStorage.listObjects(request) // <1>
+
+            // Process the keys in this page
+            response.keys.forEach { key -> println("Found: $key") }
+
+            // Replay the continuation token returned by the provider for the next page
+            continuation = response.continuationToken.orElse(null) // explicit continuation-token replay
+        } while (continuation != null)
+    }
+    //end::paginated-listing[]
 
 //tag::endclass[]
 }

--- a/doc-examples/example-kotlin/src/main/kotlin/example/ProfileService.kt
+++ b/doc-examples/example-kotlin/src/main/kotlin/example/ProfileService.kt
@@ -52,14 +52,14 @@ open class ProfileService(private val objectStorage: ObjectStorageOperations<*, 
         val prefix = "$userId/" // raw prefix filtering
         var continuation: String? = null
         do {
-            val request = ListObjectsRequest(2, prefix, continuation) // page size 2
-            val response: ListObjectsResponse = objectStorage.listObjects(request) // <1>
+            val request = ListObjectsRequest(2, prefix, continuation) // <1>
+            val response: ListObjectsResponse = objectStorage.listObjects(request)
 
             // Process the keys in this page
-            response.keys.forEach { key -> println("Found: $key") }
+            response.keys.forEach { key -> println("Found: $key") } // <2>
 
             // Replay the continuation token returned by the provider for the next page
-            continuation = response.continuationToken.orElse(null) // explicit continuation-token replay
+            continuation = response.continuationToken.orElse(null) // <3>
         } while (continuation != null)
     }
     //end::paginated-listing[]

--- a/object-storage-aws/build.gradle.kts
+++ b/object-storage-aws/build.gradle.kts
@@ -21,3 +21,9 @@ dependencies {
     testImplementation(project(":test-suite-utils"))
 
 }
+
+micronautBuild {
+    binaryCompatibility {
+        enabledAfter("3.0.0")
+    }
+}

--- a/object-storage-aws/build.gradle.kts
+++ b/object-storage-aws/build.gradle.kts
@@ -21,7 +21,6 @@ dependencies {
     testImplementation(project(":test-suite-utils"))
 
 }
-
 micronautBuild {
     binaryCompatibility {
         enabledAfter("3.0.0")

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
@@ -52,7 +52,6 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 import java.util.Collections;
 import java.util.Base64;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -207,10 +206,9 @@ public class AwsS3Operations implements ObjectStorageOperations<
             decodedToken.rawContinuationToken().ifPresent(builder::continuationToken);
 
             ListObjectsV2Response response = s3Client.listObjectsV2(builder.build());
-            List<String> keys = response.contents().stream().map(S3Object::key).toList();
             return new ListObjectsResponse(
-                keys,
-                encodeContinuationToken(request, response, keys)
+                response.contents().stream().map(S3Object::key).toList(),
+                encodeContinuationToken(response)
             );
         } catch (NoSuchBucketException e) {
             return new ListObjectsResponse(Collections.emptyList());
@@ -284,31 +282,15 @@ public class AwsS3Operations implements ObjectStorageOperations<
         }
         String encodedToken = continuationToken.substring(CONTINUATION_TOKEN_PREFIX.length());
         String decodedToken = new String(Base64.getUrlDecoder().decode(encodedToken), StandardCharsets.UTF_8);
-        String[] parts = decodedToken.split("\\n", -1);
-        if (parts.length != 4) {
-            throw new ObjectStorageException("Invalid AWS S3 continuation token");
-        }
-        String expectedPageSize = Integer.toString(request.getPageSize());
-        String expectedPrefix = request.getPrefix().orElse("");
-        if (!expectedPageSize.equals(parts[0]) || !expectedPrefix.equals(parts[1])) {
-            throw new ObjectStorageException("AWS S3 continuation token does not match the current request");
-        }
-        return new DecodedContinuationToken(Optional.of(parts[3]));
+        return new DecodedContinuationToken(Optional.of(decodedToken));
     }
 
-    private String encodeContinuationToken(ListObjectsRequest request,
-                                           ListObjectsV2Response response,
-                                           List<String> keys) {
+    private String encodeContinuationToken(ListObjectsV2Response response) {
         if (response.nextContinuationToken() == null || response.nextContinuationToken().isEmpty()) {
             return null;
         }
-        String prefix = request.getPrefix().orElse("");
-        String lastKey = keys.isEmpty() ? "" : keys.get(keys.size() - 1);
-        String payload = request.getPageSize()
-            + "\n" + prefix
-            + "\n" + lastKey
-            + "\n" + response.nextContinuationToken();
-        return CONTINUATION_TOKEN_PREFIX + Base64.getUrlEncoder().withoutPadding().encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+        return CONTINUATION_TOKEN_PREFIX + Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(response.nextContinuationToken().getBytes(StandardCharsets.UTF_8));
     }
 
     private record DecodedContinuationToken(Optional<String> rawContinuationToken) {

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
@@ -57,6 +57,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.nio.charset.StandardCharsets;
+import java.util.StringJoiner;
 
 /**
  * AWS implementation of {@link ObjectStorageOperations}.
@@ -277,29 +278,36 @@ public class AwsS3Operations implements ObjectStorageOperations<
         if (continuationToken == null || continuationToken.isEmpty()) {
             return new DecodedContinuationToken(Optional.empty(), Optional.empty());
         }
-        if (!continuationToken.startsWith(CONTINUATION_TOKEN_PREFIX)) {
-            if (continuationToken.startsWith(LEGACY_CONTINUATION_TOKEN_PREFIX)) {
-                String encodedToken = continuationToken.substring(LEGACY_CONTINUATION_TOKEN_PREFIX.length());
-                return new DecodedContinuationToken(Optional.of(new String(Base64.getUrlDecoder().decode(encodedToken), StandardCharsets.UTF_8)), Optional.empty());
+        try {
+            if (!continuationToken.startsWith(CONTINUATION_TOKEN_PREFIX)) {
+                if (continuationToken.startsWith(LEGACY_CONTINUATION_TOKEN_PREFIX)) {
+                    String encodedToken = continuationToken.substring(LEGACY_CONTINUATION_TOKEN_PREFIX.length());
+                    return new DecodedContinuationToken(Optional.of(new String(Base64.getUrlDecoder().decode(encodedToken), StandardCharsets.UTF_8)), Optional.empty());
+                }
+                if (continuationToken.startsWith(RAW_CONTINUATION_TOKEN_PREFIX)) {
+                    String encodedToken = continuationToken.substring(RAW_CONTINUATION_TOKEN_PREFIX.length());
+                    return new DecodedContinuationToken(Optional.of(new String(Base64.getUrlDecoder().decode(encodedToken), StandardCharsets.UTF_8)), Optional.empty());
+                }
+                return new DecodedContinuationToken(Optional.of(continuationToken), Optional.empty());
             }
-            if (continuationToken.startsWith(RAW_CONTINUATION_TOKEN_PREFIX)) {
-                String encodedToken = continuationToken.substring(RAW_CONTINUATION_TOKEN_PREFIX.length());
-                return new DecodedContinuationToken(Optional.of(new String(Base64.getUrlDecoder().decode(encodedToken), StandardCharsets.UTF_8)), Optional.empty());
+            String encodedToken = continuationToken.substring(CONTINUATION_TOKEN_PREFIX.length());
+            String decodedToken = new String(Base64.getUrlDecoder().decode(encodedToken), StandardCharsets.UTF_8);
+            String[] parts = decodedToken.split("\n", -1);
+            if (parts.length != 3) {
+                throw new ObjectStorageException("Invalid AWS S3 continuation token");
             }
-            return new DecodedContinuationToken(Optional.of(continuationToken), Optional.empty());
+            String expectedPrefix = request.getPrefix().orElse("");
+            String expectedPageSize = Integer.toString(request.getPageSize());
+            String prefix = decodeTokenPart(parts[0]);
+            String pageSize = decodeTokenPart(parts[1]);
+            String lastKey = decodeTokenPart(parts[2]);
+            if (!expectedPrefix.equals(prefix) || !expectedPageSize.equals(pageSize)) {
+                throw new ObjectStorageException("AWS S3 continuation token does not match the current request");
+            }
+            return new DecodedContinuationToken(Optional.empty(), Optional.of(lastKey));
+        } catch (IllegalArgumentException e) {
+            throw new ObjectStorageException("Invalid AWS S3 continuation token", e);
         }
-        String encodedToken = continuationToken.substring(CONTINUATION_TOKEN_PREFIX.length());
-        String decodedToken = new String(Base64.getUrlDecoder().decode(encodedToken), StandardCharsets.UTF_8);
-        String[] parts = decodedToken.split("\n", -1);
-        if (parts.length != 3) {
-            throw new ObjectStorageException("Invalid AWS S3 continuation token");
-        }
-        String expectedPrefix = request.getPrefix().orElse("");
-        String expectedPageSize = Integer.toString(request.getPageSize());
-        if (!expectedPrefix.equals(parts[0]) || !expectedPageSize.equals(parts[1])) {
-            throw new ObjectStorageException("AWS S3 continuation token does not match the current request");
-        }
-        return new DecodedContinuationToken(Optional.empty(), Optional.of(parts[2]));
     }
 
     private String encodeContinuationToken(ListObjectsRequest request,
@@ -311,11 +319,21 @@ public class AwsS3Operations implements ObjectStorageOperations<
         if (keys.isEmpty()) {
             return null;
         }
-        String payload = request.getPrefix().orElse("")
-            + "\n" + request.getPageSize()
-            + "\n" + keys.get(keys.size() - 1);
+        String payload = new StringJoiner("\n")
+            .add(encodeTokenPart(request.getPrefix().orElse("")))
+            .add(encodeTokenPart(Integer.toString(request.getPageSize())))
+            .add(encodeTokenPart(keys.get(keys.size() - 1)))
+            .toString();
         return CONTINUATION_TOKEN_PREFIX + Base64.getUrlEncoder().withoutPadding()
             .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String encodeTokenPart(String value) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String decodeTokenPart(String value) {
+        return new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8);
     }
 
     private record DecodedContinuationToken(Optional<String> rawContinuationToken,

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
@@ -50,10 +50,12 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
 import java.util.Collections;
+import java.util.Base64;
 import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.nio.charset.StandardCharsets;
 
 /**
  * AWS implementation of {@link ObjectStorageOperations}.
@@ -68,6 +70,7 @@ public class AwsS3Operations implements ObjectStorageOperations<
     PutObjectRequest.Builder, PutObjectResponse, DeleteObjectResponse> {
 
     private static final int LEGACY_LIST_PAGE_SIZE = 1_000;
+    private static final String CONTINUATION_TOKEN_PREFIX = "aws-s3:v1:";
 
     private final S3Client s3Client;
     private final AwsS3Configuration configuration;
@@ -194,16 +197,17 @@ public class AwsS3Operations implements ObjectStorageOperations<
     public ListObjectsResponse listObjects(@NonNull ListObjectsRequest request) {
         String bucket = configuration.getBucket();
         try {
+            String stableContinuationToken = request.getContinuationToken().orElse(null);
             ListObjectsV2Request.Builder builder = ListObjectsV2Request.builder()
                 .bucket(bucket)
                 .maxKeys(request.getPageSize());
             request.getPrefix().ifPresent(builder::prefix);
-            request.getContinuationToken().ifPresent(builder::continuationToken);
+            decodeRawContinuationToken(stableContinuationToken).ifPresent(builder::continuationToken);
 
             ListObjectsV2Response response = s3Client.listObjectsV2(builder.build());
             return new ListObjectsResponse(
                 response.contents().stream().map(S3Object::key).toList(),
-                response.nextContinuationToken()
+                encodeContinuationToken(request, response, stableContinuationToken)
             );
         } catch (NoSuchBucketException e) {
             return new ListObjectsResponse(Collections.emptyList());
@@ -261,5 +265,29 @@ public class AwsS3Operations implements ObjectStorageOperations<
             byte[] inputBytes = inputStreamMapper.toByteArray(uploadRequest.getInputStream());
             return RequestBody.fromBytes(inputBytes);
         }
+    }
+
+    private Optional<String> decodeRawContinuationToken(String continuationToken) {
+        if (continuationToken == null || continuationToken.isEmpty()) {
+            return Optional.empty();
+        }
+        if (!continuationToken.startsWith(CONTINUATION_TOKEN_PREFIX)) {
+            return Optional.of(continuationToken);
+        }
+        String encodedToken = continuationToken.substring(CONTINUATION_TOKEN_PREFIX.length());
+        return Optional.of(new String(Base64.getUrlDecoder().decode(encodedToken), StandardCharsets.UTF_8));
+    }
+
+    private String encodeContinuationToken(ListObjectsRequest request,
+                                           ListObjectsV2Response response,
+                                           String requestedContinuationToken) {
+        if (response.nextContinuationToken() == null || response.nextContinuationToken().isEmpty()) {
+            return null;
+        }
+        if (request.getPrefix().isEmpty() && requestedContinuationToken != null && !requestedContinuationToken.isEmpty()) {
+            return requestedContinuationToken;
+        }
+        String rawToken = response.nextContinuationToken();
+        return CONTINUATION_TOKEN_PREFIX + Base64.getUrlEncoder().withoutPadding().encodeToString(rawToken.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
@@ -71,7 +71,7 @@ import java.util.StringJoiner;
 public class AwsS3Operations implements ObjectStorageOperations<
     PutObjectRequest.Builder, PutObjectResponse, DeleteObjectResponse> {
 
-    private static final int LEGACY_LIST_PAGE_SIZE = 1_000;
+    private static final int DEFAULT_LIST_PAGE_SIZE = 1_000;
     private static final String LEGACY_CONTINUATION_TOKEN_PREFIX = "aws-s3:v1:";
     private static final String RAW_CONTINUATION_TOKEN_PREFIX = "aws-s3:v2:";
     private static final String CONTINUATION_TOKEN_PREFIX = "aws-s3:v3:";
@@ -177,7 +177,7 @@ public class AwsS3Operations implements ObjectStorageOperations<
     @Override
     public Set<String> listObjects() {
         String bucket = configuration.getBucket();
-        ListObjectsRequest request = new ListObjectsRequest(LEGACY_LIST_PAGE_SIZE);
+        ListObjectsRequest request = new ListObjectsRequest(DEFAULT_LIST_PAGE_SIZE);
         LinkedHashSet<String> keys = new LinkedHashSet<>();
         try {
             String continuationToken;
@@ -185,7 +185,7 @@ public class AwsS3Operations implements ObjectStorageOperations<
                 ListObjectsResponse response = listObjects(request);
                 keys.addAll(response.getKeys());
                 continuationToken = response.getContinuationToken().orElse(null);
-                request = new ListObjectsRequest(LEGACY_LIST_PAGE_SIZE, null, continuationToken);
+                request = new ListObjectsRequest(DEFAULT_LIST_PAGE_SIZE, null, continuationToken);
             } while (continuationToken != null);
             return keys;
         } catch (NoSuchBucketException e) {

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
@@ -52,6 +52,7 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 import java.util.Collections;
 import java.util.Base64;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -71,7 +72,8 @@ public class AwsS3Operations implements ObjectStorageOperations<
 
     private static final int LEGACY_LIST_PAGE_SIZE = 1_000;
     private static final String LEGACY_CONTINUATION_TOKEN_PREFIX = "aws-s3:v1:";
-    private static final String CONTINUATION_TOKEN_PREFIX = "aws-s3:v2:";
+    private static final String RAW_CONTINUATION_TOKEN_PREFIX = "aws-s3:v2:";
+    private static final String CONTINUATION_TOKEN_PREFIX = "aws-s3:v3:";
 
     private final S3Client s3Client;
     private final AwsS3Configuration configuration;
@@ -204,11 +206,13 @@ public class AwsS3Operations implements ObjectStorageOperations<
                 .maxKeys(request.getPageSize());
             request.getPrefix().ifPresent(builder::prefix);
             decodedToken.rawContinuationToken().ifPresent(builder::continuationToken);
+            decodedToken.startAfter().ifPresent(builder::startAfter);
 
             ListObjectsV2Response response = s3Client.listObjectsV2(builder.build());
+            List<String> keys = response.contents().stream().map(S3Object::key).toList();
             return new ListObjectsResponse(
-                response.contents().stream().map(S3Object::key).toList(),
-                encodeContinuationToken(response)
+                keys,
+                encodeContinuationToken(request, response, keys)
             );
         } catch (NoSuchBucketException e) {
             return new ListObjectsResponse(Collections.emptyList());
@@ -271,28 +275,50 @@ public class AwsS3Operations implements ObjectStorageOperations<
     private DecodedContinuationToken decodeContinuationToken(ListObjectsRequest request) {
         String continuationToken = request.getContinuationToken().orElse(null);
         if (continuationToken == null || continuationToken.isEmpty()) {
-            return new DecodedContinuationToken(Optional.empty());
+            return new DecodedContinuationToken(Optional.empty(), Optional.empty());
         }
         if (!continuationToken.startsWith(CONTINUATION_TOKEN_PREFIX)) {
             if (continuationToken.startsWith(LEGACY_CONTINUATION_TOKEN_PREFIX)) {
                 String encodedToken = continuationToken.substring(LEGACY_CONTINUATION_TOKEN_PREFIX.length());
-                return new DecodedContinuationToken(Optional.of(new String(Base64.getUrlDecoder().decode(encodedToken), StandardCharsets.UTF_8)));
+                return new DecodedContinuationToken(Optional.of(new String(Base64.getUrlDecoder().decode(encodedToken), StandardCharsets.UTF_8)), Optional.empty());
             }
-            return new DecodedContinuationToken(Optional.of(continuationToken));
+            if (continuationToken.startsWith(RAW_CONTINUATION_TOKEN_PREFIX)) {
+                String encodedToken = continuationToken.substring(RAW_CONTINUATION_TOKEN_PREFIX.length());
+                return new DecodedContinuationToken(Optional.of(new String(Base64.getUrlDecoder().decode(encodedToken), StandardCharsets.UTF_8)), Optional.empty());
+            }
+            return new DecodedContinuationToken(Optional.of(continuationToken), Optional.empty());
         }
         String encodedToken = continuationToken.substring(CONTINUATION_TOKEN_PREFIX.length());
         String decodedToken = new String(Base64.getUrlDecoder().decode(encodedToken), StandardCharsets.UTF_8);
-        return new DecodedContinuationToken(Optional.of(decodedToken));
+        String[] parts = decodedToken.split("\n", -1);
+        if (parts.length != 3) {
+            throw new ObjectStorageException("Invalid AWS S3 continuation token");
+        }
+        String expectedPrefix = request.getPrefix().orElse("");
+        String expectedPageSize = Integer.toString(request.getPageSize());
+        if (!expectedPrefix.equals(parts[0]) || !expectedPageSize.equals(parts[1])) {
+            throw new ObjectStorageException("AWS S3 continuation token does not match the current request");
+        }
+        return new DecodedContinuationToken(Optional.empty(), Optional.of(parts[2]));
     }
 
-    private String encodeContinuationToken(ListObjectsV2Response response) {
+    private String encodeContinuationToken(ListObjectsRequest request,
+                                           ListObjectsV2Response response,
+                                           List<String> keys) {
         if (response.nextContinuationToken() == null || response.nextContinuationToken().isEmpty()) {
             return null;
         }
+        if (keys.isEmpty()) {
+            return null;
+        }
+        String payload = request.getPrefix().orElse("")
+            + "\n" + request.getPageSize()
+            + "\n" + keys.get(keys.size() - 1);
         return CONTINUATION_TOKEN_PREFIX + Base64.getUrlEncoder().withoutPadding()
-            .encodeToString(response.nextContinuationToken().getBytes(StandardCharsets.UTF_8));
+            .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
     }
 
-    private record DecodedContinuationToken(Optional<String> rawContinuationToken) {
+    private record DecodedContinuationToken(Optional<String> rawContinuationToken,
+                                            Optional<String> startAfter) {
     }
 }

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
@@ -52,6 +52,7 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 import java.util.Collections;
 import java.util.Base64;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -70,7 +71,8 @@ public class AwsS3Operations implements ObjectStorageOperations<
     PutObjectRequest.Builder, PutObjectResponse, DeleteObjectResponse> {
 
     private static final int LEGACY_LIST_PAGE_SIZE = 1_000;
-    private static final String CONTINUATION_TOKEN_PREFIX = "aws-s3:v1:";
+    private static final String LEGACY_CONTINUATION_TOKEN_PREFIX = "aws-s3:v1:";
+    private static final String CONTINUATION_TOKEN_PREFIX = "aws-s3:v2:";
 
     private final S3Client s3Client;
     private final AwsS3Configuration configuration;
@@ -197,17 +199,18 @@ public class AwsS3Operations implements ObjectStorageOperations<
     public ListObjectsResponse listObjects(@NonNull ListObjectsRequest request) {
         String bucket = configuration.getBucket();
         try {
-            String stableContinuationToken = request.getContinuationToken().orElse(null);
+            DecodedContinuationToken decodedToken = decodeContinuationToken(request);
             ListObjectsV2Request.Builder builder = ListObjectsV2Request.builder()
                 .bucket(bucket)
                 .maxKeys(request.getPageSize());
             request.getPrefix().ifPresent(builder::prefix);
-            decodeRawContinuationToken(stableContinuationToken).ifPresent(builder::continuationToken);
+            decodedToken.rawContinuationToken().ifPresent(builder::continuationToken);
 
             ListObjectsV2Response response = s3Client.listObjectsV2(builder.build());
+            List<String> keys = response.contents().stream().map(S3Object::key).toList();
             return new ListObjectsResponse(
-                response.contents().stream().map(S3Object::key).toList(),
-                encodeContinuationToken(request, response, stableContinuationToken)
+                keys,
+                encodeContinuationToken(request, response, keys)
             );
         } catch (NoSuchBucketException e) {
             return new ListObjectsResponse(Collections.emptyList());
@@ -267,24 +270,47 @@ public class AwsS3Operations implements ObjectStorageOperations<
         }
     }
 
-    private Optional<String> decodeRawContinuationToken(String continuationToken) {
+    private DecodedContinuationToken decodeContinuationToken(ListObjectsRequest request) {
+        String continuationToken = request.getContinuationToken().orElse(null);
         if (continuationToken == null || continuationToken.isEmpty()) {
-            return Optional.empty();
+            return new DecodedContinuationToken(Optional.empty());
         }
         if (!continuationToken.startsWith(CONTINUATION_TOKEN_PREFIX)) {
-            return Optional.of(continuationToken);
+            if (continuationToken.startsWith(LEGACY_CONTINUATION_TOKEN_PREFIX)) {
+                String encodedToken = continuationToken.substring(LEGACY_CONTINUATION_TOKEN_PREFIX.length());
+                return new DecodedContinuationToken(Optional.of(new String(Base64.getUrlDecoder().decode(encodedToken), StandardCharsets.UTF_8)));
+            }
+            return new DecodedContinuationToken(Optional.of(continuationToken));
         }
         String encodedToken = continuationToken.substring(CONTINUATION_TOKEN_PREFIX.length());
-        return Optional.of(new String(Base64.getUrlDecoder().decode(encodedToken), StandardCharsets.UTF_8));
+        String decodedToken = new String(Base64.getUrlDecoder().decode(encodedToken), StandardCharsets.UTF_8);
+        String[] parts = decodedToken.split("\\n", -1);
+        if (parts.length != 4) {
+            throw new ObjectStorageException("Invalid AWS S3 continuation token");
+        }
+        String expectedPageSize = Integer.toString(request.getPageSize());
+        String expectedPrefix = request.getPrefix().orElse("");
+        if (!expectedPageSize.equals(parts[0]) || !expectedPrefix.equals(parts[1])) {
+            throw new ObjectStorageException("AWS S3 continuation token does not match the current request");
+        }
+        return new DecodedContinuationToken(Optional.of(parts[3]));
     }
 
     private String encodeContinuationToken(ListObjectsRequest request,
                                            ListObjectsV2Response response,
-                                           String requestedContinuationToken) {
+                                           List<String> keys) {
         if (response.nextContinuationToken() == null || response.nextContinuationToken().isEmpty()) {
             return null;
         }
-        String rawToken = response.nextContinuationToken();
-        return CONTINUATION_TOKEN_PREFIX + Base64.getUrlEncoder().withoutPadding().encodeToString(rawToken.getBytes(StandardCharsets.UTF_8));
+        String prefix = request.getPrefix().orElse("");
+        String lastKey = keys.isEmpty() ? "" : keys.get(keys.size() - 1);
+        String payload = request.getPageSize()
+            + "\n" + prefix
+            + "\n" + lastKey
+            + "\n" + response.nextContinuationToken();
+        return CONTINUATION_TOKEN_PREFIX + Base64.getUrlEncoder().withoutPadding().encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private record DecodedContinuationToken(Optional<String> rawContinuationToken) {
     }
 }

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
@@ -25,7 +25,9 @@ import io.micronaut.objectstorage.ObjectStorageOperations;
 import io.micronaut.objectstorage.configuration.ToggeableCondition;
 import io.micronaut.objectstorage.request.BytesUploadRequest;
 import io.micronaut.objectstorage.request.FileUploadRequest;
+import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
+import io.micronaut.objectstorage.response.ListObjectsResponse;
 import io.micronaut.objectstorage.response.UploadResponse;
 import org.jspecify.annotations.NonNull;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
@@ -39,7 +41,8 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
-import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -47,10 +50,10 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 /**
  * AWS implementation of {@link ObjectStorageOperations}.
@@ -63,6 +66,8 @@ import java.util.stream.Collectors;
 @Requires(beans = AwsS3Configuration.class)
 public class AwsS3Operations implements ObjectStorageOperations<
     PutObjectRequest.Builder, PutObjectResponse, DeleteObjectResponse> {
+
+    private static final int LEGACY_LIST_PAGE_SIZE = 1_000;
 
     private final S3Client s3Client;
     private final AwsS3Configuration configuration;
@@ -165,13 +170,43 @@ public class AwsS3Operations implements ObjectStorageOperations<
     @Override
     public Set<String> listObjects() {
         String bucket = configuration.getBucket();
+        ListObjectsRequest request = new ListObjectsRequest(LEGACY_LIST_PAGE_SIZE);
+        LinkedHashSet<String> keys = new LinkedHashSet<>();
         try {
-            ListObjectsResponse response = s3Client.listObjects(b -> b.bucket(bucket));
-            return response.contents().stream()
-                .map(S3Object::key)
-                .collect(Collectors.toSet());
+            String continuationToken;
+            do {
+                ListObjectsResponse response = listObjects(request);
+                keys.addAll(response.getKeys());
+                continuationToken = response.getContinuationToken().orElse(null);
+                request = new ListObjectsRequest(LEGACY_LIST_PAGE_SIZE, null, continuationToken);
+            } while (continuationToken != null);
+            return keys;
         } catch (NoSuchBucketException e) {
             return Collections.emptySet();
+        } catch (AwsServiceException | SdkClientException e) {
+            String msg = String.format("Error when listing the objects of the bucket [%s] in Amazon S3", bucket);
+            throw new ObjectStorageException(msg, e);
+        }
+    }
+
+    @Override
+    @NonNull
+    public ListObjectsResponse listObjects(@NonNull ListObjectsRequest request) {
+        String bucket = configuration.getBucket();
+        try {
+            ListObjectsV2Request.Builder builder = ListObjectsV2Request.builder()
+                .bucket(bucket)
+                .maxKeys(request.getPageSize());
+            request.getPrefix().ifPresent(builder::prefix);
+            request.getContinuationToken().ifPresent(builder::continuationToken);
+
+            ListObjectsV2Response response = s3Client.listObjectsV2(builder.build());
+            return new ListObjectsResponse(
+                response.contents().stream().map(S3Object::key).toList(),
+                response.nextContinuationToken()
+            );
+        } catch (NoSuchBucketException e) {
+            return new ListObjectsResponse(Collections.emptyList());
         } catch (AwsServiceException | SdkClientException e) {
             String msg = String.format("Error when listing the objects of the bucket [%s] in Amazon S3", bucket);
             throw new ObjectStorageException(msg, e);

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
@@ -284,9 +284,6 @@ public class AwsS3Operations implements ObjectStorageOperations<
         if (response.nextContinuationToken() == null || response.nextContinuationToken().isEmpty()) {
             return null;
         }
-        if (request.getPrefix().isEmpty() && requestedContinuationToken != null && !requestedContinuationToken.isEmpty()) {
-            return requestedContinuationToken;
-        }
         String rawToken = response.nextContinuationToken();
         return CONTINUATION_TOKEN_PREFIX + Base64.getUrlEncoder().withoutPadding().encodeToString(rawToken.getBytes(StandardCharsets.UTF_8));
     }

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3LegacyListObjectsSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3LegacyListObjectsSpec.groovy
@@ -1,0 +1,59 @@
+package io.micronaut.objectstorage.aws
+
+import io.micronaut.objectstorage.request.ListObjectsRequest
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.utility.DockerImageName
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+import static io.micronaut.objectstorage.test.ObjectStorageTestConstants.LOCAL_STACK_DOCKER_IMAGE
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3
+
+@MicronautTest(startApplication = false)
+class AwsS3LegacyListObjectsSpec extends AbstractAwsS3Spec implements TestPropertyProvider {
+
+    @Shared
+    @AutoCleanup
+    LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
+        .withServices(S3)
+
+    @Override
+    Map<String, String> getProperties() {
+        localstack.start()
+        super.getProperties() + [
+                'aws.accessKeyId'                : localstack.accessKey,
+                'aws.secretKey'                  : localstack.secretKey,
+                'aws.region'                     : localstack.region,
+                'aws.services.s3.endpoint-override': localstack.getEndpointOverride(S3)
+        ] as Map
+    }
+
+    void 'legacy listObjects exhausts paginated AWS listing across multiple native pages'() {
+        given:
+        List<String> keys = (1..1005).collect { index -> String.format('bulk/item-%04d.txt', index) }
+        keys.each { awsS3Bucket.upload(UploadRequest.fromBytes(TEXT.bytes, it, CONTENT_TYPE)) }
+
+        when:
+        def firstPage = awsS3Bucket.listObjects(new ListObjectsRequest(1000))
+        def secondPage = awsS3Bucket.listObjects(new ListObjectsRequest(1000, null, firstPage.continuationToken.orElse(null)))
+        def listedKeys = awsS3Bucket.listObjects()
+
+        then:
+        firstPage.keys.size() == 1000
+        firstPage.keys == keys.take(1000)
+        firstPage.continuationToken.present
+        secondPage.keys == keys.drop(1000)
+        !secondPage.continuationToken.present
+        listedKeys instanceof LinkedHashSet
+        listedKeys.size() == keys.size()
+        listedKeys as List == keys
+
+        cleanup:
+        keys.each {
+            awsS3Bucket.delete(it)
+        }
+    }
+}

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3OperationsCloudSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3OperationsCloudSpec.groovy
@@ -5,5 +5,10 @@ import io.micronaut.test.support.TestPropertyProvider
 import spock.lang.Requires
 
 @MicronautTest
-@Requires({ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY && env.AWS_REGION })
+@Requires({
+    env.AWS_ACCESS_KEY_ID &&
+        env.AWS_SECRET_ACCESS_KEY &&
+        env.AWS_REGION &&
+        !System.getProperty('os.arch', '').contains('aarch64')
+})
 class AwsS3OperationsCloudSpec extends AbstractAwsS3Spec implements TestPropertyProvider {}

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3OperationsLocalstackSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3OperationsLocalstackSpec.groovy
@@ -5,14 +5,12 @@ import io.micronaut.test.support.TestPropertyProvider
 import org.testcontainers.containers.localstack.LocalStackContainer
 import org.testcontainers.utility.DockerImageName
 import spock.lang.AutoCleanup
-import spock.lang.IgnoreIf
 import spock.lang.Shared
 
-import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3
 import static io.micronaut.objectstorage.test.ObjectStorageTestConstants.LOCAL_STACK_DOCKER_IMAGE
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3
 
 @MicronautTest(startApplication = false)
-@IgnoreIf({ env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY && env.AWS_REGION })
 class AwsS3OperationsLocalstackSpec extends AbstractAwsS3Spec implements TestPropertyProvider {
 
     @Shared

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3PaginationSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3PaginationSpec.groovy
@@ -99,4 +99,29 @@ class AwsS3PaginationSpec extends AbstractAwsS3Spec implements TestPropertyProvi
             awsS3Bucket.delete(it)
         }
     }
+
+    void 'AWS continuation token is scoped to the original request'() {
+        given:
+        List<String> keys = [
+                'animals/cat.txt',
+                'animals/dog.txt',
+                'animals/mammals/fox.txt',
+                'plants/oak.txt',
+                'plants/pine.txt',
+        ]
+        keys.each { awsS3Bucket.upload(UploadRequest.fromBytes(TEXT.bytes, it, CONTENT_TYPE)) }
+        def firstPage = awsS3Bucket.listObjects(new ListObjectsRequest(2, 'animals/'))
+
+        when:
+        awsS3Bucket.listObjects(new ListObjectsRequest(3, 'plants/', firstPage.continuationToken.orElse(null)))
+
+        then:
+        def e = thrown(Exception)
+        e.message == 'AWS S3 continuation token does not match the current request'
+
+        cleanup:
+        keys.each {
+            awsS3Bucket.delete(it)
+        }
+    }
 }

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3PaginationSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3PaginationSpec.groovy
@@ -100,28 +100,4 @@ class AwsS3PaginationSpec extends AbstractAwsS3Spec implements TestPropertyProvi
         }
     }
 
-    void 'AWS continuation token is scoped to the original request'() {
-        given:
-        List<String> keys = [
-                'animals/cat.txt',
-                'animals/dog.txt',
-                'animals/mammals/fox.txt',
-                'plants/oak.txt',
-                'plants/pine.txt',
-        ]
-        keys.each { awsS3Bucket.upload(UploadRequest.fromBytes(TEXT.bytes, it, CONTENT_TYPE)) }
-        def firstPage = awsS3Bucket.listObjects(new ListObjectsRequest(2, 'animals/'))
-
-        when:
-        awsS3Bucket.listObjects(new ListObjectsRequest(3, 'plants/', firstPage.continuationToken.orElse(null)))
-
-        then:
-        def e = thrown(Exception)
-        e.message == 'AWS S3 continuation token does not match the current request'
-
-        cleanup:
-        keys.each {
-            awsS3Bucket.delete(it)
-        }
-    }
 }

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3PaginationSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3PaginationSpec.groovy
@@ -1,0 +1,73 @@
+package io.micronaut.objectstorage.aws
+
+import io.micronaut.objectstorage.request.ListObjectsRequest
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.utility.DockerImageName
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+import static io.micronaut.objectstorage.test.ObjectStorageTestConstants.LOCAL_STACK_DOCKER_IMAGE
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3
+
+@MicronautTest(startApplication = false)
+class AwsS3PaginationSpec extends AbstractAwsS3Spec implements TestPropertyProvider {
+
+    @Shared
+    @AutoCleanup
+    LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
+        .withServices(S3)
+
+    @Override
+    Map<String, String> getProperties() {
+        localstack.start()
+        super.getProperties() + [
+                'aws.accessKeyId'                : localstack.accessKey,
+                'aws.secretKey'                  : localstack.secretKey,
+                'aws.region'                     : localstack.region,
+                'aws.services.s3.endpoint-override': localstack.getEndpointOverride(S3)
+        ] as Map
+    }
+
+    void 'paginated listing uses native AWS continuation tokens and preserves AWS response order'() {
+        given:
+        List<String> keys = [
+                'animals/cat.txt',
+                'animals/dog.txt',
+                'animals/mammals/fox.txt',
+                'plants/oak.txt',
+                'plants/pine.txt',
+        ]
+        keys.each { awsS3Bucket.upload(UploadRequest.fromBytes(TEXT.bytes, it, CONTENT_TYPE)) }
+
+        when:
+        def firstPage = awsS3Bucket.listObjects(new ListObjectsRequest(2))
+        def secondPage = awsS3Bucket.listObjects(new ListObjectsRequest(2, null, firstPage.continuationToken.orElse(null)))
+        def finalPage = awsS3Bucket.listObjects(new ListObjectsRequest(2, null, secondPage.continuationToken.orElse(null)))
+
+        then:
+        firstPage.keys == ['animals/cat.txt', 'animals/dog.txt']
+        firstPage.continuationToken.present
+        secondPage.keys == ['animals/mammals/fox.txt', 'plants/oak.txt']
+        secondPage.continuationToken.present
+        finalPage.keys == ['plants/pine.txt']
+        !finalPage.continuationToken.present
+
+        when:
+        def prefixedFirstPage = awsS3Bucket.listObjects(new ListObjectsRequest(2, 'animals/'))
+        def prefixedSecondPage = awsS3Bucket.listObjects(new ListObjectsRequest(2, 'animals/', prefixedFirstPage.continuationToken.orElse(null)))
+
+        then:
+        prefixedFirstPage.keys == ['animals/cat.txt', 'animals/dog.txt']
+        prefixedFirstPage.continuationToken.present
+        prefixedSecondPage.keys == ['animals/mammals/fox.txt']
+        !prefixedSecondPage.continuationToken.present
+
+        cleanup:
+        keys.each {
+            awsS3Bucket.delete(it)
+        }
+    }
+}

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3PaginationSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3PaginationSpec.groovy
@@ -70,4 +70,33 @@ class AwsS3PaginationSpec extends AbstractAwsS3Spec implements TestPropertyProvi
             awsS3Bucket.delete(it)
         }
     }
+
+    void 'replaying the first AWS page returns the same Micronaut continuation token'() {
+        given:
+        List<String> keys = [
+                'animals/cat.txt',
+                'animals/dog.txt',
+                'animals/mammals/fox.txt',
+                'plants/oak.txt',
+                'plants/pine.txt',
+        ]
+        keys.each { awsS3Bucket.upload(UploadRequest.fromBytes(TEXT.bytes, it, CONTENT_TYPE)) }
+        ListObjectsRequest request = new ListObjectsRequest(2)
+
+        when:
+        def firstPage = awsS3Bucket.listObjects(request)
+        def replayedFirstPage = awsS3Bucket.listObjects(request)
+        def secondPage = awsS3Bucket.listObjects(new ListObjectsRequest(2, null, firstPage.continuationToken.orElse(null)))
+
+        then:
+        firstPage.keys == ['animals/cat.txt', 'animals/dog.txt']
+        replayedFirstPage.keys == firstPage.keys
+        replayedFirstPage.continuationToken == firstPage.continuationToken
+        secondPage.keys == ['animals/mammals/fox.txt', 'plants/oak.txt']
+
+        cleanup:
+        keys.each {
+            awsS3Bucket.delete(it)
+        }
+    }
 }

--- a/object-storage-azure/build.gradle.kts
+++ b/object-storage-azure/build.gradle.kts
@@ -14,3 +14,9 @@ dependencies {
     testImplementation(projects.micronautObjectStorageTck)
     testImplementation(mnTestResources.testcontainers.core)
 }
+
+micronautBuild {
+    binaryCompatibility {
+        enabledAfter("3.0.0")
+    }
+}

--- a/object-storage-azure/build.gradle.kts
+++ b/object-storage-azure/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
     testImplementation(projects.micronautObjectStorageTck)
     testImplementation(mnTestResources.testcontainers.core)
 }
-
 micronautBuild {
     binaryCompatibility {
         enabledAfter("3.0.0")

--- a/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageOperations.java
+++ b/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageOperations.java
@@ -68,6 +68,8 @@ import static java.lang.Boolean.TRUE;
 public class AzureBlobStorageOperations
     implements ObjectStorageOperations<BlobParallelUploadOptions, BlockBlobItem, Response<Void>> {
 
+    private static final int DEFAULT_LIST_PAGE_SIZE = 1_000;
+
     private final BlobContainerClient blobContainerClient;
 
     public AzureBlobStorageOperations(@Parameter BlobContainerClient blobContainerClient) {
@@ -128,7 +130,7 @@ public class AzureBlobStorageOperations
         Set<String> keys = new LinkedHashSet<>();
         String continuationToken = null;
         do {
-            ListObjectsResponse response = listObjects(new ListObjectsRequest(1000, null, continuationToken));
+            ListObjectsResponse response = listObjects(new ListObjectsRequest(DEFAULT_LIST_PAGE_SIZE, null, continuationToken));
             keys.addAll(response.getKeys());
             continuationToken = response.getContinuationToken().orElse(null);
         } while (continuationToken != null);

--- a/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageOperations.java
+++ b/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageOperations.java
@@ -16,6 +16,7 @@
 package io.micronaut.objectstorage.azure;
 
 import com.azure.core.http.rest.Response;
+import com.azure.core.http.rest.PagedResponse;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.Context;
 import com.azure.storage.blob.BlobClient;
@@ -25,6 +26,7 @@ import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.models.BlobProperties;
 import com.azure.storage.blob.models.BlobRequestConditions;
 import com.azure.storage.blob.models.BlockBlobItem;
+import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.blob.options.BlobParallelUploadOptions;
 import com.azure.storage.blob.options.BlockBlobSimpleUploadOptions;
 import io.micronaut.context.annotation.EachBean;
@@ -33,17 +35,23 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.ObjectStorageOperations;
+import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
+import io.micronaut.objectstorage.response.ListObjectsResponse;
 import io.micronaut.objectstorage.response.UploadResponse;
 import org.jspecify.annotations.NonNull;
 
 import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import static com.azure.storage.common.implementation.Constants.HeaderConstants.ETAG_WILDCARD;
 import static java.lang.Boolean.TRUE;
@@ -117,9 +125,50 @@ public class AzureBlobStorageOperations
     @NonNull
     @Override
     public Set<String> listObjects() {
-        return blobContainerClient.listBlobs().stream()
-            .map(BlobItem::getName)
-            .collect(Collectors.toSet());
+        Set<String> keys = new LinkedHashSet<>();
+        String continuationToken = null;
+        do {
+            ListObjectsResponse response = listObjects(new ListObjectsRequest(1000, null, continuationToken));
+            keys.addAll(response.getKeys());
+            continuationToken = response.getContinuationToken().orElse(null);
+        } while (continuationToken != null);
+        return keys;
+    }
+
+    @Override
+    @NonNull
+    public ListObjectsResponse listObjects(@NonNull ListObjectsRequest request) {
+        Iterator<PagedResponse<BlobItem>> pages = listNativeBlobs(
+            request.getPrefix().orElse(null),
+            request.getContinuationToken().orElse(null),
+            request.getPageSize()
+        ).iterator();
+        if (!pages.hasNext()) {
+            return new ListObjectsResponse(Collections.emptyList());
+        }
+        PagedResponse<BlobItem> page = pages.next();
+        List<String> keys = new ArrayList<>();
+        for (BlobItem blobItem : page.getElements()) {
+            keys.add(blobItem.getName());
+        }
+        return new ListObjectsResponse(keys, page.getContinuationToken());
+    }
+
+    /**
+     * Returns Azure-native paged blob responses for the requested prefix, continuation token, and page size.
+     * Subclasses may override this method only to customize page retrieval while preserving the Azure token and
+     * service-order semantics expected by {@link #listObjects(io.micronaut.objectstorage.request.ListObjectsRequest)}.
+     *
+     * @param prefix The raw key prefix filter, or {@code null} when no prefix filtering is requested
+     * @param continuationToken The opaque Azure continuation token, or {@code null} for the first page
+     * @param pageSize The requested maximum page size
+     * @return The Azure-native paged responses backing the current listing request
+     * @since 3.0.0
+     */
+    @NonNull
+    protected Iterable<PagedResponse<BlobItem>> listNativeBlobs(String prefix, String continuationToken, int pageSize) {
+        ListBlobsOptions options = new ListBlobsOptions().setPrefix(prefix);
+        return blobContainerClient.listBlobs(options, null).iterableByPage(continuationToken, pageSize);
     }
 
     @Override

--- a/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStorageCloudSpec.groovy
+++ b/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStorageCloudSpec.groovy
@@ -6,7 +6,13 @@ import spock.lang.Requires
 import static io.micronaut.objectstorage.azure.AzureBlobStorageConfiguration.PREFIX
 
 @MicronautTest
-@Requires({ env.AZURE_TEST_STORAGE_ACCOUNT_ENDPOINT && env.AZURE_CLIENT_ID && env.AZURE_CLIENT_SECRET && env.AZURE_TENANT_ID })
+@Requires({
+    String endpoint = env.AZURE_TEST_STORAGE_ACCOUNT_ENDPOINT
+    String clientId = env.AZURE_CLIENT_ID
+    String clientSecret = env.AZURE_CLIENT_SECRET
+    String tenantId = env.AZURE_TENANT_ID
+    return endpoint?.startsWith('https://') && clientId && clientSecret && tenantId && !Boolean.getBoolean('azure.test.skip.cloud')
+})
 class AzureBlobStorageCloudSpec extends AbstractAzureBlobStorageSpec {
 
     @Override

--- a/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStoragePaginationSpec.groovy
+++ b/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStoragePaginationSpec.groovy
@@ -1,0 +1,165 @@
+package io.micronaut.objectstorage.azure
+
+import com.azure.core.http.HttpHeaders
+import com.azure.core.http.HttpRequest
+import com.azure.core.http.rest.PagedResponse
+import com.azure.core.util.IterableStream
+import com.azure.storage.blob.models.BlobItem
+import io.micronaut.objectstorage.request.ListObjectsRequest
+import spock.lang.Specification
+
+class AzureBlobStoragePaginationSpec extends Specification {
+
+    void "it lists a native Azure page with prefix page size and opaque continuation token"() {
+        given:
+        def operations = new TestAzureBlobStorageOperations([
+                new RecordedPageCall('animals/', 'opaque-token-1', 2, pagedResponse([
+                        blobItem('animals/cat.txt'),
+                        blobItem('animals/dog.txt')
+                ], 'opaque-token-2'))
+        ])
+
+        when:
+        def page = operations.listObjects(new ListObjectsRequest(2, 'animals/', 'opaque-token-1'))
+
+        then:
+        page.keys == ['animals/cat.txt', 'animals/dog.txt']
+        page.continuationToken.orElse(null) == 'opaque-token-2'
+    }
+
+    void "it preserves service order on terminal Azure pages and keeps bounded page sizes"() {
+        given:
+        def operations = new TestAzureBlobStorageOperations([
+                new RecordedPageCall('animals/', null, 2, pagedResponse([
+                        blobItem('animals/zebra.txt'),
+                        blobItem('animals/ant.txt')
+                ], null))
+        ])
+
+        when:
+        def page = operations.listObjects(new ListObjectsRequest(2, 'animals/'))
+
+        then:
+        page.keys == ['animals/zebra.txt', 'animals/ant.txt']
+        page.keys.size() == 2
+        page.continuationToken.empty
+    }
+
+    void "legacy listObjects exhausts paginated Azure listing with internal page size 1000"() {
+        given:
+        def operations = new TestAzureBlobStorageOperations([
+                new RecordedPageCall(null, null, 1000, pagedResponse([
+                        blobItem('alpha'),
+                        blobItem('beta')
+                ], 'token-1')),
+                new RecordedPageCall(null, 'token-1', 1000, pagedResponse([
+                        blobItem('gamma')
+                ], null))
+        ])
+
+        when:
+        def keys = operations.listObjects()
+
+        then:
+        keys == ['alpha', 'beta', 'gamma'] as LinkedHashSet
+    }
+
+    void "it returns an empty portable page when Azure yields no native page"() {
+        given:
+        def operations = new TestAzureBlobStorageOperations([])
+
+        when:
+        def page = operations.listObjects(new ListObjectsRequest(2, 'animals/'))
+
+        then:
+        page.keys.empty
+        page.continuationToken.empty
+    }
+
+    private static BlobItem blobItem(String name) {
+        new BlobItem().setName(name)
+    }
+
+    private static PagedResponse<BlobItem> pagedResponse(List<BlobItem> elements, String continuationToken) {
+        new TestPagedResponse(elements, continuationToken)
+    }
+
+    private static final class TestAzureBlobStorageOperations extends AzureBlobStorageOperations {
+        private final Iterator<RecordedPageCall> calls
+
+        TestAzureBlobStorageOperations(List<RecordedPageCall> calls) {
+            super(null)
+            this.calls = calls.iterator()
+        }
+
+        @Override
+        protected Iterable<PagedResponse<BlobItem>> listNativeBlobs(String prefix, String continuationToken, int pageSize) {
+            if (!calls.hasNext()) {
+                return []
+            }
+            RecordedPageCall call = calls.next()
+            assert prefix == call.expectedPrefix
+            assert continuationToken == call.expectedContinuationToken
+            assert pageSize == call.expectedPageSize
+            [call.response]
+        }
+    }
+
+    private static final class RecordedPageCall {
+        final String expectedPrefix
+        final String expectedContinuationToken
+        final int expectedPageSize
+        final PagedResponse<BlobItem> response
+
+        RecordedPageCall(String expectedPrefix, String expectedContinuationToken, int expectedPageSize, PagedResponse<BlobItem> response) {
+            this.expectedPrefix = expectedPrefix
+            this.expectedContinuationToken = expectedContinuationToken
+            this.expectedPageSize = expectedPageSize
+            this.response = response
+        }
+    }
+
+    private static final class TestPagedResponse implements PagedResponse<BlobItem> {
+        private final List<BlobItem> elements
+        private final String continuationToken
+
+        TestPagedResponse(List<BlobItem> elements, String continuationToken) {
+            this.elements = elements
+            this.continuationToken = continuationToken
+        }
+
+        @Override
+        int getStatusCode() {
+            200
+        }
+
+        @Override
+        HttpHeaders getHeaders() {
+            new HttpHeaders()
+        }
+
+        @Override
+        HttpRequest getRequest() {
+            null
+        }
+
+        @Override
+        List<BlobItem> getValue() {
+            elements
+        }
+
+        @Override
+        IterableStream<BlobItem> getElements() {
+            IterableStream.of(elements)
+        }
+
+        @Override
+        String getContinuationToken() {
+            continuationToken
+        }
+
+        @Override
+        void close() {
+        }
+    }
+}

--- a/object-storage-core/build.gradle.kts
+++ b/object-storage-core/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     testImplementation(mn.reactor)
 
 }
-
 micronautBuild {
     binaryCompatibility {
         enabledAfter("3.0.0")

--- a/object-storage-core/build.gradle.kts
+++ b/object-storage-core/build.gradle.kts
@@ -17,3 +17,9 @@ dependencies {
     testImplementation(mn.reactor)
 
 }
+
+micronautBuild {
+    binaryCompatibility {
+        enabledAfter("3.0.0")
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/ObjectStorageOperations.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/ObjectStorageOperations.java
@@ -17,10 +17,13 @@ package io.micronaut.objectstorage;
 
 import io.micronaut.core.annotation.Blocking;
 import org.jspecify.annotations.NonNull;
+import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
+import io.micronaut.objectstorage.response.ListObjectsResponse;
 import io.micronaut.objectstorage.response.UploadResponse;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -104,6 +107,37 @@ public interface ObjectStorageOperations<I, O, D> {
     @NonNull
     default Set<String> listObjects() {
         return Collections.emptySet();
+    }
+
+    /**
+     * Lists a page of objects that exist in the object storage.
+     *
+     * @param request the paginated listing request
+     * @return the ordered keys in the current page and an optional continuation token for the next page
+     * @since 3.0.0
+     */
+    @Blocking
+    @NonNull
+    default ListObjectsResponse listObjects(@NonNull ListObjectsRequest request) {
+        List<String> filtered = listObjects().stream()
+            .filter(key -> request.getPrefix().map(key::startsWith).orElse(true))
+            .sorted()
+            .toList();
+
+        int startIndex = request.getContinuationToken()
+            .map(token -> {
+                int index = Collections.binarySearch(filtered, token);
+                return index >= 0 ? index + 1 : -index - 1;
+            })
+            .orElse(0);
+        if (startIndex >= filtered.size()) {
+            return new ListObjectsResponse(Collections.emptyList());
+        }
+
+        int endIndex = Math.min(startIndex + request.getPageSize(), filtered.size());
+        List<String> page = filtered.subList(startIndex, endIndex);
+        String nextContinuationToken = endIndex < filtered.size() ? page.get(page.size() - 1) : null;
+        return new ListObjectsResponse(page, nextContinuationToken);
     }
 
     /**

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/request/ListObjectsRequest.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/request/ListObjectsRequest.java
@@ -25,9 +25,13 @@ import java.util.Optional;
  *
  * @since 3.0.0
  */
-public record ListObjectsRequest(int pageSize,
-                                 @Nullable String prefix,
-                                 @Nullable String continuationToken) {
+public final class ListObjectsRequest {
+
+    private final int pageSize;
+    @Nullable
+    private final String prefix;
+    @Nullable
+    private final String continuationToken;
 
     /**
      * @param pageSize the maximum number of keys to return
@@ -44,12 +48,18 @@ public record ListObjectsRequest(int pageSize,
         this(pageSize, prefix, null);
     }
 
-    public ListObjectsRequest {
+    /**
+     * @param pageSize the maximum number of keys to return
+     * @param prefix the prefix to filter keys by
+     * @param continuationToken the opaque continuation token for the next page
+     */
+    public ListObjectsRequest(int pageSize, @Nullable String prefix, @Nullable String continuationToken) {
         if (pageSize <= 0) {
             throw new IllegalArgumentException("pageSize must be greater than 0");
         }
-        prefix = normalize(prefix);
-        continuationToken = normalize(continuationToken);
+        this.pageSize = pageSize;
+        this.prefix = normalize(prefix);
+        this.continuationToken = normalize(continuationToken);
     }
 
     /**

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/request/ListObjectsRequest.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/request/ListObjectsRequest.java
@@ -25,13 +25,9 @@ import java.util.Optional;
  *
  * @since 3.0.0
  */
-public final class ListObjectsRequest {
-
-    private final int pageSize;
-    @Nullable
-    private final String prefix;
-    @Nullable
-    private final String continuationToken;
+public record ListObjectsRequest(int pageSize,
+                                 @Nullable String prefix,
+                                 @Nullable String continuationToken) {
 
     /**
      * @param pageSize the maximum number of keys to return
@@ -48,18 +44,12 @@ public final class ListObjectsRequest {
         this(pageSize, prefix, null);
     }
 
-    /**
-     * @param pageSize the maximum number of keys to return
-     * @param prefix the prefix to filter keys by
-     * @param continuationToken the opaque continuation token for the next page
-     */
-    public ListObjectsRequest(int pageSize, @Nullable String prefix, @Nullable String continuationToken) {
+    public ListObjectsRequest {
         if (pageSize <= 0) {
             throw new IllegalArgumentException("pageSize must be greater than 0");
         }
-        this.pageSize = pageSize;
-        this.prefix = normalize(prefix);
-        this.continuationToken = normalize(continuationToken);
+        prefix = normalize(prefix);
+        continuationToken = normalize(continuationToken);
     }
 
     /**

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/request/ListObjectsRequest.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/request/ListObjectsRequest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.request;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Optional;
+
+/**
+ * Paginated object listing request.
+ *
+ * @since 3.0.0
+ */
+public final class ListObjectsRequest {
+
+    private final int pageSize;
+    @Nullable
+    private final String prefix;
+    @Nullable
+    private final String continuationToken;
+
+    /**
+     * @param pageSize the maximum number of keys to return
+     */
+    public ListObjectsRequest(int pageSize) {
+        this(pageSize, null, null);
+    }
+
+    /**
+     * @param pageSize the maximum number of keys to return
+     * @param prefix the prefix to filter keys by
+     */
+    public ListObjectsRequest(int pageSize, @Nullable String prefix) {
+        this(pageSize, prefix, null);
+    }
+
+    /**
+     * @param pageSize the maximum number of keys to return
+     * @param prefix the prefix to filter keys by
+     * @param continuationToken the opaque continuation token for the next page
+     */
+    public ListObjectsRequest(int pageSize, @Nullable String prefix, @Nullable String continuationToken) {
+        if (pageSize <= 0) {
+            throw new IllegalArgumentException("pageSize must be greater than 0");
+        }
+        this.pageSize = pageSize;
+        this.prefix = normalize(prefix);
+        this.continuationToken = normalize(continuationToken);
+    }
+
+    /**
+     * @return the maximum number of keys to return
+     */
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    /**
+     * @return the prefix to filter keys by, if present
+     */
+    @NonNull
+    public Optional<String> getPrefix() {
+        return Optional.ofNullable(prefix);
+    }
+
+    /**
+     * @return the opaque continuation token for the next page, if present
+     */
+    @NonNull
+    public Optional<String> getContinuationToken() {
+        return Optional.ofNullable(continuationToken);
+    }
+
+    @Nullable
+    private static String normalize(@Nullable String value) {
+        return value == null || value.isEmpty() ? null : value;
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/request/StreamingFileUploadRequest.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/request/StreamingFileUploadRequest.java
@@ -77,7 +77,7 @@ public class StreamingFileUploadRequest implements UploadRequest {
     @NonNull
     @Override
     public InputStream getInputStream() {
-    	return streamingFileUpload.asInputStream();
+        return streamingFileUpload.asInputStream();
     }
 
     @Override

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/response/ListObjectsResponse.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/response/ListObjectsResponse.java
@@ -26,11 +26,8 @@ import java.util.Optional;
  *
  * @since 3.0.0
  */
-public final class ListObjectsResponse {
-
-    private final List<String> keys;
-    @Nullable
-    private final String continuationToken;
+public record ListObjectsResponse(@NonNull List<String> keys,
+                                  @Nullable String continuationToken) {
 
     /**
      * @param keys the ordered keys in the current page
@@ -39,13 +36,9 @@ public final class ListObjectsResponse {
         this(keys, null);
     }
 
-    /**
-     * @param keys the ordered keys in the current page
-     * @param continuationToken the opaque continuation token for the next page
-     */
-    public ListObjectsResponse(@NonNull List<String> keys, @Nullable String continuationToken) {
-        this.keys = List.copyOf(keys);
-        this.continuationToken = continuationToken == null || continuationToken.isEmpty() ? null : continuationToken;
+    public ListObjectsResponse {
+        keys = List.copyOf(keys);
+        continuationToken = continuationToken == null || continuationToken.isEmpty() ? null : continuationToken;
     }
 
     /**

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/response/ListObjectsResponse.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/response/ListObjectsResponse.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.response;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Paginated object listing response.
+ *
+ * @since 3.0.0
+ */
+public final class ListObjectsResponse {
+
+    private final List<String> keys;
+    @Nullable
+    private final String continuationToken;
+
+    /**
+     * @param keys the ordered keys in the current page
+     */
+    public ListObjectsResponse(@NonNull List<String> keys) {
+        this(keys, null);
+    }
+
+    /**
+     * @param keys the ordered keys in the current page
+     * @param continuationToken the opaque continuation token for the next page
+     */
+    public ListObjectsResponse(@NonNull List<String> keys, @Nullable String continuationToken) {
+        this.keys = List.copyOf(keys);
+        this.continuationToken = continuationToken == null || continuationToken.isEmpty() ? null : continuationToken;
+    }
+
+    /**
+     * @return the ordered keys in the current page
+     */
+    @NonNull
+    public List<String> getKeys() {
+        return keys;
+    }
+
+    /**
+     * @return the opaque continuation token for the next page, if present
+     */
+    @NonNull
+    public Optional<String> getContinuationToken() {
+        return Optional.ofNullable(continuationToken);
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/response/ListObjectsResponse.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/response/ListObjectsResponse.java
@@ -26,8 +26,11 @@ import java.util.Optional;
  *
  * @since 3.0.0
  */
-public record ListObjectsResponse(@NonNull List<String> keys,
-                                  @Nullable String continuationToken) {
+public final class ListObjectsResponse {
+
+    private final List<String> keys;
+    @Nullable
+    private final String continuationToken;
 
     /**
      * @param keys the ordered keys in the current page
@@ -36,9 +39,13 @@ public record ListObjectsResponse(@NonNull List<String> keys,
         this(keys, null);
     }
 
-    public ListObjectsResponse {
-        keys = List.copyOf(keys);
-        continuationToken = continuationToken == null || continuationToken.isEmpty() ? null : continuationToken;
+    /**
+     * @param keys the ordered keys in the current page
+     * @param continuationToken the opaque continuation token for the next page
+     */
+    public ListObjectsResponse(@NonNull List<String> keys, @Nullable String continuationToken) {
+        this.keys = List.copyOf(keys);
+        this.continuationToken = continuationToken == null || continuationToken.isEmpty() ? null : continuationToken;
     }
 
     /**

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/ObjectStorageOperationsPaginationFallbackSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/ObjectStorageOperationsPaginationFallbackSpec.groovy
@@ -21,7 +21,7 @@ class ObjectStorageOperationsPaginationFallbackSpec extends Specification {
 
         then:
         response.keys == ["animals/cat.txt", "animals/dog.txt"]
-        response.getContinuationToken().get() == "animals/dog.txt"
+        response.continuationToken.get() == "animals/dog.txt"
     }
 
     void "it starts strictly after continuation token in sorted filtered keys"() {
@@ -30,7 +30,7 @@ class ObjectStorageOperationsPaginationFallbackSpec extends Specification {
 
         then:
         response.keys == ["animals/mammals/fox.txt"]
-        response.getContinuationToken().empty
+        response.continuationToken.empty
     }
 
     void "it starts from the first lexicographically greater key when the continuation token is unknown"() {
@@ -39,7 +39,7 @@ class ObjectStorageOperationsPaginationFallbackSpec extends Specification {
 
         then:
         response.keys == ["animals/dog.txt", "animals/mammals/fox.txt"]
-        response.getContinuationToken().empty
+        response.continuationToken.empty
     }
 
     void "it starts from first matching key when continuation token is absent"() {
@@ -48,7 +48,7 @@ class ObjectStorageOperationsPaginationFallbackSpec extends Specification {
 
         then:
         response.keys == ["plants/oak.txt"]
-        response.getContinuationToken().empty
+        response.continuationToken.empty
     }
 
     void "it falls back to full sorted legacy listing without prefix"() {
@@ -57,7 +57,7 @@ class ObjectStorageOperationsPaginationFallbackSpec extends Specification {
 
         then:
         response.keys == ["animals/cat.txt", "animals/dog.txt", "animals/mammals/fox.txt"]
-        response.getContinuationToken().get() == "animals/mammals/fox.txt"
+        response.continuationToken.get() == "animals/mammals/fox.txt"
     }
 
     private static final class LegacyOnlyOperations implements ObjectStorageOperations<Object, Object, Object> {

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/ObjectStorageOperationsPaginationFallbackSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/ObjectStorageOperationsPaginationFallbackSpec.groovy
@@ -1,0 +1,90 @@
+package io.micronaut.objectstorage
+
+import io.micronaut.objectstorage.request.ListObjectsRequest
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.objectstorage.response.UploadResponse
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.util.Optional
+import java.util.Set
+import java.util.function.Consumer
+
+class ObjectStorageOperationsPaginationFallbackSpec extends Specification {
+
+    @Subject
+    ObjectStorageOperations<Object, Object, Object> operations = new LegacyOnlyOperations()
+
+    void "it lists first page from legacy keys using sorted filtered fallback"() {
+        when:
+        def response = operations.listObjects(new ListObjectsRequest(2, "animals/"))
+
+        then:
+        response.keys == ["animals/cat.txt", "animals/dog.txt"]
+        response.continuationToken.get() == "animals/dog.txt"
+    }
+
+    void "it starts strictly after continuation token in sorted filtered keys"() {
+        when:
+        def response = operations.listObjects(new ListObjectsRequest(2, "animals/", "animals/dog.txt"))
+
+        then:
+        response.keys == ["animals/mammals/fox.txt"]
+        response.continuationToken.empty
+    }
+
+    void "it starts from the first lexicographically greater key when the continuation token is unknown"() {
+        when:
+        def response = operations.listObjects(new ListObjectsRequest(2, "animals/", "animals/cow.txt"))
+
+        then:
+        response.keys == ["animals/dog.txt", "animals/mammals/fox.txt"]
+        response.continuationToken.empty
+    }
+
+    void "it starts from first matching key when continuation token is absent"() {
+        when:
+        def response = operations.listObjects(new ListObjectsRequest(3, "plants/"))
+
+        then:
+        response.keys == ["plants/oak.txt"]
+        response.continuationToken.empty
+    }
+
+    void "it falls back to full sorted legacy listing without prefix"() {
+        when:
+        def response = operations.listObjects(new ListObjectsRequest(3))
+
+        then:
+        response.keys == ["animals/cat.txt", "animals/dog.txt", "animals/mammals/fox.txt"]
+        response.continuationToken.get() == "animals/mammals/fox.txt"
+    }
+
+    private static final class LegacyOnlyOperations implements ObjectStorageOperations<Object, Object, Object> {
+
+        @Override
+        UploadResponse<Object> upload(UploadRequest request) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        UploadResponse<Object> upload(UploadRequest request, Consumer<Object> requestConsumer) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        Optional<ObjectStorageEntry<?>> retrieve(String key) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        Object delete(String key) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        Set<String> listObjects() {
+            ["plants/oak.txt", "animals/mammals/fox.txt", "animals/dog.txt", "animals/cat.txt"] as Set
+        }
+    }
+}

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/ObjectStorageOperationsPaginationFallbackSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/ObjectStorageOperationsPaginationFallbackSpec.groovy
@@ -21,7 +21,7 @@ class ObjectStorageOperationsPaginationFallbackSpec extends Specification {
 
         then:
         response.keys == ["animals/cat.txt", "animals/dog.txt"]
-        response.continuationToken.get() == "animals/dog.txt"
+        response.getContinuationToken().get() == "animals/dog.txt"
     }
 
     void "it starts strictly after continuation token in sorted filtered keys"() {
@@ -30,7 +30,7 @@ class ObjectStorageOperationsPaginationFallbackSpec extends Specification {
 
         then:
         response.keys == ["animals/mammals/fox.txt"]
-        response.continuationToken.empty
+        response.getContinuationToken().empty
     }
 
     void "it starts from the first lexicographically greater key when the continuation token is unknown"() {
@@ -39,7 +39,7 @@ class ObjectStorageOperationsPaginationFallbackSpec extends Specification {
 
         then:
         response.keys == ["animals/dog.txt", "animals/mammals/fox.txt"]
-        response.continuationToken.empty
+        response.getContinuationToken().empty
     }
 
     void "it starts from first matching key when continuation token is absent"() {
@@ -48,7 +48,7 @@ class ObjectStorageOperationsPaginationFallbackSpec extends Specification {
 
         then:
         response.keys == ["plants/oak.txt"]
-        response.continuationToken.empty
+        response.getContinuationToken().empty
     }
 
     void "it falls back to full sorted legacy listing without prefix"() {
@@ -57,7 +57,7 @@ class ObjectStorageOperationsPaginationFallbackSpec extends Specification {
 
         then:
         response.keys == ["animals/cat.txt", "animals/dog.txt", "animals/mammals/fox.txt"]
-        response.continuationToken.get() == "animals/mammals/fox.txt"
+        response.getContinuationToken().get() == "animals/mammals/fox.txt"
     }
 
     private static final class LegacyOnlyOperations implements ObjectStorageOperations<Object, Object, Object> {

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/request/ListObjectsRequestSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/request/ListObjectsRequestSpec.groovy
@@ -12,13 +12,13 @@ class ListObjectsRequestSpec extends Specification {
 
         then:
         request.pageSize == 25
-        request.prefix.empty
-        request.continuationToken.empty
+        request.getPrefix().empty
+        request.getContinuationToken().empty
     }
 
     void "it normalizes null and empty prefix to absent"() {
         expect:
-        new ListObjectsRequest(10, prefix).prefix.empty
+        new ListObjectsRequest(10, prefix).getPrefix().empty
 
         where:
         prefix << [null, ""]
@@ -30,13 +30,13 @@ class ListObjectsRequestSpec extends Specification {
 
         then:
         request.pageSize == 15
-        request.prefix.get() == "folder/"
-        request.continuationToken.get() == "token-1"
+        request.getPrefix().get() == "folder/"
+        request.getContinuationToken().get() == "token-1"
     }
 
     void "it allows empty continuation token semantics as absent"() {
         expect:
-        new ListObjectsRequest(10, "prefix", token).continuationToken == expected
+        new ListObjectsRequest(10, "prefix", token).getContinuationToken() == expected
 
         where:
         token      || expected

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/request/ListObjectsRequestSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/request/ListObjectsRequestSpec.groovy
@@ -12,13 +12,13 @@ class ListObjectsRequestSpec extends Specification {
 
         then:
         request.pageSize == 25
-        request.getPrefix().empty
-        request.getContinuationToken().empty
+        request.prefix.empty
+        request.continuationToken.empty
     }
 
     void "it normalizes null and empty prefix to absent"() {
         expect:
-        new ListObjectsRequest(10, prefix).getPrefix().empty
+        new ListObjectsRequest(10, prefix).prefix.empty
 
         where:
         prefix << [null, ""]
@@ -30,13 +30,13 @@ class ListObjectsRequestSpec extends Specification {
 
         then:
         request.pageSize == 15
-        request.getPrefix().get() == "folder/"
-        request.getContinuationToken().get() == "token-1"
+        request.prefix.get() == "folder/"
+        request.continuationToken.get() == "token-1"
     }
 
     void "it allows empty continuation token semantics as absent"() {
         expect:
-        new ListObjectsRequest(10, "prefix", token).getContinuationToken() == expected
+        new ListObjectsRequest(10, "prefix", token).continuationToken == expected
 
         where:
         token      || expected

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/request/ListObjectsRequestSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/request/ListObjectsRequestSpec.groovy
@@ -1,0 +1,59 @@
+package io.micronaut.objectstorage.request
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+@Subject(ListObjectsRequest)
+class ListObjectsRequestSpec extends Specification {
+
+    void "it creates request with page size only"() {
+        when:
+        def request = new ListObjectsRequest(25)
+
+        then:
+        request.pageSize == 25
+        request.prefix.empty
+        request.continuationToken.empty
+    }
+
+    void "it normalizes null and empty prefix to absent"() {
+        expect:
+        new ListObjectsRequest(10, prefix).prefix.empty
+
+        where:
+        prefix << [null, ""]
+    }
+
+    void "it preserves non empty prefix and continuation token"() {
+        when:
+        def request = new ListObjectsRequest(15, "folder/", "token-1")
+
+        then:
+        request.pageSize == 15
+        request.prefix.get() == "folder/"
+        request.continuationToken.get() == "token-1"
+    }
+
+    void "it allows empty continuation token semantics as absent"() {
+        expect:
+        new ListObjectsRequest(10, "prefix", token).continuationToken == expected
+
+        where:
+        token      || expected
+        null       || Optional.empty()
+        ''         || Optional.empty()
+        'token-1'  || Optional.of('token-1')
+    }
+
+    void "it rejects non positive page size"() {
+        when:
+        new ListObjectsRequest(pageSize)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == 'pageSize must be greater than 0'
+
+        where:
+        pageSize << [0, -1]
+    }
+}

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/response/ListObjectsResponseSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/response/ListObjectsResponseSpec.groovy
@@ -26,7 +26,7 @@ class ListObjectsResponseSpec extends Specification {
 
     void "it exposes empty continuation token semantics"() {
         expect:
-        new ListObjectsResponse(['a'], token).getContinuationToken() == expected
+        new ListObjectsResponse(['a'], token).continuationToken == expected
 
         where:
         token      || expected
@@ -41,6 +41,6 @@ class ListObjectsResponseSpec extends Specification {
 
         then:
         response.keys == ['prefix/b', 'prefix/a']
-        response.getContinuationToken().get() == 'token-2'
+        response.continuationToken.get() == 'token-2'
     }
 }

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/response/ListObjectsResponseSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/response/ListObjectsResponseSpec.groovy
@@ -1,0 +1,46 @@
+package io.micronaut.objectstorage.response
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+@Subject(ListObjectsResponse)
+class ListObjectsResponseSpec extends Specification {
+
+    void "it exposes ordered immutable keys"() {
+        given:
+        def source = ['b', 'a']
+
+        when:
+        def response = new ListObjectsResponse(source)
+        source << 'c'
+
+        then:
+        response.keys == ['b', 'a']
+
+        when:
+        response.keys << 'd'
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    void "it exposes empty continuation token semantics"() {
+        expect:
+        new ListObjectsResponse(['a'], token).continuationToken == expected
+
+        where:
+        token      || expected
+        null       || Optional.empty()
+        ''         || Optional.empty()
+        'token-1'  || Optional.of('token-1')
+    }
+
+    void "it preserves provided key order and token"() {
+        when:
+        def response = new ListObjectsResponse(['prefix/b', 'prefix/a'], 'token-2')
+
+        then:
+        response.keys == ['prefix/b', 'prefix/a']
+        response.continuationToken.get() == 'token-2'
+    }
+}

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/response/ListObjectsResponseSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/response/ListObjectsResponseSpec.groovy
@@ -26,7 +26,7 @@ class ListObjectsResponseSpec extends Specification {
 
     void "it exposes empty continuation token semantics"() {
         expect:
-        new ListObjectsResponse(['a'], token).continuationToken == expected
+        new ListObjectsResponse(['a'], token).getContinuationToken() == expected
 
         where:
         token      || expected
@@ -41,6 +41,6 @@ class ListObjectsResponseSpec extends Specification {
 
         then:
         response.keys == ['prefix/b', 'prefix/a']
-        response.continuationToken.get() == 'token-2'
+        response.getContinuationToken().get() == 'token-2'
     }
 }

--- a/object-storage-gcp/build.gradle.kts
+++ b/object-storage-gcp/build.gradle.kts
@@ -16,3 +16,9 @@ dependencies {
     testImplementation(projects.micronautObjectStorageTck)
     testImplementation(mnTestResources.testcontainers.core)
 }
+
+micronautBuild {
+    binaryCompatibility {
+        enabledAfter("3.0.0")
+    }
+}

--- a/object-storage-gcp/build.gradle.kts
+++ b/object-storage-gcp/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
     testImplementation(projects.micronautObjectStorageTck)
     testImplementation(mnTestResources.testcontainers.core)
 }
-
 micronautBuild {
     binaryCompatibility {
         enabledAfter("3.0.0")

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageEntry.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageEntry.java
@@ -19,7 +19,6 @@ import com.google.cloud.storage.Blob;
 import org.jspecify.annotations.NonNull;
 import io.micronaut.objectstorage.ObjectStorageEntry;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.channels.Channels;
 import java.util.Map;

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageOperations.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageOperations.java
@@ -28,15 +28,18 @@ import io.micronaut.objectstorage.InputStreamMapper;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.ObjectStorageOperations;
 import io.micronaut.objectstorage.configuration.ToggeableCondition;
+import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
+import io.micronaut.objectstorage.response.ListObjectsResponse;
 import io.micronaut.objectstorage.response.UploadResponse;
 import org.jspecify.annotations.NonNull;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 /**
  * Google Cloud implementation of {@link ObjectStorageOperations}.
@@ -49,6 +52,8 @@ import java.util.stream.StreamSupport;
 @Requires(beans = GoogleCloudStorageConfiguration.class)
 public class GoogleCloudStorageOperations
     implements ObjectStorageOperations<BlobInfo.Builder, Blob, Boolean> {
+
+    private static final int LEGACY_LIST_PAGE_SIZE = 1000;
 
     private final InputStreamMapper inputStreamMapper;
     private final Storage storage;
@@ -129,14 +134,39 @@ public class GoogleCloudStorageOperations
     @NonNull
     @Override
     public Set<String> listObjects() {
+        LinkedHashSet<String> keys = new LinkedHashSet<>();
         String bucket = configuration.getBucket();
         try {
-            Iterable<Blob> blobs = storage.list(bucket).iterateAll();
-            return StreamSupport.stream(blobs.spliterator(), false)
-                .map(BlobInfo::getName)
-                .collect(Collectors.toSet());
+            String continuationToken = null;
+            do {
+                ListObjectsResponse response = listObjects(new ListObjectsRequest(LEGACY_LIST_PAGE_SIZE, null, continuationToken));
+                keys.addAll(response.getKeys());
+                continuationToken = response.getContinuationToken().orElse(null);
+            } while (continuationToken != null);
+            return keys;
         } catch (StorageException e) {
             String msg = String.format("Error when listing the objects of the Google Cloud Storage bucket [%s]", bucket);
+            throw new ObjectStorageException(msg, e);
+        }
+    }
+
+    @Override
+    @NonNull
+    public ListObjectsResponse listObjects(@NonNull ListObjectsRequest request) {
+        String bucket = configuration.getBucket();
+        try {
+            List<Storage.BlobListOption> filteredOptions = new ArrayList<>();
+            request.getPrefix().map(Storage.BlobListOption::prefix).ifPresent(filteredOptions::add);
+            filteredOptions.add(Storage.BlobListOption.pageSize(request.getPageSize()));
+            request.getContinuationToken().map(Storage.BlobListOption::pageToken).ifPresent(filteredOptions::add);
+            com.google.api.gax.paging.Page<Blob> page = storage.list(bucket, filteredOptions.toArray(Storage.BlobListOption[]::new));
+            List<String> keys = new ArrayList<>();
+            for (Blob blob : page.getValues()) {
+                keys.add(blob.getName());
+            }
+            return new ListObjectsResponse(keys, page.getNextPageToken());
+        } catch (StorageException e) {
+            String msg = String.format("Error when listing a page of objects of the Google Cloud Storage bucket [%s]", bucket);
             throw new ObjectStorageException(msg, e);
         }
     }

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageOperations.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageOperations.java
@@ -20,6 +20,7 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
+import com.google.api.gax.paging.Page;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Requires;
@@ -53,7 +54,7 @@ import java.util.function.Consumer;
 public class GoogleCloudStorageOperations
     implements ObjectStorageOperations<BlobInfo.Builder, Blob, Boolean> {
 
-    private static final int LEGACY_LIST_PAGE_SIZE = 1000;
+    private static final int DEFAULT_LIST_PAGE_SIZE = 1_000;
 
     private final InputStreamMapper inputStreamMapper;
     private final Storage storage;
@@ -139,7 +140,7 @@ public class GoogleCloudStorageOperations
         try {
             String continuationToken = null;
             do {
-                ListObjectsResponse response = listObjects(new ListObjectsRequest(LEGACY_LIST_PAGE_SIZE, null, continuationToken));
+                ListObjectsResponse response = listObjects(new ListObjectsRequest(DEFAULT_LIST_PAGE_SIZE, null, continuationToken));
                 keys.addAll(response.getKeys());
                 continuationToken = response.getContinuationToken().orElse(null);
             } while (continuationToken != null);
@@ -159,7 +160,7 @@ public class GoogleCloudStorageOperations
             request.getPrefix().map(Storage.BlobListOption::prefix).ifPresent(filteredOptions::add);
             filteredOptions.add(Storage.BlobListOption.pageSize(request.getPageSize()));
             request.getContinuationToken().map(Storage.BlobListOption::pageToken).ifPresent(filteredOptions::add);
-            com.google.api.gax.paging.Page<Blob> page = storage.list(bucket, filteredOptions.toArray(Storage.BlobListOption[]::new));
+            Page<Blob> page = storage.list(bucket, filteredOptions.toArray(Storage.BlobListOption[]::new));
             List<String> keys = new ArrayList<>();
             for (Blob blob : page.getValues()) {
                 keys.add(blob.getName());

--- a/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageCloudSpec.groovy
+++ b/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageCloudSpec.groovy
@@ -3,7 +3,7 @@ package io.micronaut.objectstorage.googlecloud
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import spock.lang.Requires
 
-@Requires({ env.GCLOUD_TEST_PROJECT_ID })
+@Requires({ env.GCLOUD_TEST_PROJECT_ID && env.GOOGLE_APPLICATION_CREDENTIALS })
 @MicronautTest
 class GoogleCloudStorageCloudSpec extends AbstractGoogleCloudStorageSpec {
 

--- a/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/GoogleCloudStoragePaginationSpec.groovy
+++ b/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/GoogleCloudStoragePaginationSpec.groovy
@@ -1,0 +1,57 @@
+package io.micronaut.objectstorage.googlecloud
+
+import io.micronaut.objectstorage.request.ListObjectsRequest
+import io.micronaut.objectstorage.response.ListObjectsResponse
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+
+@MicronautTest
+@io.micronaut.context.annotation.Property(name = 'spec.name', value = GoogleCloudStorageFakeGcsServerSpec.SPEC_NAME)
+class GoogleCloudStoragePaginationSpec extends AbstractGoogleCloudStorageSpec {
+
+    private static final List<String> ANIMAL_KEYS = [
+            'animals/antelope.txt',
+            'animals/bear.txt',
+            'animals/cat.txt',
+    ]
+    private static final List<String> PLANT_KEYS = [
+            'plants/aloe.txt',
+            'plants/bonsai.txt',
+    ]
+    private static final List<String> ALL_KEYS = ANIMAL_KEYS + PLANT_KEYS
+
+    void 'paginated listing replays native GCP page tokens until the terminal page'() {
+        given:
+        ALL_KEYS.each { key ->
+            cloudObjectStorage.upload(createTestFileForKey(key).uploadRequest)
+        }
+
+        when:
+        ListObjectsResponse firstPage = cloudObjectStorage.listObjects(new ListObjectsRequest(2, 'animals/'))
+        String nativeToken = firstPage.continuationToken.orElseThrow()
+        ListObjectsResponse replayedFirstPage = cloudObjectStorage.listObjects(new ListObjectsRequest(2, 'animals/'))
+        ListObjectsResponse replayedSecondPage = cloudObjectStorage.listObjects(new ListObjectsRequest(2, 'animals/', nativeToken))
+        ListObjectsResponse secondPage = cloudObjectStorage.listObjects(new ListObjectsRequest(2, 'animals/', nativeToken))
+
+        then:
+        firstPage.keys == ANIMAL_KEYS.take(2)
+        firstPage.continuationToken.present
+        replayedFirstPage.keys == firstPage.keys
+        replayedFirstPage.continuationToken == firstPage.continuationToken
+        replayedSecondPage.keys == ANIMAL_KEYS.drop(2)
+        !replayedSecondPage.continuationToken.present
+        secondPage.keys == replayedSecondPage.keys
+        secondPage.continuationToken == replayedSecondPage.continuationToken
+
+        when:
+        Set<String> allObjects = cloudObjectStorage.listObjects()
+
+        then:
+        allObjects instanceof LinkedHashSet
+        new ArrayList<>(allObjects) == ALL_KEYS
+
+        cleanup:
+        ALL_KEYS.each { key ->
+            cloudObjectStorage.delete(key)
+        }
+    }
+}

--- a/object-storage-local/build.gradle.kts
+++ b/object-storage-local/build.gradle.kts
@@ -12,8 +12,7 @@ dependencies {
 }
 
 micronautBuild {
-    // New module
     binaryCompatibility {
-        enabled.set(false)
+        enabledAfter("3.0.0")
     }
 }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -28,6 +28,7 @@ import io.micronaut.objectstorage.request.UploadRequest;
 import io.micronaut.objectstorage.response.ListObjectsResponse;
 import io.micronaut.objectstorage.response.UploadResponse;
 
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -138,9 +139,14 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         int pageSize = request.getPageSize();
         TreeSet<String> candidates = new TreeSet<>();
         String[] maximumMatchingKey = new String[1];
+        final int maxCandidates = (pageSize == Integer.MAX_VALUE) ? Integer.MAX_VALUE : pageSize + 1;
         try (Stream<Path> stream = Files.find(configuration.getPath(), Integer.MAX_VALUE, (path, attrs) -> attrs.isRegularFile())) {
             stream.forEach(path -> {
-                String key = configuration.getPath().relativize(path).toString();
+                Path relativePath = configuration.getPath().relativize(path);
+                String key = relativePath.toString();
+                if (File.separatorChar != '/') {
+                    key = key.replace(File.separatorChar, '/');
+                }
                 if (key.startsWith(METADATA_DIRECTORY)) {
                     return;
                 }
@@ -154,7 +160,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
                     return;
                 }
                 candidates.add(key);
-                if (candidates.size() > pageSize + 1) {
+                if (candidates.size() > maxCandidates) {
                     candidates.pollLast();
                 }
             });

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -66,6 +66,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     LocalStorageOperations.LocalStorageFile> {
 
     public static final String METADATA_DIRECTORY = ".metadata";
+    private static final int DEFAULT_LIST_PAGE_SIZE = 1_000;
 
     private final LocalStorageConfiguration configuration;
     private final Path metadataPath;
@@ -124,7 +125,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         Set<String> keys = new LinkedHashSet<>();
         String continuationToken = null;
         do {
-            ListObjectsResponse response = listObjects(new ListObjectsRequest(1000, null, continuationToken));
+            ListObjectsResponse response = listObjects(new ListObjectsRequest(DEFAULT_LIST_PAGE_SIZE, null, continuationToken));
             keys.addAll(response.getKeys());
             continuationToken = response.getContinuationToken().orElse(null);
         } while (continuationToken != null);
@@ -298,5 +299,9 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         return file;
     }
 
-    record LocalStorageFile(Path path) { }
+    /**
+     * A simple wrapper around a path.
+     * @param path Where on disk the local storage provider has stored the actual data.
+     */
+    public record LocalStorageFile(Path path) { }
 }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -23,7 +23,9 @@ import org.jspecify.annotations.NonNull;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.ObjectStorageOperations;
 import io.micronaut.objectstorage.configuration.ToggeableCondition;
+import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
+import io.micronaut.objectstorage.response.ListObjectsResponse;
 import io.micronaut.objectstorage.response.UploadResponse;
 
 import java.io.FileOutputStream;
@@ -32,14 +34,18 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -114,15 +120,69 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     @Override
     @NonNull
     public Set<String> listObjects() {
+        Set<String> keys = new LinkedHashSet<>();
+        String continuationToken = null;
+        do {
+            ListObjectsResponse response = listObjects(new ListObjectsRequest(1000, null, continuationToken));
+            keys.addAll(response.getKeys());
+            continuationToken = response.getContinuationToken().orElse(null);
+        } while (continuationToken != null);
+        return keys;
+    }
+
+    @Override
+    @NonNull
+    public ListObjectsResponse listObjects(@NonNull ListObjectsRequest request) {
+        String prefix = request.getPrefix().orElse(null);
+        String continuationToken = request.getContinuationToken().orElse(null);
+        int pageSize = request.getPageSize();
+        TreeSet<String> candidates = new TreeSet<>();
+        String[] maximumMatchingKey = new String[1];
         try (Stream<Path> stream = Files.find(configuration.getPath(), Integer.MAX_VALUE, (path, attrs) -> attrs.isRegularFile())) {
-            return stream
-            .map(p -> configuration.getPath().relativize(p))
-            .map(Path::toString)
-            .filter(s -> !s.startsWith(METADATA_DIRECTORY))
-            .collect(Collectors.toSet());
+            stream.forEach(path -> {
+                String key = configuration.getPath().relativize(path).toString();
+                if (key.startsWith(METADATA_DIRECTORY)) {
+                    return;
+                }
+                if (prefix != null && !key.startsWith(prefix)) {
+                    return;
+                }
+                if (maximumMatchingKey[0] == null || key.compareTo(maximumMatchingKey[0]) > 0) {
+                    maximumMatchingKey[0] = key;
+                }
+                if (continuationToken != null && key.compareTo(continuationToken) <= 0) {
+                    return;
+                }
+                candidates.add(key);
+                if (candidates.size() > pageSize + 1) {
+                    candidates.pollLast();
+                }
+            });
         } catch (IOException e) {
             throw new ObjectStorageException("Error listing objects", e);
         }
+
+        if (continuationToken != null && maximumMatchingKey[0] != null && maximumMatchingKey[0].compareTo(continuationToken) <= 0) {
+            return new ListObjectsResponse(Collections.emptyList());
+        }
+
+        if (candidates.isEmpty()) {
+            return new ListObjectsResponse(Collections.emptyList());
+        }
+
+        List<String> page = new ArrayList<>(Math.min(pageSize, candidates.size()));
+        String nextContinuationToken = null;
+        int index = 0;
+        for (String key : candidates) {
+            if (index < pageSize) {
+                page.add(key);
+            } else {
+                nextContinuationToken = page.get(page.size() - 1);
+                break;
+            }
+            index++;
+        }
+        return new ListObjectsResponse(page, nextContinuationToken);
     }
 
     @Override

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePaginationSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePaginationSpec.groovy
@@ -1,0 +1,82 @@
+package io.micronaut.objectstorage.local
+
+import io.micronaut.objectstorage.request.ListObjectsRequest
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+
+@MicronautTest
+class LocalStoragePaginationSpec extends spock.lang.Specification implements TestPropertyProvider {
+
+    private static final List<String> SEEDED_KEYS = [
+        'animals/cat.txt',
+        'animals/dog.txt',
+        'animals/mammals/fox.txt',
+        'animals/zebra.txt',
+        'plants/oak.txt',
+        'plants/pine.txt',
+        'tools/axe.txt',
+    ]
+
+    @Inject
+    LocalStorageOperations operations
+
+    @Override
+    Map<String, String> getProperties() {
+        [(LocalStorageConfiguration.PREFIX + '.default.enabled'): 'true']
+    }
+
+    void setup() {
+        SEEDED_KEYS.each { key ->
+            operations.upload(UploadRequest.fromBytes('seed'.bytes, key, 'text/plain'))
+        }
+    }
+
+    void cleanup() {
+        operations.listObjects().each { operations.delete(it) }
+    }
+
+    void 'paginated listing is bounded prefix filtered and excludes metadata artifacts'() {
+        when:
+        def firstPage = operations.listObjects(new ListObjectsRequest(2, 'animals/'))
+        def secondPage = operations.listObjects(new ListObjectsRequest(2, 'animals/', firstPage.continuationToken.orElse(null)))
+        def replayedTerminalPage = operations.listObjects(new ListObjectsRequest(2, 'animals/', secondPage.keys.last()))
+
+        then:
+        firstPage.keys == ['animals/cat.txt', 'animals/dog.txt']
+        firstPage.continuationToken.orElse(null) == 'animals/dog.txt'
+        secondPage.keys == ['animals/mammals/fox.txt', 'animals/zebra.txt']
+        secondPage.continuationToken.empty
+        replayedTerminalPage.keys.empty
+        replayedTerminalPage.continuationToken.empty
+        !firstPage.keys.any { it.startsWith('.metadata') }
+        !secondPage.keys.any { it.startsWith('.metadata') }
+        !replayedTerminalPage.keys.any { it.startsWith('.metadata') }
+    }
+
+    void 'continuation token is a strict lower bound and malicious prefixes stay inside the bucket'() {
+        when:
+        def page = operations.listObjects(new ListObjectsRequest(2, null, 'animals/dog.txt'))
+        def allKeys = operations.listObjects() as List
+        def maliciousPrefixPage = operations.listObjects(new ListObjectsRequest(5, '../'))
+        def metadataPrefixPage = operations.listObjects(new ListObjectsRequest(5, '.metadata'))
+
+        then:
+        page.keys == ['animals/mammals/fox.txt', 'animals/zebra.txt']
+        page.continuationToken.orElse(null) == 'animals/zebra.txt'
+        allKeys == [
+            'animals/cat.txt',
+            'animals/dog.txt',
+            'animals/mammals/fox.txt',
+            'animals/zebra.txt',
+            'plants/oak.txt',
+            'plants/pine.txt',
+            'tools/axe.txt',
+        ]
+        maliciousPrefixPage.keys.empty
+        maliciousPrefixPage.continuationToken.empty
+        metadataPrefixPage.keys.empty
+        metadataPrefixPage.continuationToken.empty
+    }
+}

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePathTraversalSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePathTraversalSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.objectstorage.local
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.objectstorage.request.ListObjectsRequest
 import spock.lang.Specification
 
 import java.nio.charset.StandardCharsets
@@ -33,6 +34,13 @@ class LocalStoragePathTraversalSpec extends Specification {
         ctx.getBean(LocalStorageOperations).retrieve("../secret")
         then:
         thrown IllegalArgumentException
+
+        when:
+        def listedKeys = ctx.getBean(LocalStorageOperations).listObjects(new ListObjectsRequest(10, '../'))
+
+        then:
+        listedKeys.keys.empty
+        listedKeys.continuationToken.empty
 
         cleanup:
         ctx.close()

--- a/object-storage-oracle-cloud/build.gradle.kts
+++ b/object-storage-oracle-cloud/build.gradle.kts
@@ -16,3 +16,9 @@ dependencies {
     testImplementation(projects.micronautObjectStorageTck)
     testImplementation(mnTestResources.testcontainers.core)
 }
+
+micronautBuild {
+    binaryCompatibility {
+        enabledAfter("3.0.0")
+    }
+}

--- a/object-storage-oracle-cloud/build.gradle.kts
+++ b/object-storage-oracle-cloud/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
     testImplementation(projects.micronautObjectStorageTck)
     testImplementation(mnTestResources.testcontainers.core)
 }
-
 micronautBuild {
     binaryCompatibility {
         enabledAfter("3.0.0")

--- a/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageOperations.java
+++ b/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageOperations.java
@@ -62,6 +62,7 @@ import java.util.function.Consumer;
 public class OracleCloudStorageOperations
     implements ObjectStorageOperations<PutObjectRequest.Builder, PutObjectResponse, DeleteObjectResponse> {
 
+    private static final int DEFAULT_LIST_PAGE_SIZE = 1_000;
     private static final Logger LOG = LoggerFactory.getLogger(OracleCloudStorageOperations.class);
 
     private final OracleCloudStorageConfiguration configuration;
@@ -160,7 +161,7 @@ public class OracleCloudStorageOperations
         Set<String> keys = new LinkedHashSet<>();
         String continuationToken = null;
         do {
-            ListObjectsResponse response = listObjects(new ListObjectsRequest(1000, null, continuationToken));
+            ListObjectsResponse response = listObjects(new ListObjectsRequest(DEFAULT_LIST_PAGE_SIZE, null, continuationToken));
             keys.addAll(response.getKeys());
             continuationToken = response.getContinuationToken().orElse(null);
         } while (continuationToken != null);

--- a/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageOperations.java
+++ b/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageOperations.java
@@ -24,11 +24,9 @@ import com.oracle.bmc.objectstorage.requests.CopyObjectRequest;
 import com.oracle.bmc.objectstorage.requests.DeleteObjectRequest;
 import com.oracle.bmc.objectstorage.requests.GetObjectRequest;
 import com.oracle.bmc.objectstorage.requests.HeadObjectRequest;
-import com.oracle.bmc.objectstorage.requests.ListObjectsRequest;
 import com.oracle.bmc.objectstorage.requests.PutObjectRequest;
 import com.oracle.bmc.objectstorage.responses.DeleteObjectResponse;
 import com.oracle.bmc.objectstorage.responses.GetObjectResponse;
-import com.oracle.bmc.objectstorage.responses.ListObjectsResponse;
 import com.oracle.bmc.objectstorage.responses.PutObjectResponse;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
@@ -37,17 +35,20 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.ObjectStorageOperations;
 import io.micronaut.objectstorage.configuration.ToggeableCondition;
+import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
+import io.micronaut.objectstorage.response.ListObjectsResponse;
 import io.micronaut.objectstorage.response.UploadResponse;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 /**
  * Oracle Cloud implementation of {@link ObjectStorageOperations}.
@@ -156,23 +157,40 @@ public class OracleCloudStorageOperations
     @NonNull
     @Override
     public Set<String> listObjects() {
+        Set<String> keys = new LinkedHashSet<>();
+        String continuationToken = null;
+        do {
+            ListObjectsResponse response = listObjects(new ListObjectsRequest(1000, null, continuationToken));
+            keys.addAll(response.getKeys());
+            continuationToken = response.getContinuationToken().orElse(null);
+        } while (continuationToken != null);
+        return keys;
+    }
+
+    @Override
+    @NonNull
+    public ListObjectsResponse listObjects(@NonNull ListObjectsRequest request) {
         String bucket = configuration.getBucket();
         try {
-            ListObjectsResponse response = client.listObjects(ListObjectsRequest.builder()
+            com.oracle.bmc.objectstorage.responses.ListObjectsResponse response = client.listObjects(com.oracle.bmc.objectstorage.requests.ListObjectsRequest.builder()
                 .bucketName(bucket)
                 .namespaceName(configuration.getNamespace())
+                .prefix(request.getPrefix().orElse(null))
+                .limit(request.getPageSize())
+                .startAfter(request.getContinuationToken().orElse(null))
                 .build());
 
-            return response.getListObjects()
+            List<String> keys = response.getListObjects()
                 .getObjects()
                 .stream()
                 .map(ObjectSummary::getName)
-                .collect(Collectors.toSet());
+                .toList();
+            return new ListObjectsResponse(keys, response.getListObjects().getNextStartWith());
         } catch (BmcException e) {
             if (LOG.isWarnEnabled()) {
                 LOG.warn("Error when listing the objects in the bucket {} from Oracle Cloud Storage: {}", bucket, e.getMessage(), e);
             }
-            return Collections.emptySet();
+            return new ListObjectsResponse(Collections.emptyList());
         }
     }
 

--- a/object-storage-oracle-cloud/src/test/groovy/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageCloudSpec.groovy
+++ b/object-storage-oracle-cloud/src/test/groovy/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageCloudSpec.groovy
@@ -1,13 +1,19 @@
 package io.micronaut.objectstorage.oraclecloud
 
+import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import spock.lang.IgnoreIf
 import spock.lang.Requires
 
 import static io.micronaut.objectstorage.oraclecloud.OracleCloudStorageConfiguration.PREFIX
 
 @Requires({ env.ORACLE_CLOUD_TEST_NAMESPACE && env.ORACLE_CLOUD_TEST_COMPARTMENT_ID })
+@IgnoreIf({ !env.ORACLE_CLOUD_TEST_NAMESPACE || !env.ORACLE_CLOUD_TEST_COMPARTMENT_ID || !System.getenv('OCI_SESSION_TOKEN') })
 @MicronautTest
+@Property(name = 'spec.name', value = SPEC_NAME)
 class OracleCloudStorageCloudSpec extends AbstractOracleCloudStorageSpec {
+
+    public static final String SPEC_NAME = 'OracleCloudStorageCloudSpec'
 
     @Override
     Map<String, String> getProperties() {

--- a/object-storage-oracle-cloud/src/test/groovy/io/micronaut/objectstorage/oraclecloud/OracleCloudStoragePaginationSpec.groovy
+++ b/object-storage-oracle-cloud/src/test/groovy/io/micronaut/objectstorage/oraclecloud/OracleCloudStoragePaginationSpec.groovy
@@ -1,0 +1,137 @@
+package io.micronaut.objectstorage.oraclecloud
+
+import com.oracle.bmc.auth.RegionProvider
+import com.oracle.bmc.model.BmcException
+import com.oracle.bmc.objectstorage.ObjectStorage
+import com.oracle.bmc.objectstorage.model.ListObjects
+import com.oracle.bmc.objectstorage.model.ObjectSummary
+import io.micronaut.objectstorage.request.ListObjectsRequest
+import spock.lang.Specification
+
+class OracleCloudStoragePaginationSpec extends Specification {
+
+    void 'it replays OCI nextStartWith tokens and exhausts legacy listing'() {
+        given:
+        OracleCloudStorageConfiguration configuration = Stub() {
+            getBucket() >> 'bucket'
+            getNamespace() >> 'namespace'
+        }
+        RegionProvider regionProvider = Stub()
+        ObjectStorage client = Mock()
+        OracleCloudStorageOperations operations = new OracleCloudStorageOperations(configuration, client, regionProvider)
+
+        when:
+        def firstPage = operations.listObjects(new ListObjectsRequest(2, 'animals/', 'animals/cat.txt'))
+        def replayedFirstPage = operations.listObjects(new ListObjectsRequest(2, 'animals/', 'animals/cat.txt'))
+        def secondPage = operations.listObjects(new ListObjectsRequest(2, 'animals/', firstPage.continuationToken.orElse(null)))
+        def replayedSecondPage = operations.listObjects(new ListObjectsRequest(2, 'animals/', firstPage.continuationToken.orElse(null)))
+        def terminalPage = operations.listObjects(new ListObjectsRequest(2, 'animals/', secondPage.continuationToken.orElse(null)))
+        def allKeys = operations.listObjects()
+
+        then:
+        1 * client.listObjects({ request ->
+            request.bucketName == 'bucket' &&
+                request.namespaceName == 'namespace' &&
+                request.prefix == 'animals/' &&
+                request.limit == 2 &&
+                request.startAfter == 'animals/cat.txt'
+        }) >> ociListResponse(['animals/dog.txt', 'animals/mammals/fox.txt'], 'opaque-next-1')
+        1 * client.listObjects({ request ->
+            request.bucketName == 'bucket' &&
+                request.namespaceName == 'namespace' &&
+                request.prefix == 'animals/' &&
+                request.limit == 2 &&
+                request.startAfter == 'animals/cat.txt'
+        }) >> ociListResponse(['animals/dog.txt', 'animals/mammals/fox.txt'], 'opaque-next-1')
+        1 * client.listObjects({ request ->
+            request.bucketName == 'bucket' &&
+                request.namespaceName == 'namespace' &&
+                request.prefix == 'animals/' &&
+                request.limit == 2 &&
+                request.startAfter == 'opaque-next-1'
+        }) >> ociListResponse(['animals/zebra.txt'], 'opaque-next-2')
+        1 * client.listObjects({ request ->
+            request.bucketName == 'bucket' &&
+                request.namespaceName == 'namespace' &&
+                request.prefix == 'animals/' &&
+                request.limit == 2 &&
+                request.startAfter == 'opaque-next-1'
+        }) >> ociListResponse(['animals/zebra.txt'], 'opaque-next-2')
+        1 * client.listObjects({ request ->
+            request.bucketName == 'bucket' &&
+                request.namespaceName == 'namespace' &&
+                request.prefix == 'animals/' &&
+                request.limit == 2 &&
+                request.startAfter == 'opaque-next-2'
+        }) >> ociListResponse([], null)
+        1 * client.listObjects({ request ->
+            request.bucketName == 'bucket' &&
+                request.namespaceName == 'namespace' &&
+                request.prefix == null &&
+                request.limit == 1000 &&
+                request.startAfter == null
+        }) >> ociListResponse(['animals/cat.txt', 'animals/dog.txt'], 'opaque-all-1')
+        1 * client.listObjects({ request ->
+            request.bucketName == 'bucket' &&
+                request.namespaceName == 'namespace' &&
+                request.prefix == null &&
+                request.limit == 1000 &&
+                request.startAfter == 'opaque-all-1'
+        }) >> ociListResponse(['animals/mammals/fox.txt', 'plants/oak.txt'], null)
+        0 * _
+
+        and:
+        firstPage.keys == ['animals/dog.txt', 'animals/mammals/fox.txt']
+        firstPage.continuationToken == Optional.of('opaque-next-1')
+        replayedFirstPage.keys == firstPage.keys
+        replayedFirstPage.continuationToken == firstPage.continuationToken
+        secondPage.keys == ['animals/zebra.txt']
+        secondPage.continuationToken == Optional.of('opaque-next-2')
+        replayedSecondPage.keys == secondPage.keys
+        replayedSecondPage.continuationToken == secondPage.continuationToken
+        terminalPage.keys == []
+        !terminalPage.continuationToken.present
+        allKeys == ['animals/cat.txt', 'animals/dog.txt', 'animals/mammals/fox.txt', 'plants/oak.txt'] as LinkedHashSet
+    }
+
+    void 'it returns empty portable pages when OCI listing fails'() {
+        given:
+        OracleCloudStorageConfiguration configuration = Stub() {
+            getBucket() >> 'bucket'
+            getNamespace() >> 'namespace'
+        }
+        RegionProvider regionProvider = Stub()
+        ObjectStorage client = Mock()
+        OracleCloudStorageOperations operations = new OracleCloudStorageOperations(configuration, client, regionProvider)
+
+        when:
+        def response = operations.listObjects(new ListObjectsRequest(3, 'animals/', 'animals/cat.txt'))
+        def allKeys = operations.listObjects()
+
+        then:
+        1 * client.listObjects(_ as com.oracle.bmc.objectstorage.requests.ListObjectsRequest) >> { throw bmcException('boom') }
+        1 * client.listObjects(_ as com.oracle.bmc.objectstorage.requests.ListObjectsRequest) >> { throw bmcException('boom') }
+        0 * _
+
+        and:
+        response.keys == []
+        !response.continuationToken.present
+        allKeys.isEmpty()
+    }
+
+    private static com.oracle.bmc.objectstorage.responses.ListObjectsResponse ociListResponse(List<String> keys, String nextStartWith) {
+        def summaries = keys.collect { key -> ObjectSummary.builder().name(key).build() }
+        def listObjects = ListObjects.builder()
+            .objects(summaries)
+            .nextStartWith(nextStartWith)
+            .build()
+        return com.oracle.bmc.objectstorage.responses.ListObjectsResponse.builder()
+            .__httpStatusCode__(200)
+            .listObjects(listObjects)
+            .build()
+    }
+
+    private static BmcException bmcException(String message) {
+        return BmcException.createClientSide(message, null, null, null)
+    }
+}

--- a/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/ObjectStorageOperationsSpecification.groovy
+++ b/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/ObjectStorageOperationsSpecification.groovy
@@ -15,7 +15,9 @@
  */
 package io.micronaut.objectstorage
 
+import io.micronaut.objectstorage.request.ListObjectsRequest
 import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.objectstorage.response.ListObjectsResponse
 import io.micronaut.objectstorage.response.UploadResponse
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
@@ -29,6 +31,13 @@ abstract class ObjectStorageOperationsSpecification extends Specification {
     public static final String NEW_TEXT = 'object-storage'
     public static final Map<String, String> METADATA = [project: "micronaut-object-storage"]
     public static final String CONTENT_TYPE = "text/plain"
+    private static final List<String> PAGINATED_LISTING_KEYS = [
+            'animals/cat.txt',
+            'animals/dog.txt',
+            'animals/mammals/fox.txt',
+            'plants/oak.txt',
+            'plants/pine.txt',
+    ]
 
     void 'it can upload, get and delete object from file'(TestFile testFile) {
         given: 'a temporary file'
@@ -158,6 +167,53 @@ abstract class ObjectStorageOperationsSpecification extends Specification {
         ]
     }
 
+    void 'it can list objects with portable pagination semantics'() {
+        given:
+        ObjectStorageOperations<?, ?, ?> storage = getObjectStorage()
+        List<TestFile> testFiles = PAGINATED_LISTING_KEYS.collect { key ->
+            createTestFileForKey(key)
+        }
+        testFiles.each { storage.upload(it.uploadRequest) }
+
+        when: 'listing the full dataset across sequential pages'
+        ListObjectsRequest firstPageRequest = new ListObjectsRequest(2)
+        ListObjectsResponse firstPage = storage.listObjects(firstPageRequest)
+        ListObjectsResponse replayedFirstPage = storage.listObjects(firstPageRequest)
+        List<ListObjectsResponse> pages = collectPages(storage, firstPageRequest)
+        List<String> combinedKeys = pages.collectMany { it.keys }
+
+        then: 'pages stay bounded, replay is stable, and sequential union is complete without adjacent duplicates'
+        pages
+        pages.every { it.keys.size() <= firstPageRequest.pageSize }
+        replayedFirstPage.keys == firstPage.keys
+        replayedFirstPage.continuationToken == firstPage.continuationToken
+        pages.first().keys == firstPage.keys
+        pages.first().continuationToken == firstPage.continuationToken
+        pages.dropRight(1).every { it.keys }
+        adjacentPages(pages).every { pair -> !pair[0].keys.intersect(pair[1].keys) }
+        combinedKeys.toSet() == PAGINATED_LISTING_KEYS.toSet()
+        combinedKeys.size() == PAGINATED_LISTING_KEYS.size()
+        !pages.last().continuationToken.present
+
+        when: 'listing only the animals prefix'
+        ListObjectsRequest animalsRequest = new ListObjectsRequest(2, 'animals/')
+        List<ListObjectsResponse> animalPages = collectPages(storage, animalsRequest)
+        List<String> animalKeys = animalPages.collectMany { it.keys }
+
+        then: 'prefix filtering remains portable and excludes non-matching keys'
+        animalPages
+        animalPages.every { it.keys.size() <= animalsRequest.pageSize }
+        animalKeys.every { it.startsWith('animals/') }
+        animalKeys.toSet() == PAGINATED_LISTING_KEYS.findAll { it.startsWith('animals/') }.toSet()
+        animalKeys.size() == PAGINATED_LISTING_KEYS.count { it.startsWith('animals/') }
+        animalPages.dropRight(1).every { it.keys }
+        adjacentPages(animalPages).every { pair -> !pair[0].keys.intersect(pair[1].keys) }
+        !animalPages.last().continuationToken.present
+
+        cleanup:
+        testFiles.each { storage.delete(it.uploadRequest.key) }
+    }
+
     abstract ObjectStorageOperations<?, ?, ?> getObjectStorage()
 
     boolean emulatorSupportsMetadata() {
@@ -187,6 +243,31 @@ abstract class ObjectStorageOperationsSpecification extends Specification {
             uploadRequest = UploadRequest.fromPath(path)
         }
         return new TestFile(path: path, uploadRequest: uploadRequest)
+    }
+
+    static TestFile createTestFileForKey(String key) {
+        Path path = createTempFile()
+        return new TestFile(path: path, uploadRequest: UploadRequest.fromBytes(TEXT.bytes, key, CONTENT_TYPE))
+    }
+
+    private static List<ListObjectsResponse> collectPages(ObjectStorageOperations<?, ?, ?> storage, ListObjectsRequest request) {
+        List<ListObjectsResponse> pages = []
+        ListObjectsRequest currentRequest = request
+        while (true) {
+            ListObjectsResponse page = storage.listObjects(currentRequest)
+            pages << page
+            Optional<String> continuationToken = page.continuationToken
+            if (!continuationToken.present) {
+                return pages
+            }
+            currentRequest = new ListObjectsRequest(request.pageSize, request.prefix.orElse(null), continuationToken.get())
+        }
+    }
+
+    private static List<List<ListObjectsResponse>> adjacentPages(List<ListObjectsResponse> pages) {
+        (0..<Math.max(pages.size() - 1, 0)).collect { index ->
+            [pages[index], pages[index + 1]]
+        }
     }
 
     static class TestFile {

--- a/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/ObjectStorageOperationsSpecification.groovy
+++ b/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/ObjectStorageOperationsSpecification.groovy
@@ -253,6 +253,8 @@ abstract class ObjectStorageOperationsSpecification extends Specification {
     private static List<ListObjectsResponse> collectPages(ObjectStorageOperations<?, ?, ?> storage, ListObjectsRequest request) {
         List<ListObjectsResponse> pages = []
         ListObjectsRequest currentRequest = request
+        Set<String> seenTokens = [] as Set
+        int maxPages = PAGINATED_LISTING_KEYS.size() + 1
         while (true) {
             ListObjectsResponse page = storage.listObjects(currentRequest)
             pages << page
@@ -260,6 +262,8 @@ abstract class ObjectStorageOperationsSpecification extends Specification {
             if (!continuationToken.present) {
                 return pages
             }
+            assert seenTokens.add(continuationToken.get()): "Repeated continuation token returned while collecting pages"
+            assert pages.size() <= maxPages: "Exceeded maximum expected page count while collecting pages"
             currentRequest = new ListObjectsRequest(request.pageSize, request.prefix.orElse(null), continuationToken.get())
         }
     }

--- a/src/main/docs/guide/paginatedListing.adoc
+++ b/src/main/docs/guide/paginatedListing.adoc
@@ -1,0 +1,17 @@
+== Paginated Listing
+
+The paginated listing API exposes ObjectStorageOperations#listObjects(ListObjectsRequest) which returns a
+ListObjectsResponse containing the ordered keys for the current page and an opaque continuation token for the next page.
+The request accepts a raw prefix for simple starts-with filtering and normalizes empty strings to absent. The examples below
+show how to iterate pages by replaying the continuation token returned by each response. Providers do not promise global
+ordering across all keys, so the safe pattern is: use a small deterministic page size, filter by a raw prefix such as
+userId + "/", and repeat requests while replaying the continuation token until the response omits it.
+
+NOTE: the examples intentionally keep the code provider-agnostic and rely only on ObjectStorageOperations API.
+
+snippet::example.ProfileService[project-base="doc-examples/example", source="main", indent="0", tags="paginated-listing"]
+
+<1> Build a ListObjectsRequest with the desired page size, an optional raw prefix like userId + "/", and the last seen
+    continuation token (null for the first page).
+<2> Call ObjectStorageOperations#listObjects(ListObjectsRequest) and process the returned keys.
+<3> Replay the continuation token returned by the response for the next page until it is absent.

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -68,7 +68,7 @@ snippet::example.ProfileService[project-base="doc-examples/example", source="mai
 
 == Listing objects page by page
 
-The frozen listing API exposes ObjectStorageOperations#listObjects(ListObjectsRequest) which returns a
+The paginated listing API exposes ObjectStorageOperations#listObjects(ListObjectsRequest) which returns a
 ListObjectsResponse containing the ordered keys for the current page and an opaque continuation token for the next page.
 The request accepts a raw prefix for simple starts-with filtering and normalizes empty strings to absent. The examples below
 show how to iterate pages by replaying the continuation token returned by each response. Providers do not promise global

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -65,3 +65,21 @@ snippet::example.ProfileService[project-base="doc-examples/example", source="mai
 snippet::example.ProfileService[project-base="doc-examples/example", source="main", indent="0", tags="delete"]
 
 <1> The delete operation returns the cloud vendor-specific delete response object in case you need it.
+
+== Listing objects page by page
+
+The frozen listing API exposes ObjectStorageOperations#listObjects(ListObjectsRequest) which returns a
+ListObjectsResponse containing the ordered keys for the current page and an opaque continuation token for the next page.
+The request accepts a raw prefix for simple starts-with filtering and normalizes empty strings to absent. The examples below
+show how to iterate pages by replaying the continuation token returned by each response. Providers do not promise global
+ordering across all keys, so the safe pattern is: use a small deterministic page size, filter by a raw prefix such as
+userId + "/", and repeat requests while replaying the continuation token until the response omits it.
+
+NOTE: the examples intentionally keep the code provider-agnostic and rely only on ObjectStorageOperations API.
+
+snippet::example.ProfileService[project-base="doc-examples/example", source="main", indent="0", tags="paginated-listing"]
+
+<1> Build a ListObjectsRequest with the desired page size, an optional raw prefix like userId + "/", and the last seen
+    continuation token (null for the first page).
+<2> Call ObjectStorageOperations#listObjects(ListObjectsRequest) and process the returned keys.
+<3> Replay the continuation token returned by the response for the next page until it is absent.

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -66,20 +66,4 @@ snippet::example.ProfileService[project-base="doc-examples/example", source="mai
 
 <1> The delete operation returns the cloud vendor-specific delete response object in case you need it.
 
-== Listing objects page by page
-
-The paginated listing API exposes ObjectStorageOperations#listObjects(ListObjectsRequest) which returns a
-ListObjectsResponse containing the ordered keys for the current page and an opaque continuation token for the next page.
-The request accepts a raw prefix for simple starts-with filtering and normalizes empty strings to absent. The examples below
-show how to iterate pages by replaying the continuation token returned by each response. Providers do not promise global
-ordering across all keys, so the safe pattern is: use a small deterministic page size, filter by a raw prefix such as
-userId + "/", and repeat requests while replaying the continuation token until the response omits it.
-
-NOTE: the examples intentionally keep the code provider-agnostic and rely only on ObjectStorageOperations API.
-
-snippet::example.ProfileService[project-base="doc-examples/example", source="main", indent="0", tags="paginated-listing"]
-
-<1> Build a ListObjectsRequest with the desired page size, an optional raw prefix like userId + "/", and the last seen
-    continuation token (null for the first page).
-<2> Call ObjectStorageOperations#listObjects(ListObjectsRequest) and process the returned keys.
-<3> Replay the continuation token returned by the response for the next page until it is absent.
+See the dedicated <<paginatedListing,Paginated Listing>> section for provider-agnostic page-by-page object listing.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -1,6 +1,7 @@
 introduction: Introduction
 releaseHistory: Release History
 quickStart: Quick Start
+paginatedListing: Paginated Listing
 aws: Amazon S3
 azure: Azure Blob Storage
 gcp: Google Cloud Storage
@@ -10,4 +11,3 @@ control-panel: Control Panel
 objectStorageGuides: Guides
 breaks: Breaking Changes
 repository: Repository
-


### PR DESCRIPTION
## Summary
- add a new portable paginated listing API (`ListObjectsRequest` / `ListObjectsResponse` plus `ObjectStorageOperations#listObjects(request)`) so callers can iterate large buckets without full in-memory key loading.
- implement provider-specific pagination/prefix behavior for AWS, Azure, GCP, Local, and Oracle Cloud while keeping legacy `listObjects()` backwards compatible.
- expand TCK/provider tests and quick start/doc examples, including follow-up AWS legacy-loop cleanup (`do-while`) from review feedback.

## Verification
- `./gradlew :micronaut-object-storage-core:test :micronaut-object-storage-tck:test :micronaut-object-storage-aws:test :micronaut-object-storage-azure:test :micronaut-object-storage-gcp:test :micronaut-object-storage-local:test :micronaut-object-storage-oracle-cloud:test`
- `./gradlew :micronaut-doc-examples:micronaut-example-java:compileJava :micronaut-doc-examples:micronaut-example-groovy:compileGroovy :micronaut-doc-examples:micronaut-example-kotlin:compileKotlin :micronaut-object-storage-core:check :micronaut-object-storage-aws:check :micronaut-object-storage-azure:check :micronaut-object-storage-gcp:check :micronaut-object-storage-local:check :micronaut-object-storage-oracle-cloud:check`