### PR TITLE
Migrates LocalStack Testcontainers API to the newer org.testcontainers.localstack.LocalStackContainer API

### DIFF
--- a/doc-examples/example-groovy/src/test/groovy/example/ProfileServiceSpec.groovy
+++ b/doc-examples/example-groovy/src/test/groovy/example/ProfileServiceSpec.groovy
@@ -7,7 +7,7 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import jakarta.inject.Named
-import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.localstack.LocalStackContainer
 import org.testcontainers.utility.DockerImageName
 import software.amazon.awssdk.services.s3.S3Client
 import spock.lang.AutoCleanup
@@ -28,7 +28,7 @@ class ProfileServiceSpec extends Specification implements TestPropertyProvider {
     @Shared
     @AutoCleanup
     public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
-            .withServices(LocalStackContainer.Service.S3)
+            .withServices("s3")
 
     @Inject
     @Named(OBJECT_STORAGE_NAME)
@@ -48,7 +48,7 @@ class ProfileServiceSpec extends Specification implements TestPropertyProvider {
                 "aws.accessKeyId": localstack.getAccessKey(),
                 "aws.secretKey": localstack.getSecretKey(),
                 "aws.region": localstack.getRegion(),
-                "aws.services.s3.endpoint-override": localstack.getEndpointOverride(LocalStackContainer.Service.S3)
+                "aws.services.s3.endpoint-override": localstack.getEndpoint().toString()
 
         ]
     }

--- a/doc-examples/example-groovy/src/test/groovy/example/UploadControllerSpec.groovy
+++ b/doc-examples/example-groovy/src/test/groovy/example/UploadControllerSpec.groovy
@@ -13,7 +13,7 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import jakarta.inject.Named
-import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.localstack.LocalStackContainer
 import org.testcontainers.utility.DockerImageName
 import software.amazon.awssdk.services.s3.S3Client
 import spock.lang.AutoCleanup
@@ -32,7 +32,7 @@ class UploadControllerSpec extends Specification implements TestPropertyProvider
     @Shared
     @AutoCleanup
     public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
-            .withServices(LocalStackContainer.Service.S3)
+            .withServices("s3")
 
     @Inject
     @Named(OBJECT_STORAGE_NAME)
@@ -53,7 +53,7 @@ class UploadControllerSpec extends Specification implements TestPropertyProvider
                 "aws.accessKeyId": localstack.getAccessKey(),
                 "aws.secretKey": localstack.getSecretKey(),
                 "aws.region": localstack.getRegion(),
-                "aws.services.s3.endpoint-override": localstack.getEndpointOverride(LocalStackContainer.Service.S3)
+                "aws.services.s3.endpoint-override": localstack.getEndpoint().toString()
 
         ]
     }

--- a/doc-examples/example-java/src/test/groovy/example/ProfileServiceSpec.groovy
+++ b/doc-examples/example-java/src/test/groovy/example/ProfileServiceSpec.groovy
@@ -7,7 +7,7 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import jakarta.inject.Named
-import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.localstack.LocalStackContainer
 import org.testcontainers.utility.DockerImageName
 import software.amazon.awssdk.services.s3.S3Client
 import spock.lang.AutoCleanup
@@ -28,7 +28,7 @@ class ProfileServiceSpec extends Specification implements TestPropertyProvider {
     @Shared
     @AutoCleanup
     public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
-            .withServices(LocalStackContainer.Service.S3)
+            .withServices("s3")
 
     @Inject
     @Named(OBJECT_STORAGE_NAME)
@@ -48,7 +48,7 @@ class ProfileServiceSpec extends Specification implements TestPropertyProvider {
                 "aws.accessKeyId": localstack.getAccessKey(),
                 "aws.secretKey": localstack.getSecretKey(),
                 "aws.region": localstack.getRegion(),
-                "aws.services.s3.endpoint-override": localstack.getEndpointOverride(LocalStackContainer.Service.S3)
+                "aws.services.s3.endpoint-override": localstack.getEndpoint().toString()
 
         ]
     }

--- a/doc-examples/example-java/src/test/groovy/example/UploadControllerSpec.groovy
+++ b/doc-examples/example-java/src/test/groovy/example/UploadControllerSpec.groovy
@@ -13,7 +13,7 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import jakarta.inject.Named
-import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.localstack.LocalStackContainer
 import org.testcontainers.utility.DockerImageName
 import software.amazon.awssdk.services.s3.S3Client
 import spock.lang.AutoCleanup
