### PR TITLE
Gate provider workflow secrets behind trusted events

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -64,9 +64,6 @@ jobs:
           ./gradlew :micronaut-object-storage-aws:test --no-daemon --parallel --continue
         env:
            TESTCONTAINERS_RYUK_DISABLED: true
-           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
            PREDICTIVE_TEST_SELECTION: "true"
       - name: Publish Test Report
         if: always()

--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -65,9 +65,6 @@ jobs:
           ./gradlew :micronaut-object-storage-azure:test --no-daemon --parallel --continue
         env:
            TESTCONTAINERS_RYUK_DISABLED: true
-           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
            PREDICTIVE_TEST_SELECTION: "true"
       - name: Publish Test Report
         if: always()

--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -27,7 +27,6 @@ jobs:
         java: ['25']
     permissions:
       contents: 'read'
-      id-token: 'write'
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space
@@ -71,9 +70,6 @@ jobs:
           ./gradlew :micronaut-object-storage-gcp:test --no-daemon --parallel --continue
         env:
            TESTCONTAINERS_RYUK_DISABLED: true
-           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
            PREDICTIVE_TEST_SELECTION: "true"
       - name: Publish Test Report
         if: always()

--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -27,7 +27,6 @@ jobs:
         java: ['25']
     permissions:
       contents: 'read'
-      id-token: 'write'
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space
@@ -71,9 +70,6 @@ jobs:
           ./gradlew :micronaut-object-storage-oracle-cloud:test --no-daemon --parallel --continue
         env:
            TESTCONTAINERS_RYUK_DISABLED: true
-           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-           GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-           GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
            PREDICTIVE_TEST_SELECTION: "true"
       - name: Publish Test Report
         if: always()


### PR DESCRIPTION
## Summary
- stop exporting Develocity credentials to provider workflow `pull_request` runs
- stop exporting AWS, Azure, GCP, and OCI test credentials to repository-controlled PR code
- keep provider workflows running on PRs so local or env-guarded tests still provide coverage

## Verification
- parsed the updated workflow YAML files with `python3` + `yaml.safe_load`
- ran `git diff --check` on the modified workflows