@@ -31,7 +31,7 @@ class UploadControllerSpec extends Specification implements TestPropertyProvider
     @Shared
     @AutoCleanup
     public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
-            .withServices(LocalStackContainer.Service.S3)
+            .withServices("s3")
 
     @Inject
     @Named(OBJECT_STORAGE_NAME)
@@ -52,7 +52,7 @@ class UploadControllerSpec extends Specification implements TestPropertyProvider
                 "aws.accessKeyId": localstack.getAccessKey(),
                 "aws.secretKey": localstack.getSecretKey(),
                 "aws.region": localstack.getRegion(),
-                "aws.services.s3.endpoint-override": localstack.getEndpointOverride(LocalStackContainer.Service.S3)
+                "aws.services.s3.endpoint-override": localstack.getEndpoint().toString()
 
         ]
     }

--- a/doc-examples/example-kotlin/src/test/groovy/example/ProfileServiceSpec.groovy
+++ b/doc-examples/example-kotlin/src/test/groovy/example/ProfileServiceSpec.groovy
@@ -7,7 +7,7 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import jakarta.inject.Named
-import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.localstack.LocalStackContainer
 import org.testcontainers.utility.DockerImageName
 import software.amazon.awssdk.services.s3.S3Client
 import spock.lang.AutoCleanup
@@ -28,7 +28,7 @@ class ProfileServiceSpec extends Specification implements TestPropertyProvider {
     @Shared
     @AutoCleanup
     public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
-            .withServices(LocalStackContainer.Service.S3)
+            .withServices("s3")
 
     @Inject
     @Named(OBJECT_STORAGE_NAME)
@@ -48,7 +48,7 @@ class ProfileServiceSpec extends Specification implements TestPropertyProvider {
                 "aws.accessKeyId": localstack.getAccessKey(),
                 "aws.secretKey": localstack.getSecretKey(),
                 "aws.region": localstack.getRegion(),
-                "aws.services.s3.endpoint-override": localstack.getEndpointOverride(LocalStackContainer.Service.S3)
+                "aws.services.s3.endpoint-override": localstack.getEndpoint().toString()
 
         ]
     }

--- a/doc-examples/example-kotlin/src/test/groovy/example/UploadControllerSpec.groovy
+++ b/doc-examples/example-kotlin/src/test/groovy/example/UploadControllerSpec.groovy
@@ -13,7 +13,7 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import jakarta.inject.Named
-import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.localstack.LocalStackContainer
 import org.testcontainers.utility.DockerImageName
 import software.amazon.awssdk.services.s3.S3Client
 import spock.lang.AutoCleanup
@@ -32,7 +32,7 @@ class UploadControllerSpec extends Specification implements TestPropertyProvider
     @Shared
     @AutoCleanup
     public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
-            .withServices(LocalStackContainer.Service.S3)
+            .withServices("s3")
 
     @Inject
     @Named(OBJECT_STORAGE_NAME)
@@ -53,7 +53,7 @@ class UploadControllerSpec extends Specification implements TestPropertyProvider
                 "aws.accessKeyId": localstack.getAccessKey(),
                 "aws.secretKey": localstack.getSecretKey(),
                 "aws.region": localstack.getRegion(),
-                "aws.services.s3.endpoint-override": localstack.getEndpointOverride(LocalStackContainer.Service.S3)
+                "aws.services.s3.endpoint-override": localstack.getEndpoint().toString()
 
         ]
     }

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3LegacyListObjectsSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3LegacyListObjectsSpec.groovy
@@ -4,13 +4,12 @@ import io.micronaut.objectstorage.request.ListObjectsRequest
 import io.micronaut.objectstorage.request.UploadRequest
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
-import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.localstack.LocalStackContainer
 import org.testcontainers.utility.DockerImageName
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 
 import static io.micronaut.objectstorage.test.ObjectStorageTestConstants.LOCAL_STACK_DOCKER_IMAGE
-import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3
 
 @MicronautTest(startApplication = false)
 class AwsS3LegacyListObjectsSpec extends AbstractAwsS3Spec implements TestPropertyProvider {
@@ -18,7 +17,7 @@ class AwsS3LegacyListObjectsSpec extends AbstractAwsS3Spec implements TestProper
     @Shared
     @AutoCleanup
     LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
-        .withServices(S3)
+        .withServices("s3")
 
     @Override
     Map<String, String> getProperties() {
@@ -27,7 +26,7 @@ class AwsS3LegacyListObjectsSpec extends AbstractAwsS3Spec implements TestProper
                 'aws.accessKeyId'                : localstack.accessKey,
                 'aws.secretKey'                  : localstack.secretKey,
                 'aws.region'                     : localstack.region,
-                'aws.services.s3.endpoint-override': localstack.getEndpointOverride(S3)
+                'aws.services.s3.endpoint-override': localstack.getEndpoint().toString()
         ] as Map
     }
 

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3OperationsLocalstackSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3OperationsLocalstackSpec.groovy
@@ -2,13 +2,12 @@ package io.micronaut.objectstorage.aws
 
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
-import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.localstack.LocalStackContainer
 import org.testcontainers.utility.DockerImageName
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 
 import static io.micronaut.objectstorage.test.ObjectStorageTestConstants.LOCAL_STACK_DOCKER_IMAGE
-import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3
 
 @MicronautTest(startApplication = false)
 class AwsS3OperationsLocalstackSpec extends AbstractAwsS3Spec implements TestPropertyProvider {
@@ -16,7 +15,7 @@ class AwsS3OperationsLocalstackSpec extends AbstractAwsS3Spec implements TestPro
     @Shared
     @AutoCleanup
     public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
-            .withServices(S3)
+            .withServices("s3")
 
     @Override
     Map<String, String> getProperties() {
@@ -25,7 +24,7 @@ class AwsS3OperationsLocalstackSpec extends AbstractAwsS3Spec implements TestPro
                 'aws.accessKeyId'         : localstack.accessKey,
                 'aws.secretKey'           : localstack.secretKey,
                 'aws.region'              : localstack.region,
-                'aws.services.s3.endpoint-override': localstack.getEndpointOverride(S3)
+                'aws.services.s3.endpoint-override': localstack.getEndpoint().toString()
         ] as Map
     }
 }

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3PaginationSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3PaginationSpec.groovy
@@ -4,13 +4,12 @@ import io.micronaut.objectstorage.request.ListObjectsRequest
 import io.micronaut.objectstorage.request.UploadRequest
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
-import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.localstack.LocalStackContainer
 import org.testcontainers.utility.DockerImageName
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 
 import static io.micronaut.objectstorage.test.ObjectStorageTestConstants.LOCAL_STACK_DOCKER_IMAGE
-import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3
 
 @MicronautTest(startApplication = false)
 class AwsS3PaginationSpec extends AbstractAwsS3Spec implements TestPropertyProvider {
@@ -18,7 +17,7 @@ class AwsS3PaginationSpec extends AbstractAwsS3Spec implements TestPropertyProvi
     @Shared
     @AutoCleanup
     LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
-        .withServices(S3)
+        .withServices("s3")
 
     @Override
     Map<String, String> getProperties() {
@@ -27,7 +26,7 @@ class AwsS3PaginationSpec extends AbstractAwsS3Spec implements TestPropertyProvi
                 'aws.accessKeyId'                : localstack.accessKey,
                 'aws.secretKey'                  : localstack.secretKey,
                 'aws.region'                     : localstack.region,
-                'aws.services.s3.endpoint-override': localstack.getEndpointOverride(S3)
+                'aws.services.s3.endpoint-override': localstack.getEndpoint().toString()
         ] as Map
     }
 

--- a/test-suite-utils/src/main/java/io/micronaut/objectstorage/test/ObjectStorageTestConstants.java
+++ b/test-suite-utils/src/main/java/io/micronaut/objectstorage/test/ObjectStorageTestConstants.java
@@ -16,7 +16,7 @@
 package io.micronaut.objectstorage.test;
 
 public final class ObjectStorageTestConstants {
-    public static final String LOCAL_STACK_DOCKER_IMAGE = "localstack/localstack:4.2.0";
+    public static final String LOCAL_STACK_DOCKER_IMAGE = "localstack/localstack:4.14.0";
     private ObjectStorageTestConstants() {
 
     }


### PR DESCRIPTION
- move from deprecated localstack testcontainer
- use localstack 4.14.0 docker image