### PR TITLE
Add ResourceLoader support for object storage URIs

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.objectstorage-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.objectstorage-module.gradle
@@ -4,6 +4,8 @@ plugins {
 }
 dependencies {
     annotationProcessor mn.micronaut.inject.java
+    implementation platform(libs.netty.bom)
     implementation mn.micronaut.inject
     implementation mn.micronaut.context
+    testImplementation platform(libs.netty.bom)
 }

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.objectstorage-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.objectstorage-module.gradle
@@ -4,8 +4,6 @@ plugins {
 }
 dependencies {
     annotationProcessor mn.micronaut.inject.java
-    implementation platform(libs.netty.bom)
     implementation mn.micronaut.inject
     implementation mn.micronaut.context
-    testImplementation platform(libs.netty.bom)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ micronaut-oracle-cloud = "6.0.0-M1"
 micronaut-test-resources = "3.0.0-M6"
 micronaut-validation = "5.0.0-M1"
 micronaut-logging = "2.0.0-M2"
+netty = "4.2.12.Final"
 
 gcp-libraries = '26.78.0'
 bytebuddy = '1.18.7'
@@ -44,6 +45,7 @@ micronaut-oracle-cloud = { module = 'io.micronaut.oraclecloud:micronaut-oraclecl
 micronaut-test-resources = { module = "io.micronaut.testresources:micronaut-test-resources-bom", version.ref = "micronaut-test-resources" }
 micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "micronaut-validation" }
 micronaut-logging = { module = "io.micronaut.logging:micronaut-logging-bom", version.ref = "micronaut-logging" }
+netty-bom = { module = "io.netty:netty-bom", version.ref = "netty" }
 
 bytebuddy = { module = 'net.bytebuddy:byte-buddy', version.ref = 'bytebuddy' }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,6 @@ micronaut-oracle-cloud = "6.0.0-M1"
 micronaut-test-resources = "3.0.0-M6"
 micronaut-validation = "5.0.0-M1"
 micronaut-logging = "2.0.0-M2"
-netty = "4.2.12.Final"
 
 gcp-libraries = '26.78.0'
 bytebuddy = '1.18.7'
@@ -45,7 +44,6 @@ micronaut-oracle-cloud = { module = 'io.micronaut.oraclecloud:micronaut-oraclecl
 micronaut-test-resources = { module = "io.micronaut.testresources:micronaut-test-resources-bom", version.ref = "micronaut-test-resources" }
 micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "micronaut-validation" }
 micronaut-logging = { module = "io.micronaut.logging:micronaut-logging-bom", version.ref = "micronaut-logging" }
-netty-bom = { module = "io.netty:netty-bom", version.ref = "netty" }
 
 bytebuddy = { module = 'net.bytebuddy:byte-buddy', version.ref = 'bytebuddy' }
 

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3ResourceLoader.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3ResourceLoader.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.aws;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.ObjectStorageOperations;
+import io.micronaut.objectstorage.resource.AbstractObjectStorageResourceLoader;
+import io.micronaut.objectstorage.resource.ObjectStorageResourceParser;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * AWS S3 {@link io.micronaut.core.io.ResourceLoader} for {@code s3://<bucket>/<key>}.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.1.0
+ */
+@Internal
+final class AwsS3ResourceLoader extends AbstractObjectStorageResourceLoader {
+
+    private final List<AwsS3Configuration> configurations;
+    private final Map<String, ObjectStorageOperations<?, ?, ?>> operationsByName;
+
+    AwsS3ResourceLoader(@NonNull List<AwsS3Configuration> configurations,
+                        @NonNull Map<String, ObjectStorageOperations<?, ?, ?>> operationsByName) {
+        this(configurations, operationsByName, null);
+    }
+
+    private AwsS3ResourceLoader(@NonNull List<AwsS3Configuration> configurations,
+                                @NonNull Map<String, ObjectStorageOperations<?, ?, ?>> operationsByName,
+                                @Nullable RelativeBase relativeBase) {
+        super(relativeBase);
+        this.configurations = configurations;
+        this.operationsByName = operationsByName;
+    }
+
+    @Override
+    protected boolean hasRecognizedPrefix(@NonNull String path) {
+        return path.startsWith(ObjectStorageResourceParser.S3_SCHEME + ':');
+    }
+
+    @Override
+    protected Optional<ResolvedObjectStorageResource> resolveAbsolute(@NonNull String path) {
+        return ObjectStorageResourceParser.parseBucketStorageUri(path, ObjectStorageResourceParser.S3_SCHEME)
+            .flatMap(uri -> {
+                List<AwsS3Configuration> matches = configurations.stream()
+                    .filter(configuration -> configuration.getBucket().equals(uri.bucket()))
+                    .filter(configuration -> operationsByName.containsKey(configuration.getName()))
+                    .toList();
+                if (matches.isEmpty()) {
+                    return Optional.empty();
+                }
+                if (matches.size() > 1) {
+                    throw new IllegalStateException("Multiple configured AWS object storages match bucket [" + uri.bucket() + "]");
+                }
+                AwsS3Configuration configuration = matches.get(0);
+                return Optional.of(new ResolvedObjectStorageResource(
+                    uri.key(),
+                    ObjectStorageResourceParser.S3_SCHEME + "://" + uri.bucket() + '/' + uri.key(),
+                    operationsByName.get(configuration.getName())
+                ));
+            });
+    }
+
+    @Override
+    protected AbstractObjectStorageResourceLoader withRelativeBase(@NonNull RelativeBase relativeBase) {
+        return new AwsS3ResourceLoader(configurations, operationsByName, relativeBase);
+    }
+}

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3ResourceLoader.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3ResourceLoader.java
@@ -30,7 +30,7 @@ import java.util.Optional;
  * AWS S3 {@link io.micronaut.core.io.ResourceLoader} for {@code s3://<bucket>/<key>}.
  *
  * @author Álvaro Sánchez-Mariscal
- * @since 3.1.0
+ * @since 3.0.0
  */
 @Internal
 final class AwsS3ResourceLoader extends AbstractObjectStorageResourceLoader {

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3ResourceLoaderFactory.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3ResourceLoaderFactory.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
  * Registers the {@code s3:} resource loader.
  *
  * @author Álvaro Sánchez-Mariscal
- * @since 3.1.0
+ * @since 3.0.0
  */
 @Factory
 @Internal

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3ResourceLoaderFactory.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3ResourceLoaderFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.aws;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.io.ResourceLoader;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.objectstorage.ObjectStorageOperations;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Registers the {@code s3:} resource loader.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.1.0
+ */
+@Factory
+@Internal
+public class AwsS3ResourceLoaderFactory {
+
+    @Singleton
+    @Requires(beans = AwsS3Configuration.class)
+    ResourceLoader awsS3ResourceLoader(BeanContext beanContext) {
+        List<AwsS3Configuration> configurations = beanContext.getBeansOfType(AwsS3Configuration.class).stream()
+            .toList();
+        Map<String, ObjectStorageOperations<?, ?, ?>> operationsByName = configurations.stream()
+            .map(configuration -> Map.entry(configuration.getName(), findOperations(beanContext, configuration.getName())))
+            .filter(entry -> entry.getValue().isPresent())
+            .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().orElseThrow()));
+        return new AwsS3ResourceLoader(configurations, operationsByName);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private Optional<ObjectStorageOperations<?, ?, ?>> findOperations(BeanContext beanContext, String name) {
+        return (Optional) beanContext.findBean(ObjectStorageOperations.class, Qualifiers.byName(name));
+    }
+}

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3ResourceLoaderSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3ResourceLoaderSpec.groovy
@@ -1,0 +1,77 @@
+package io.micronaut.objectstorage.aws
+
+import io.micronaut.objectstorage.ObjectStorageEntry
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.response.UploadResponse
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class AwsS3ResourceLoaderSpec extends Specification {
+
+    void 'it resolves s3 resources for configured buckets and rebases relative lookups'() {
+        given:
+        def configuration = new AwsS3Configuration('public-images')
+        configuration.bucket = 'public-images-bucket'
+        def loader = new AwsS3ResourceLoader(
+            [configuration],
+            ['public-images': new TestObjectStorageOperations(['avatars/logo.txt': 'aws-logo'])]
+        )
+
+        expect:
+        loader.supportsPrefix('s3://public-images-bucket/avatars/logo.txt')
+        loader.getResourceAsStream('s3://public-images-bucket/avatars/logo.txt').get().text == 'aws-logo'
+        loader.forBase('s3://public-images-bucket/avatars/').getResourceAsStream('logo.txt').get().text == 'aws-logo'
+    }
+
+    void 'it fails deterministically when multiple storages match the same bucket'() {
+        given:
+        def first = new AwsS3Configuration('first')
+        first.bucket = 'shared-bucket'
+        def second = new AwsS3Configuration('second')
+        second.bucket = 'shared-bucket'
+        def loader = new AwsS3ResourceLoader(
+            [first, second],
+            [
+                (first.name) : new TestObjectStorageOperations(['logo.txt': 'a']),
+                (second.name): new TestObjectStorageOperations(['logo.txt': 'b'])
+            ]
+        )
+
+        when:
+        loader.getResourceAsStream('s3://shared-bucket/logo.txt')
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message.contains('Multiple configured AWS object storages')
+    }
+
+    private static final class TestObjectStorageOperations implements ObjectStorageOperations<Object, Object, Object> {
+        private final Map<String, byte[]> contents
+
+        private TestObjectStorageOperations(Map<String, String> contents) {
+            this.contents = contents.collectEntries { key, value -> [(key): value.getBytes(StandardCharsets.UTF_8)] }
+        }
+
+        @Override
+        UploadResponse<Object> upload(io.micronaut.objectstorage.request.UploadRequest request) { throw new UnsupportedOperationException() }
+
+        @Override
+        UploadResponse<Object> upload(io.micronaut.objectstorage.request.UploadRequest request, java.util.function.Consumer<Object> requestConsumer) { throw new UnsupportedOperationException() }
+
+        @Override
+        Optional<ObjectStorageEntry<byte[]>> retrieve(String key) {
+            return Optional.ofNullable(contents.get(key)).map(bytes -> [
+                getKey        : { -> key },
+                getInputStream: { -> new ByteArrayInputStream(bytes) },
+                getNativeEntry: { -> bytes }
+            ] as ObjectStorageEntry<byte[]>)
+        }
+
+        @Override
+        Object delete(String key) { throw new UnsupportedOperationException() }
+
+        @Override
+        boolean exists(String key) { contents.containsKey(key) }
+    }
+}

--- a/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageResourceLoader.java
+++ b/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageResourceLoader.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.azure;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.ObjectStorageOperations;
+import io.micronaut.objectstorage.resource.AbstractObjectStorageResourceLoader;
+import io.micronaut.objectstorage.resource.ObjectStorageResourceParser;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Azure Blob Storage {@link io.micronaut.core.io.ResourceLoader} for
+ * {@code azb:<account>://<container>/<key>}.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.1.0
+ */
+@Internal
+final class AzureBlobStorageResourceLoader extends AbstractObjectStorageResourceLoader {
+
+    private final List<AzureBlobStorageConfiguration> configurations;
+    private final Map<String, ObjectStorageOperations<?, ?, ?>> operationsByName;
+
+    AzureBlobStorageResourceLoader(@NonNull List<AzureBlobStorageConfiguration> configurations,
+                                   @NonNull Map<String, ObjectStorageOperations<?, ?, ?>> operationsByName) {
+        this(configurations, operationsByName, null);
+    }
+
+    private AzureBlobStorageResourceLoader(@NonNull List<AzureBlobStorageConfiguration> configurations,
+                                           @NonNull Map<String, ObjectStorageOperations<?, ?, ?>> operationsByName,
+                                           @Nullable RelativeBase relativeBase) {
+        super(relativeBase);
+        this.configurations = configurations;
+        this.operationsByName = operationsByName;
+    }
+
+    @Override
+    protected boolean hasRecognizedPrefix(@NonNull String path) {
+        return path.startsWith(ObjectStorageResourceParser.AZB_SCHEME + ':');
+    }
+
+    @Override
+    protected Optional<ResolvedObjectStorageResource> resolveAbsolute(@NonNull String path) {
+        return ObjectStorageResourceParser.parseAzureBlobStorageUri(path)
+            .flatMap(uri -> {
+                List<AzureBlobStorageConfiguration> matches = configurations.stream()
+                    .filter(configuration -> configuration.getContainer().equals(uri.container()))
+                    .filter(configuration -> extractAccountName(configuration).filter(uri.account()::equals).isPresent())
+                    .filter(configuration -> operationsByName.containsKey(configuration.getName()))
+                    .toList();
+                if (matches.isEmpty()) {
+                    return Optional.empty();
+                }
+                if (matches.size() > 1) {
+                    throw new IllegalStateException(
+                        "Multiple configured Azure object storages match account [" + uri.account() + "] and container [" + uri.container() + "]"
+                    );
+                }
+                AzureBlobStorageConfiguration configuration = matches.get(0);
+                return Optional.of(new ResolvedObjectStorageResource(
+                    uri.key(),
+                    ObjectStorageResourceParser.AZB_SCHEME + ':' + uri.account() + "://" + uri.container() + '/' + uri.key(),
+                    operationsByName.get(configuration.getName())
+                ));
+            });
+    }
+
+    @Override
+    protected AbstractObjectStorageResourceLoader withRelativeBase(@NonNull RelativeBase relativeBase) {
+        return new AzureBlobStorageResourceLoader(configurations, operationsByName, relativeBase);
+    }
+
+    private Optional<String> extractAccountName(AzureBlobStorageConfiguration configuration) {
+        try {
+            URI uri = URI.create(configuration.getEndpoint());
+            String path = uri.getPath();
+            if (path != null) {
+                String normalized = path.startsWith("/") ? path.substring(1) : path;
+                if (!normalized.isEmpty()) {
+                    int separator = normalized.indexOf('/');
+                    return Optional.of(separator >= 0 ? normalized.substring(0, separator) : normalized);
+                }
+            }
+            String host = uri.getHost();
+            if (host == null || host.isEmpty()) {
+                return Optional.empty();
+            }
+            int separator = host.indexOf('.');
+            return Optional.of(separator >= 0 ? host.substring(0, separator) : host);
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageResourceLoader.java
+++ b/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageResourceLoader.java
@@ -32,7 +32,7 @@ import java.util.Optional;
  * {@code azb:<account>://<container>/<key>}.
  *
  * @author Álvaro Sánchez-Mariscal
- * @since 3.1.0
+ * @since 3.0.0
  */
 @Internal
 final class AzureBlobStorageResourceLoader extends AbstractObjectStorageResourceLoader {

--- a/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageResourceLoaderFactory.java
+++ b/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageResourceLoaderFactory.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
  * Registers the {@code azb:} resource loader.
  *
  * @author Álvaro Sánchez-Mariscal
- * @since 3.1.0
+ * @since 3.0.0
  */
 @Factory
 @Internal

--- a/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageResourceLoaderFactory.java
+++ b/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageResourceLoaderFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.azure;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.io.ResourceLoader;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.objectstorage.ObjectStorageOperations;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Registers the {@code azb:} resource loader.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.1.0
+ */
+@Factory
+@Internal
+public class AzureBlobStorageResourceLoaderFactory {
+
+    @Singleton
+    @Requires(beans = AzureBlobStorageConfiguration.class)
+    ResourceLoader azureBlobStorageResourceLoader(BeanContext beanContext) {
+        List<AzureBlobStorageConfiguration> configurations = beanContext.getBeansOfType(AzureBlobStorageConfiguration.class).stream()
+            .toList();
+        Map<String, ObjectStorageOperations<?, ?, ?>> operationsByName = configurations.stream()
+            .map(configuration -> Map.entry(configuration.getName(), findOperations(beanContext, configuration.getName())))
+            .filter(entry -> entry.getValue().isPresent())
+            .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().orElseThrow()));
+        return new AzureBlobStorageResourceLoader(configurations, operationsByName);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private Optional<ObjectStorageOperations<?, ?, ?>> findOperations(BeanContext beanContext, String name) {
+        return (Optional) beanContext.findBean(ObjectStorageOperations.class, Qualifiers.byName(name));
+    }
+}

--- a/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStorageResourceLoaderSpec.groovy
+++ b/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStorageResourceLoaderSpec.groovy
@@ -1,0 +1,70 @@
+package io.micronaut.objectstorage.azure
+
+import io.micronaut.objectstorage.ObjectStorageEntry
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.response.UploadResponse
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class AzureBlobStorageResourceLoaderSpec extends Specification {
+
+    void 'it resolves azure blob resources for configured account and container'() {
+        given:
+        def configuration = new AzureBlobStorageConfiguration('public-images')
+        configuration.endpoint = 'https://cliponaut.blob.core.windows.net'
+        configuration.container = 'public-images'
+        def loader = new AzureBlobStorageResourceLoader(
+            [configuration],
+            ['public-images': new TestObjectStorageOperations(['avatars/logo.txt': 'azure-logo'])]
+        )
+
+        expect:
+        loader.supportsPrefix('azb:cliponaut://public-images/avatars/logo.txt')
+        loader.getResourceAsStream('azb:cliponaut://public-images/avatars/logo.txt').get().text == 'azure-logo'
+        loader.forBase('azb:cliponaut://public-images/avatars/').getResourceAsStream('logo.txt').get().text == 'azure-logo'
+    }
+
+    void 'it extracts azurite account names from the endpoint path'() {
+        given:
+        def configuration = new AzureBlobStorageConfiguration('public-images')
+        configuration.endpoint = 'http://127.0.0.1:10000/devstoreaccount1'
+        configuration.container = 'public-images'
+        def loader = new AzureBlobStorageResourceLoader(
+            [configuration],
+            ['public-images': new TestObjectStorageOperations(['avatars/logo.txt': 'azure-logo'])]
+        )
+
+        expect:
+        loader.getResourceAsStream('azb:devstoreaccount1://public-images/avatars/logo.txt').get().text == 'azure-logo'
+    }
+
+    private static final class TestObjectStorageOperations implements ObjectStorageOperations<Object, Object, Object> {
+        private final Map<String, byte[]> contents
+
+        private TestObjectStorageOperations(Map<String, String> contents) {
+            this.contents = contents.collectEntries { key, value -> [(key): value.getBytes(StandardCharsets.UTF_8)] }
+        }
+
+        @Override
+        UploadResponse<Object> upload(io.micronaut.objectstorage.request.UploadRequest request) { throw new UnsupportedOperationException() }
+
+        @Override
+        UploadResponse<Object> upload(io.micronaut.objectstorage.request.UploadRequest request, java.util.function.Consumer<Object> requestConsumer) { throw new UnsupportedOperationException() }
+
+        @Override
+        Optional<ObjectStorageEntry<byte[]>> retrieve(String key) {
+            return Optional.ofNullable(contents.get(key)).map(bytes -> [
+                getKey        : { -> key },
+                getInputStream: { -> new ByteArrayInputStream(bytes) },
+                getNativeEntry: { -> bytes }
+            ] as ObjectStorageEntry<byte[]>)
+        }
+
+        @Override
+        Object delete(String key) { throw new UnsupportedOperationException() }
+
+        @Override
+        boolean exists(String key) { contents.containsKey(key) }
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/AbstractObjectStorageResourceLoader.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/AbstractObjectStorageResourceLoader.java
@@ -78,7 +78,11 @@ public abstract class AbstractObjectStorageResourceLoader implements ResourceLoa
         if (!hasRecognizedPrefix(path)) {
             return false;
         }
-        return resolveAbsolute(path).isPresent();
+        try {
+            return resolveAbsolute(path).isPresent();
+        } catch (IllegalArgumentException e) {
+            return true;
+        }
     }
 
     @Override
@@ -104,7 +108,7 @@ public abstract class AbstractObjectStorageResourceLoader implements ResourceLoa
     }
 
     protected final Optional<ResolvedObjectStorageResource> resolveRelative(@NonNull String path) {
-        if (relativeBase == null || !ObjectStorageResourceParser.isRelativePath(path)) {
+        if (relativeBase == null || hasRecognizedPrefix(path) || !ObjectStorageResourceParser.isRelativePath(path)) {
             return Optional.empty();
         }
         return Optional.of(new ResolvedObjectStorageResource(

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/AbstractObjectStorageResourceLoader.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/AbstractObjectStorageResourceLoader.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.resource;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.io.ResourceLoader;
+import io.micronaut.objectstorage.ObjectStorageEntry;
+import io.micronaut.objectstorage.ObjectStorageOperations;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Shared {@link ResourceLoader} support for object storage-backed resources.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.1.0
+ */
+@Internal
+public abstract class AbstractObjectStorageResourceLoader implements ResourceLoader {
+
+    @Nullable
+    private final RelativeBase relativeBase;
+
+    protected AbstractObjectStorageResourceLoader() {
+        this(null);
+    }
+
+    protected AbstractObjectStorageResourceLoader(@Nullable RelativeBase relativeBase) {
+        this.relativeBase = relativeBase;
+    }
+
+    @Override
+    public Optional<InputStream> getResourceAsStream(String path) {
+        return resolveResource(path).flatMap(this::openStream);
+    }
+
+    @Override
+    public Optional<URL> getResource(String path) {
+        return resolveResource(path)
+            .filter(this::exists)
+            .map(this::toUrl);
+    }
+
+    @Override
+    public Stream<URL> getResources(String path) {
+        return getResource(path).stream();
+    }
+
+    @Override
+    public boolean supportsPrefix(String path) {
+        if (resolveRelative(path).isPresent()) {
+            return true;
+        }
+        if (!hasRecognizedPrefix(path)) {
+            return false;
+        }
+        return resolveAbsolute(path).isPresent();
+    }
+
+    @Override
+    public ResourceLoader forBase(String basePath) {
+        ResolvedObjectStorageResource resolved = resolveAbsolute(basePath)
+            .orElseThrow(() -> new IllegalArgumentException("Unsupported object storage base path: " + basePath));
+        return withRelativeBase(new RelativeBase(
+            ObjectStorageResourceParser.ensureTrailingSlash(resolved.externalForm()),
+            ObjectStorageResourceParser.ensureTrailingSlash(resolved.key()),
+            resolved.operations()
+        ));
+    }
+
+    protected abstract boolean hasRecognizedPrefix(@NonNull String path);
+
+    protected abstract Optional<ResolvedObjectStorageResource> resolveAbsolute(@NonNull String path);
+
+    protected abstract AbstractObjectStorageResourceLoader withRelativeBase(@NonNull RelativeBase relativeBase);
+
+    protected final Optional<ResolvedObjectStorageResource> resolveResource(@NonNull String path) {
+        Optional<ResolvedObjectStorageResource> relative = resolveRelative(path);
+        return relative.isPresent() ? relative : resolveAbsolute(path);
+    }
+
+    protected final Optional<ResolvedObjectStorageResource> resolveRelative(@NonNull String path) {
+        if (relativeBase == null || !ObjectStorageResourceParser.isRelativePath(path)) {
+            return Optional.empty();
+        }
+        return Optional.of(new ResolvedObjectStorageResource(
+            relativeBase.keyPrefix() + path,
+            relativeBase.externalPrefix() + path,
+            relativeBase.operations()
+        ));
+    }
+
+    protected final Optional<InputStream> openStream(@NonNull ResolvedObjectStorageResource resolved) {
+        return retrieveEntry(resolved).map(ObjectStorageEntry::getInputStream);
+    }
+
+    protected final boolean exists(@NonNull ResolvedObjectStorageResource resolved) {
+        return resolved.operations().exists(resolved.key());
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    protected final Optional<ObjectStorageEntry<?>> retrieveEntry(@NonNull ResolvedObjectStorageResource resolved) {
+        return (Optional) resolved.operations().retrieve(resolved.key());
+    }
+
+    private URL toUrl(ResolvedObjectStorageResource resolved) {
+        String externalForm = resolved.externalForm();
+        int separator = externalForm.indexOf(':');
+        String protocol = externalForm.substring(0, separator);
+        String remainder = externalForm.substring(separator + 1);
+        try {
+            return new URL(protocol, null, -1, remainder, new ObjectStorageStreamHandler(resolved));
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid object storage URL: " + externalForm, e);
+        }
+    }
+
+    /**
+     * Relative loader state for {@link #forBase(String)}.
+     *
+     * @param externalPrefix The rebased URI prefix, always ending in {@code /}
+     * @param keyPrefix The rebased object key prefix, always ending in {@code /}
+     * @param operations The storage operations to use for relative lookups
+     */
+    @Internal
+    public record RelativeBase(
+        @NonNull String externalPrefix,
+        @NonNull String keyPrefix,
+        @NonNull ObjectStorageOperations<?, ?, ?> operations
+    ) {
+        public RelativeBase {
+            Objects.requireNonNull(externalPrefix, "externalPrefix");
+            Objects.requireNonNull(keyPrefix, "keyPrefix");
+            Objects.requireNonNull(operations, "operations");
+        }
+    }
+
+    /**
+     * Resolved object storage resource.
+     *
+     * @param key The object key used against the backing storage
+     * @param externalForm The URI exposed via {@link URL#toExternalForm()}
+     * @param operations The storage operations for the resolved resource
+     */
+    @Internal
+    public record ResolvedObjectStorageResource(
+        @NonNull String key,
+        @NonNull String externalForm,
+        @NonNull ObjectStorageOperations<?, ?, ?> operations
+    ) {
+        public ResolvedObjectStorageResource {
+            Objects.requireNonNull(key, "key");
+            Objects.requireNonNull(externalForm, "externalForm");
+            Objects.requireNonNull(operations, "operations");
+        }
+    }
+
+    private final class ObjectStorageStreamHandler extends URLStreamHandler {
+        private final ResolvedObjectStorageResource resolved;
+
+        private ObjectStorageStreamHandler(ResolvedObjectStorageResource resolved) {
+            this.resolved = resolved;
+        }
+
+        @Override
+        protected URLConnection openConnection(URL url) {
+            return new URLConnection(url) {
+                @Override
+                public void connect() {
+                    connected = true;
+                }
+
+                @Override
+                public InputStream getInputStream() throws IOException {
+                    return openStream(resolved)
+                        .orElseThrow(() -> new FileNotFoundException(resolved.externalForm()));
+                }
+            };
+        }
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/AbstractObjectStorageResourceLoader.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/AbstractObjectStorageResourceLoader.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
  * Shared {@link ResourceLoader} support for object storage-backed resources.
  *
  * @author Álvaro Sánchez-Mariscal
- * @since 3.1.0
+ * @since 3.0.0
  */
 @Internal
 public abstract class AbstractObjectStorageResourceLoader implements ResourceLoader {

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/NamedObjectStorageResourceLoader.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/NamedObjectStorageResourceLoader.java
@@ -28,7 +28,7 @@ import java.util.Optional;
  * Named storage resource loader for {@code <storage-name>://<key>}.
  *
  * @author Álvaro Sánchez-Mariscal
- * @since 3.1.0
+ * @since 3.0.0
  */
 @Internal
 public final class NamedObjectStorageResourceLoader extends AbstractObjectStorageResourceLoader {

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/NamedObjectStorageResourceLoader.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/NamedObjectStorageResourceLoader.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.resource;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.objectstorage.ObjectStorageOperations;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Optional;
+
+/**
+ * Named storage resource loader for {@code <storage-name>://<key>}.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.1.0
+ */
+@Internal
+public final class NamedObjectStorageResourceLoader extends AbstractObjectStorageResourceLoader {
+
+    private final String storageName;
+    @Nullable
+    private final BeanContext beanContext;
+    @Nullable
+    private final ObjectStorageOperations<?, ?, ?> operations;
+
+    public NamedObjectStorageResourceLoader(@NonNull String storageName,
+                                            @NonNull BeanContext beanContext) {
+        this(storageName, beanContext, null, null);
+    }
+
+    public NamedObjectStorageResourceLoader(@NonNull String storageName,
+                                            @NonNull ObjectStorageOperations<?, ?, ?> operations) {
+        this(storageName, null, operations, null);
+    }
+
+    private NamedObjectStorageResourceLoader(@NonNull String storageName,
+                                             @Nullable BeanContext beanContext,
+                                             @Nullable ObjectStorageOperations<?, ?, ?> operations,
+                                             @Nullable RelativeBase relativeBase) {
+        super(relativeBase);
+        this.storageName = storageName;
+        this.beanContext = beanContext;
+        this.operations = operations;
+    }
+
+    @Override
+    protected boolean hasRecognizedPrefix(@NonNull String path) {
+        return path.startsWith(storageName + ':');
+    }
+
+    @Override
+    protected Optional<ResolvedObjectStorageResource> resolveAbsolute(@NonNull String path) {
+        return ObjectStorageResourceParser.parseNamedStorageUri(path, storageName)
+            .flatMap(uri -> findOperations().map(operations -> new ResolvedObjectStorageResource(
+                uri.key(),
+                storageName + "://" + uri.key(),
+                operations
+            )));
+    }
+
+    @Override
+    protected AbstractObjectStorageResourceLoader withRelativeBase(@NonNull RelativeBase relativeBase) {
+        return new NamedObjectStorageResourceLoader(storageName, beanContext, operations, relativeBase);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private Optional<ObjectStorageOperations<?, ?, ?>> findOperations() {
+        if (operations != null) {
+            return Optional.of(operations);
+        }
+        if (beanContext == null) {
+            return Optional.empty();
+        }
+        return (Optional) beanContext.findBean(ObjectStorageOperations.class, Qualifiers.byName(storageName));
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/ObjectStorageNamedResourceLoaderFactory.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/ObjectStorageNamedResourceLoaderFactory.java
@@ -29,7 +29,7 @@ import java.util.Set;
  * Registers named object storage resource loaders.
  *
  * @author Álvaro Sánchez-Mariscal
- * @since 3.1.0
+ * @since 3.0.0
  */
 @Factory
 @Internal

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/ObjectStorageNamedResourceLoaderFactory.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/ObjectStorageNamedResourceLoaderFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.resource;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.exceptions.DisabledBeanException;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.io.ResourceLoader;
+import io.micronaut.objectstorage.configuration.ObjectStorageConfiguration;
+
+import java.util.Set;
+
+/**
+ * Registers named object storage resource loaders.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.1.0
+ */
+@Factory
+@Internal
+public class ObjectStorageNamedResourceLoaderFactory {
+
+    private static final Set<String> RESERVED_PREFIXES = Set.of(
+        "classpath",
+        "file",
+        "string",
+        "base64",
+        ObjectStorageResourceParser.S3_SCHEME,
+        ObjectStorageResourceParser.GS_SCHEME,
+        ObjectStorageResourceParser.AZB_SCHEME,
+        ObjectStorageResourceParser.OS_SCHEME
+    );
+
+    @EachBean(ObjectStorageConfiguration.class)
+    ResourceLoader namedResourceLoader(ObjectStorageConfiguration configuration,
+                                       BeanContext beanContext) {
+        String name = configuration.getName();
+        if (RESERVED_PREFIXES.contains(name)) {
+            throw new DisabledBeanException("Object storage resource loader prefix [" + name + "] is reserved");
+        }
+        return new NamedObjectStorageResourceLoader(name, beanContext);
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/ObjectStorageResourceParser.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/ObjectStorageResourceParser.java
@@ -33,6 +33,9 @@ public final class ObjectStorageResourceParser {
     public static final String GS_SCHEME = "gs";
     public static final String AZB_SCHEME = "azb";
     public static final String OS_SCHEME = "os";
+    private static final String EXPECTED_PREFIX = "Expected ";
+    private static final String OBJECT_KEY_MUST_NOT_BE_EMPTY = "Object key must not be empty";
+    private static final String ORACLE_CLOUD_URI_FORMAT = "os:<region>:<namespace>://<bucket>/<key>";
 
     private ObjectStorageResourceParser() {
     }
@@ -51,11 +54,11 @@ public final class ObjectStorageResourceParser {
             return Optional.empty();
         }
         if (!path.startsWith(storageName + "://")) {
-            throw invalid(path, "Expected " + storageName + "://<key>");
+            throw invalid(path, EXPECTED_PREFIX + storageName + "://<key>");
         }
         String key = path.substring(storageName.length() + 3);
         if (key.isEmpty()) {
-            throw invalid(path, "Object key must not be empty");
+            throw invalid(path, OBJECT_KEY_MUST_NOT_BE_EMPTY);
         }
         return Optional.of(new NamedStorageUri(storageName, key));
     }
@@ -66,12 +69,12 @@ public final class ObjectStorageResourceParser {
             return Optional.empty();
         }
         if (!path.startsWith(scheme + "://")) {
-            throw invalid(path, "Expected " + scheme + "://<bucket>/<key>");
+            throw invalid(path, EXPECTED_PREFIX + scheme + "://<bucket>/<key>");
         }
         String remainder = path.substring(scheme.length() + 3);
         int separator = remainder.indexOf('/');
         if (separator < 0) {
-            throw invalid(path, "Expected " + scheme + "://<bucket>/<key>");
+            throw invalid(path, EXPECTED_PREFIX + scheme + "://<bucket>/<key>");
         }
         String bucket = remainder.substring(0, separator);
         String key = remainder.substring(separator + 1);
@@ -79,7 +82,7 @@ public final class ObjectStorageResourceParser {
             throw invalid(path, "Bucket name must not be empty");
         }
         if (key.isEmpty()) {
-            throw invalid(path, "Object key must not be empty");
+            throw invalid(path, OBJECT_KEY_MUST_NOT_BE_EMPTY);
         }
         return Optional.of(new BucketStorageUri(scheme, bucket, key));
     }
@@ -91,7 +94,7 @@ public final class ObjectStorageResourceParser {
         String remainder = path.substring(AZB_SCHEME.length() + 1);
         int authoritySeparator = remainder.indexOf("://");
         if (authoritySeparator < 0) {
-            throw invalid(path, "Expected azb:<account>://<container>/<key>");
+            throw invalid(path, EXPECTED_PREFIX + "azb:<account>://<container>/<key>");
         }
         String account = remainder.substring(0, authoritySeparator);
         if (account.isEmpty()) {
@@ -100,7 +103,7 @@ public final class ObjectStorageResourceParser {
         String containerAndKey = remainder.substring(authoritySeparator + 3);
         int keySeparator = containerAndKey.indexOf('/');
         if (keySeparator < 0) {
-            throw invalid(path, "Expected azb:<account>://<container>/<key>");
+            throw invalid(path, EXPECTED_PREFIX + "azb:<account>://<container>/<key>");
         }
         String container = containerAndKey.substring(0, keySeparator);
         String key = containerAndKey.substring(keySeparator + 1);
@@ -108,7 +111,7 @@ public final class ObjectStorageResourceParser {
             throw invalid(path, "Azure container must not be empty");
         }
         if (key.isEmpty()) {
-            throw invalid(path, "Object key must not be empty");
+            throw invalid(path, OBJECT_KEY_MUST_NOT_BE_EMPTY);
         }
         return Optional.of(new AzureBlobStorageUri(account, container, key));
     }
@@ -120,16 +123,16 @@ public final class ObjectStorageResourceParser {
         String remainder = path.substring(OS_SCHEME.length() + 1);
         int authoritySeparator = remainder.indexOf("://");
         if (authoritySeparator < 0) {
-            throw invalid(path, "Expected os:<region>:<namespace>://<bucket>/<key>");
+            throw invalid(path, EXPECTED_PREFIX + ORACLE_CLOUD_URI_FORMAT);
         }
         String[] authorityParts = remainder.substring(0, authoritySeparator).split(":", 2);
         if (authorityParts.length != 2 || authorityParts[0].isEmpty() || authorityParts[1].isEmpty()) {
-            throw invalid(path, "Expected os:<region>:<namespace>://<bucket>/<key>");
+            throw invalid(path, EXPECTED_PREFIX + ORACLE_CLOUD_URI_FORMAT);
         }
         String bucketAndKey = remainder.substring(authoritySeparator + 3);
         int keySeparator = bucketAndKey.indexOf('/');
         if (keySeparator < 0) {
-            throw invalid(path, "Expected os:<region>:<namespace>://<bucket>/<key>");
+            throw invalid(path, EXPECTED_PREFIX + ORACLE_CLOUD_URI_FORMAT);
         }
         String bucket = bucketAndKey.substring(0, keySeparator);
         String key = bucketAndKey.substring(keySeparator + 1);
@@ -137,7 +140,7 @@ public final class ObjectStorageResourceParser {
             throw invalid(path, "Oracle Cloud bucket must not be empty");
         }
         if (key.isEmpty()) {
-            throw invalid(path, "Object key must not be empty");
+            throw invalid(path, OBJECT_KEY_MUST_NOT_BE_EMPTY);
         }
         return Optional.of(new OracleCloudStorageUri(authorityParts[0], authorityParts[1], bucket, key));
     }

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/ObjectStorageResourceParser.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/ObjectStorageResourceParser.java
@@ -24,7 +24,7 @@ import java.util.Optional;
  * Parser utilities for object storage resource URIs.
  *
  * @author Álvaro Sánchez-Mariscal
- * @since 3.1.0
+ * @since 3.0.0
  */
 @Internal
 public final class ObjectStorageResourceParser {

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/ObjectStorageResourceParser.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/ObjectStorageResourceParser.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.resource;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Optional;
+
+/**
+ * Parser utilities for object storage resource URIs.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.1.0
+ */
+@Internal
+public final class ObjectStorageResourceParser {
+
+    public static final String S3_SCHEME = "s3";
+    public static final String GS_SCHEME = "gs";
+    public static final String AZB_SCHEME = "azb";
+    public static final String OS_SCHEME = "os";
+
+    private ObjectStorageResourceParser() {
+    }
+
+    public static boolean isRelativePath(@NonNull String path) {
+        return path.indexOf(':') < 0;
+    }
+
+    public static String ensureTrailingSlash(@NonNull String value) {
+        return value.endsWith("/") ? value : value + '/';
+    }
+
+    public static Optional<NamedStorageUri> parseNamedStorageUri(@NonNull String path, @NonNull String storageName) {
+        String prefix = storageName + ':';
+        if (!path.startsWith(prefix)) {
+            return Optional.empty();
+        }
+        if (!path.startsWith(storageName + "://")) {
+            throw invalid(path, "Expected " + storageName + "://<key>");
+        }
+        String key = path.substring(storageName.length() + 3);
+        if (key.isEmpty()) {
+            throw invalid(path, "Object key must not be empty");
+        }
+        return Optional.of(new NamedStorageUri(storageName, key));
+    }
+
+    public static Optional<BucketStorageUri> parseBucketStorageUri(@NonNull String path, @NonNull String scheme) {
+        String prefix = scheme + ':';
+        if (!path.startsWith(prefix)) {
+            return Optional.empty();
+        }
+        if (!path.startsWith(scheme + "://")) {
+            throw invalid(path, "Expected " + scheme + "://<bucket>/<key>");
+        }
+        String remainder = path.substring(scheme.length() + 3);
+        int separator = remainder.indexOf('/');
+        if (separator < 0) {
+            throw invalid(path, "Expected " + scheme + "://<bucket>/<key>");
+        }
+        String bucket = remainder.substring(0, separator);
+        String key = remainder.substring(separator + 1);
+        if (bucket.isEmpty()) {
+            throw invalid(path, "Bucket name must not be empty");
+        }
+        if (key.isEmpty()) {
+            throw invalid(path, "Object key must not be empty");
+        }
+        return Optional.of(new BucketStorageUri(scheme, bucket, key));
+    }
+
+    public static Optional<AzureBlobStorageUri> parseAzureBlobStorageUri(@NonNull String path) {
+        if (!path.startsWith(AZB_SCHEME + ':')) {
+            return Optional.empty();
+        }
+        String remainder = path.substring(AZB_SCHEME.length() + 1);
+        int authoritySeparator = remainder.indexOf("://");
+        if (authoritySeparator < 0) {
+            throw invalid(path, "Expected azb:<account>://<container>/<key>");
+        }
+        String account = remainder.substring(0, authoritySeparator);
+        if (account.isEmpty()) {
+            throw invalid(path, "Azure storage account must not be empty");
+        }
+        String containerAndKey = remainder.substring(authoritySeparator + 3);
+        int keySeparator = containerAndKey.indexOf('/');
+        if (keySeparator < 0) {
+            throw invalid(path, "Expected azb:<account>://<container>/<key>");
+        }
+        String container = containerAndKey.substring(0, keySeparator);
+        String key = containerAndKey.substring(keySeparator + 1);
+        if (container.isEmpty()) {
+            throw invalid(path, "Azure container must not be empty");
+        }
+        if (key.isEmpty()) {
+            throw invalid(path, "Object key must not be empty");
+        }
+        return Optional.of(new AzureBlobStorageUri(account, container, key));
+    }
+
+    public static Optional<OracleCloudStorageUri> parseOracleCloudStorageUri(@NonNull String path) {
+        if (!path.startsWith(OS_SCHEME + ':')) {
+            return Optional.empty();
+        }
+        String remainder = path.substring(OS_SCHEME.length() + 1);
+        int authoritySeparator = remainder.indexOf("://");
+        if (authoritySeparator < 0) {
+            throw invalid(path, "Expected os:<region>:<namespace>://<bucket>/<key>");
+        }
+        String[] authorityParts = remainder.substring(0, authoritySeparator).split(":", 2);
+        if (authorityParts.length != 2 || authorityParts[0].isEmpty() || authorityParts[1].isEmpty()) {
+            throw invalid(path, "Expected os:<region>:<namespace>://<bucket>/<key>");
+        }
+        String bucketAndKey = remainder.substring(authoritySeparator + 3);
+        int keySeparator = bucketAndKey.indexOf('/');
+        if (keySeparator < 0) {
+            throw invalid(path, "Expected os:<region>:<namespace>://<bucket>/<key>");
+        }
+        String bucket = bucketAndKey.substring(0, keySeparator);
+        String key = bucketAndKey.substring(keySeparator + 1);
+        if (bucket.isEmpty()) {
+            throw invalid(path, "Oracle Cloud bucket must not be empty");
+        }
+        if (key.isEmpty()) {
+            throw invalid(path, "Object key must not be empty");
+        }
+        return Optional.of(new OracleCloudStorageUri(authorityParts[0], authorityParts[1], bucket, key));
+    }
+
+    private static IllegalArgumentException invalid(String path, String message) {
+        return new IllegalArgumentException("Invalid object storage URI [" + path + "]: " + message);
+    }
+
+    @Internal
+    public record NamedStorageUri(@NonNull String storageName, @NonNull String key) {
+    }
+
+    @Internal
+    public record BucketStorageUri(@NonNull String scheme, @NonNull String bucket, @NonNull String key) {
+    }
+
+    @Internal
+    public record AzureBlobStorageUri(@NonNull String account, @NonNull String container, @NonNull String key) {
+    }
+
+    @Internal
+    public record OracleCloudStorageUri(@NonNull String region, @NonNull String namespace, @NonNull String bucket, @NonNull String key) {
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/ObjectStorageResourceParser.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/ObjectStorageResourceParser.java
@@ -41,7 +41,15 @@ public final class ObjectStorageResourceParser {
     }
 
     public static boolean isRelativePath(@NonNull String path) {
-        return path.indexOf(':') < 0;
+        int schemeSeparator = path.indexOf(':');
+        if (schemeSeparator < 0) {
+            return true;
+        }
+        int firstSlash = path.indexOf('/');
+        if (firstSlash >= 0 && firstSlash < schemeSeparator) {
+            return true;
+        }
+        return path.indexOf("://", schemeSeparator) < 0;
     }
 
     public static String ensureTrailingSlash(@NonNull String value) {

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/resource/NamedObjectStorageResourceLoaderSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/resource/NamedObjectStorageResourceLoaderSpec.groovy
@@ -14,7 +14,8 @@ class NamedObjectStorageResourceLoaderSpec extends Specification {
     void 'it resolves named storage resources and rebases relative lookups'() {
         given:
         def operations = new TestObjectStorageOperations([
-            'avatars/logo.txt': 'logo-bytes'
+            'avatars/logo.txt': 'logo-bytes',
+            'avatars/logo:v2.txt': 'logo-v2-bytes'
         ])
         def loader = new NamedObjectStorageResourceLoader('public-images', operations)
 
@@ -30,6 +31,8 @@ class NamedObjectStorageResourceLoaderSpec extends Specification {
         then:
         rebased.supportsPrefix('logo.txt')
         rebased.getResourceAsStream('logo.txt').get().text == 'logo-bytes'
+        rebased.supportsPrefix('logo:v2.txt')
+        rebased.getResourceAsStream('logo:v2.txt').get().text == 'logo-v2-bytes'
     }
 
     void 'it returns empty for missing objects'() {
@@ -46,8 +49,23 @@ class NamedObjectStorageResourceLoaderSpec extends Specification {
         given:
         def loader = new NamedObjectStorageResourceLoader('public-images', new TestObjectStorageOperations([:]))
 
+        expect:
+        loader.supportsPrefix('public-images:/avatars/logo.txt')
+
         when:
         loader.getResourceAsStream('public-images://')
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('Invalid object storage URI')
+    }
+
+    void 'it rejects malformed named storage uris after supportsPrefix'() {
+        given:
+        def loader = new NamedObjectStorageResourceLoader('public-images', new TestObjectStorageOperations([:]))
+
+        when:
+        loader.getResourceAsStream('public-images:/avatars/logo.txt')
 
         then:
         def e = thrown(IllegalArgumentException)

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/resource/NamedObjectStorageResourceLoaderSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/resource/NamedObjectStorageResourceLoaderSpec.groovy
@@ -1,0 +1,128 @@
+package io.micronaut.objectstorage.resource
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.exceptions.DisabledBeanException
+import io.micronaut.objectstorage.ObjectStorageEntry
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.response.UploadResponse
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class NamedObjectStorageResourceLoaderSpec extends Specification {
+
+    void 'it resolves named storage resources and rebases relative lookups'() {
+        given:
+        def operations = new TestObjectStorageOperations([
+            'avatars/logo.txt': 'logo-bytes'
+        ])
+        def loader = new NamedObjectStorageResourceLoader('public-images', operations)
+
+        expect:
+        loader.supportsPrefix('public-images://avatars/logo.txt')
+        loader.getResourceAsStream('public-images://avatars/logo.txt').get().text == 'logo-bytes'
+        loader.getResource('public-images://avatars/logo.txt').get().text == 'logo-bytes'
+        loader.getResources('public-images://avatars/logo.txt').toList()*.text == ['logo-bytes']
+
+        when:
+        def rebased = loader.forBase('public-images://avatars/')
+
+        then:
+        rebased.supportsPrefix('logo.txt')
+        rebased.getResourceAsStream('logo.txt').get().text == 'logo-bytes'
+    }
+
+    void 'it returns empty for missing objects'() {
+        given:
+        def loader = new NamedObjectStorageResourceLoader('public-images', new TestObjectStorageOperations([:]))
+
+        expect:
+        loader.getResourceAsStream('public-images://missing.txt').empty
+        loader.getResource('public-images://missing.txt').empty
+        loader.getResources('public-images://missing.txt').toList().empty
+    }
+
+    void 'it rejects malformed named storage uris'() {
+        given:
+        def loader = new NamedObjectStorageResourceLoader('public-images', new TestObjectStorageOperations([:]))
+
+        when:
+        loader.getResourceAsStream('public-images://')
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('Invalid object storage URI')
+    }
+
+    void 'it rejects reserved named loader prefixes'() {
+        given:
+        def factory = new ObjectStorageNamedResourceLoaderFactory()
+        def configuration = Stub(io.micronaut.objectstorage.configuration.ObjectStorageConfiguration) {
+            getName() >> 'string'
+        }
+
+        when:
+        factory.namedResourceLoader(configuration, Stub(BeanContext))
+
+        then:
+        thrown(DisabledBeanException)
+    }
+
+    private static final class TestObjectStorageOperations implements ObjectStorageOperations<Object, Object, Object> {
+        private final Map<String, byte[]> contents
+
+        private TestObjectStorageOperations(Map<String, String> contents) {
+            this.contents = contents.collectEntries { key, value -> [(key): value.getBytes(StandardCharsets.UTF_8)] }
+        }
+
+        @Override
+        UploadResponse<Object> upload(io.micronaut.objectstorage.request.UploadRequest request) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        UploadResponse<Object> upload(io.micronaut.objectstorage.request.UploadRequest request, java.util.function.Consumer<Object> requestConsumer) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        Optional<TestObjectStorageEntry> retrieve(String key) {
+            return Optional.ofNullable(contents.get(key)).map(bytes -> new TestObjectStorageEntry(key, bytes))
+        }
+
+        @Override
+        Object delete(String key) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        boolean exists(String key) {
+            return contents.containsKey(key)
+        }
+    }
+
+    private static final class TestObjectStorageEntry implements ObjectStorageEntry<byte[]> {
+        private final String key
+        private final byte[] bytes
+
+        private TestObjectStorageEntry(String key, byte[] bytes) {
+            this.key = key
+            this.bytes = bytes
+        }
+
+        @Override
+        String getKey() {
+            return key
+        }
+
+        @Override
+        InputStream getInputStream() {
+            return new ByteArrayInputStream(bytes)
+        }
+
+        @Override
+        byte[] getNativeEntry() {
+            return bytes
+        }
+    }
+}

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageResourceLoader.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageResourceLoader.java
@@ -30,7 +30,7 @@ import java.util.Optional;
  * Google Cloud Storage {@link io.micronaut.core.io.ResourceLoader} for {@code gs://<bucket>/<key>}.
  *
  * @author Álvaro Sánchez-Mariscal
- * @since 3.1.0
+ * @since 3.0.0
  */
 @Internal
 final class GoogleCloudStorageResourceLoader extends AbstractObjectStorageResourceLoader {

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageResourceLoader.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageResourceLoader.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.googlecloud;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.ObjectStorageOperations;
+import io.micronaut.objectstorage.resource.AbstractObjectStorageResourceLoader;
+import io.micronaut.objectstorage.resource.ObjectStorageResourceParser;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Google Cloud Storage {@link io.micronaut.core.io.ResourceLoader} for {@code gs://<bucket>/<key>}.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.1.0
+ */
+@Internal
+final class GoogleCloudStorageResourceLoader extends AbstractObjectStorageResourceLoader {
+
+    private final List<GoogleCloudStorageConfiguration> configurations;
+    private final Map<String, ObjectStorageOperations<?, ?, ?>> operationsByName;
+
+    GoogleCloudStorageResourceLoader(@NonNull List<GoogleCloudStorageConfiguration> configurations,
+                                     @NonNull Map<String, ObjectStorageOperations<?, ?, ?>> operationsByName) {
+        this(configurations, operationsByName, null);
+    }
+
+    private GoogleCloudStorageResourceLoader(@NonNull List<GoogleCloudStorageConfiguration> configurations,
+                                             @NonNull Map<String, ObjectStorageOperations<?, ?, ?>> operationsByName,
+                                             @Nullable RelativeBase relativeBase) {
+        super(relativeBase);
+        this.configurations = configurations;
+        this.operationsByName = operationsByName;
+    }
+
+    @Override
+    protected boolean hasRecognizedPrefix(@NonNull String path) {
+        return path.startsWith(ObjectStorageResourceParser.GS_SCHEME + ':');
+    }
+
+    @Override
+    protected Optional<ResolvedObjectStorageResource> resolveAbsolute(@NonNull String path) {
+        return ObjectStorageResourceParser.parseBucketStorageUri(path, ObjectStorageResourceParser.GS_SCHEME)
+            .flatMap(uri -> {
+                List<GoogleCloudStorageConfiguration> matches = configurations.stream()
+                    .filter(configuration -> configuration.getBucket().equals(uri.bucket()))
+                    .filter(configuration -> operationsByName.containsKey(configuration.getName()))
+                    .toList();
+                if (matches.isEmpty()) {
+                    return Optional.empty();
+                }
+                if (matches.size() > 1) {
+                    throw new IllegalStateException("Multiple configured Google Cloud object storages match bucket [" + uri.bucket() + "]");
+                }
+                GoogleCloudStorageConfiguration configuration = matches.get(0);
+                return Optional.of(new ResolvedObjectStorageResource(
+                    uri.key(),
+                    ObjectStorageResourceParser.GS_SCHEME + "://" + uri.bucket() + '/' + uri.key(),
+                    operationsByName.get(configuration.getName())
+                ));
+            });
+    }
+
+    @Override
+    protected AbstractObjectStorageResourceLoader withRelativeBase(@NonNull RelativeBase relativeBase) {
+        return new GoogleCloudStorageResourceLoader(configurations, operationsByName, relativeBase);
+    }
+}

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageResourceLoaderFactory.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageResourceLoaderFactory.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
  * Registers the {@code gs:} resource loader.
  *
  * @author Álvaro Sánchez-Mariscal
- * @since 3.1.0
+ * @since 3.0.0
  */
 @Factory
 @Internal

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageResourceLoaderFactory.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageResourceLoaderFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.googlecloud;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.io.ResourceLoader;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.objectstorage.ObjectStorageOperations;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Registers the {@code gs:} resource loader.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.1.0
+ */
+@Factory
+@Internal
+public class GoogleCloudStorageResourceLoaderFactory {
+
+    @Singleton
+    @Requires(beans = GoogleCloudStorageConfiguration.class)
+    ResourceLoader googleCloudStorageResourceLoader(BeanContext beanContext) {
+        List<GoogleCloudStorageConfiguration> configurations = beanContext.getBeansOfType(GoogleCloudStorageConfiguration.class).stream()
+            .toList();
+        Map<String, ObjectStorageOperations<?, ?, ?>> operationsByName = configurations.stream()
+            .map(configuration -> Map.entry(configuration.getName(), findOperations(beanContext, configuration.getName())))
+            .filter(entry -> entry.getValue().isPresent())
+            .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().orElseThrow()));
+        return new GoogleCloudStorageResourceLoader(configurations, operationsByName);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private Optional<ObjectStorageOperations<?, ?, ?>> findOperations(BeanContext beanContext, String name) {
+        return (Optional) beanContext.findBean(ObjectStorageOperations.class, Qualifiers.byName(name));
+    }
+}

--- a/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageResourceLoaderSpec.groovy
+++ b/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageResourceLoaderSpec.groovy
@@ -1,0 +1,55 @@
+package io.micronaut.objectstorage.googlecloud
+
+import io.micronaut.objectstorage.ObjectStorageEntry
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.response.UploadResponse
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class GoogleCloudStorageResourceLoaderSpec extends Specification {
+
+    void 'it resolves gs resources for configured buckets'() {
+        given:
+        def configuration = new GoogleCloudStorageConfiguration('public-images')
+        configuration.bucket = 'public-images-bucket'
+        def loader = new GoogleCloudStorageResourceLoader(
+            [configuration],
+            ['public-images': new TestObjectStorageOperations(['avatars/logo.txt': 'gcp-logo'])]
+        )
+
+        expect:
+        loader.supportsPrefix('gs://public-images-bucket/avatars/logo.txt')
+        loader.getResourceAsStream('gs://public-images-bucket/avatars/logo.txt').get().text == 'gcp-logo'
+        loader.forBase('gs://public-images-bucket/avatars/').getResourceAsStream('logo.txt').get().text == 'gcp-logo'
+    }
+
+    private static final class TestObjectStorageOperations implements ObjectStorageOperations<Object, Object, Object> {
+        private final Map<String, byte[]> contents
+
+        private TestObjectStorageOperations(Map<String, String> contents) {
+            this.contents = contents.collectEntries { key, value -> [(key): value.getBytes(StandardCharsets.UTF_8)] }
+        }
+
+        @Override
+        UploadResponse<Object> upload(io.micronaut.objectstorage.request.UploadRequest request) { throw new UnsupportedOperationException() }
+
+        @Override
+        UploadResponse<Object> upload(io.micronaut.objectstorage.request.UploadRequest request, java.util.function.Consumer<Object> requestConsumer) { throw new UnsupportedOperationException() }
+
+        @Override
+        Optional<ObjectStorageEntry<byte[]>> retrieve(String key) {
+            return Optional.ofNullable(contents.get(key)).map(bytes -> [
+                getKey        : { -> key },
+                getInputStream: { -> new ByteArrayInputStream(bytes) },
+                getNativeEntry: { -> bytes }
+            ] as ObjectStorageEntry<byte[]>)
+        }
+
+        @Override
+        Object delete(String key) { throw new UnsupportedOperationException() }
+
+        @Override
+        boolean exists(String key) { contents.containsKey(key) }
+    }
+}

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageResourceLoaderSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageResourceLoaderSpec.groovy
@@ -1,0 +1,39 @@
+package io.micronaut.objectstorage.local
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.io.ResourceLoader
+import io.micronaut.core.io.ResourceResolver
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.request.UploadRequest
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Path
+
+import static io.micronaut.objectstorage.local.LocalStorageConfiguration.PREFIX
+
+class LocalStorageResourceLoaderSpec extends Specification {
+
+    @TempDir
+    Path tempDir
+
+    void 'it exposes named storage resource loaders through the application context'() {
+        given:
+        ApplicationContext context = ApplicationContext.run(
+            [
+                (PREFIX + '.public-images.path'): tempDir.toString()
+            ]
+        )
+        def operations = context.getBean(ObjectStorageOperations, Qualifiers.byName('public-images'))
+        operations.upload(UploadRequest.fromBytes('hello-loader'.bytes, 'avatars/logo.txt'))
+        def resolver = new ResourceResolver(context.getBeansOfType(ResourceLoader).toList())
+
+        expect:
+        resolver.getResourceAsStream('public-images://avatars/logo.txt').get().text == 'hello-loader'
+        resolver.getLoaderForBasePath('public-images://avatars/').get().getResourceAsStream('logo.txt').get().text == 'hello-loader'
+
+        cleanup:
+        context.close()
+    }
+}

--- a/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageResourceLoader.java
+++ b/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageResourceLoader.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.oraclecloud;
+
+import com.oracle.bmc.auth.RegionProvider;
+import io.micronaut.context.BeanContext;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.objectstorage.ObjectStorageOperations;
+import io.micronaut.objectstorage.resource.AbstractObjectStorageResourceLoader;
+import io.micronaut.objectstorage.resource.ObjectStorageResourceParser;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Oracle Cloud {@link io.micronaut.core.io.ResourceLoader} for
+ * {@code os:<region>:<namespace>://<bucket>/<key>}.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.1.0
+ */
+@Internal
+final class OracleCloudStorageResourceLoader extends AbstractObjectStorageResourceLoader {
+
+    @Nullable
+    private final BeanContext beanContext;
+    private final List<OracleCloudStorageConfiguration> configurations;
+    @Nullable
+    private final Map<String, ObjectStorageOperations<?, ?, ?>> operationsByName;
+    @Nullable
+    private final RegionProvider regionProvider;
+
+    OracleCloudStorageResourceLoader(@NonNull BeanContext beanContext,
+                                     @NonNull List<OracleCloudStorageConfiguration> configurations) {
+        this(beanContext, configurations, null);
+    }
+
+    OracleCloudStorageResourceLoader(@NonNull List<OracleCloudStorageConfiguration> configurations,
+                                     @NonNull Map<String, ObjectStorageOperations<?, ?, ?>> operationsByName,
+                                     @NonNull RegionProvider regionProvider) {
+        this(null, configurations, operationsByName, regionProvider, null);
+    }
+
+    private OracleCloudStorageResourceLoader(@Nullable BeanContext beanContext,
+                                             @NonNull List<OracleCloudStorageConfiguration> configurations,
+                                             @Nullable Map<String, ObjectStorageOperations<?, ?, ?>> operationsByName,
+                                             @Nullable RegionProvider regionProvider,
+                                             @Nullable RelativeBase relativeBase) {
+        super(relativeBase);
+        this.beanContext = beanContext;
+        this.configurations = configurations;
+        this.operationsByName = operationsByName;
+        this.regionProvider = regionProvider;
+    }
+
+    private OracleCloudStorageResourceLoader(@NonNull BeanContext beanContext,
+                                             @NonNull List<OracleCloudStorageConfiguration> configurations,
+                                             @Nullable RelativeBase relativeBase) {
+        this(beanContext, configurations, null, null, relativeBase);
+    }
+
+    private OracleCloudStorageResourceLoader(@NonNull List<OracleCloudStorageConfiguration> configurations,
+                                             @Nullable Map<String, ObjectStorageOperations<?, ?, ?>> operationsByName,
+                                             @Nullable RegionProvider regionProvider,
+                                             @Nullable RelativeBase relativeBase) {
+        this(null, configurations, operationsByName, regionProvider, relativeBase);
+    }
+
+    @Override
+    protected boolean hasRecognizedPrefix(@NonNull String path) {
+        return path.startsWith(ObjectStorageResourceParser.OS_SCHEME + ':');
+    }
+
+    @Override
+    protected Optional<ResolvedObjectStorageResource> resolveAbsolute(@NonNull String path) {
+        Optional<RegionProvider> regionProvider = findRegionProvider();
+        if (regionProvider.isEmpty()) {
+            return Optional.empty();
+        }
+        return ObjectStorageResourceParser.parseOracleCloudStorageUri(path)
+            .flatMap(uri -> {
+                if (!regionProvider.orElseThrow().getRegion().getRegionId().equals(uri.region())) {
+                    return Optional.empty();
+                }
+                List<ResolvedObjectStorageResource> matches = configurations.stream()
+                    .filter(configuration -> configuration.getBucket().equals(uri.bucket()))
+                    .filter(configuration -> configuration.getNamespace().equals(uri.namespace()))
+                    .map(configuration -> findOperations(configuration.getName())
+                        .map(operations -> new ResolvedObjectStorageResource(
+                            uri.key(),
+                            ObjectStorageResourceParser.OS_SCHEME + ':' + uri.region() + ':' + uri.namespace() + "://" + uri.bucket() + '/' + uri.key(),
+                            operations
+                        )))
+                    .flatMap(Optional::stream)
+                    .toList();
+                if (matches.isEmpty()) {
+                    return Optional.empty();
+                }
+                if (matches.size() > 1) {
+                    throw new IllegalStateException(
+                        "Multiple configured Oracle Cloud object storages match namespace [" + uri.namespace() + "] and bucket [" + uri.bucket() + "]"
+                    );
+                }
+                return Optional.of(matches.get(0));
+            });
+    }
+
+    @Override
+    protected AbstractObjectStorageResourceLoader withRelativeBase(@NonNull RelativeBase relativeBase) {
+        return beanContext != null
+            ? new OracleCloudStorageResourceLoader(beanContext, configurations, relativeBase)
+            : new OracleCloudStorageResourceLoader(configurations, operationsByName, regionProvider, relativeBase);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private Optional<ObjectStorageOperations<?, ?, ?>> findOperations(@NonNull String name) {
+        if (beanContext != null) {
+            return (Optional) beanContext.findBean(ObjectStorageOperations.class, Qualifiers.byName(name));
+        }
+        return Optional.ofNullable(operationsByName).map(map -> map.get(name));
+    }
+
+    private Optional<RegionProvider> findRegionProvider() {
+        if (beanContext != null) {
+            return beanContext.findBean(RegionProvider.class);
+        }
+        return Optional.ofNullable(regionProvider);
+    }
+}

--- a/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageResourceLoader.java
+++ b/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageResourceLoader.java
@@ -34,7 +34,7 @@ import java.util.Optional;
  * {@code os:<region>:<namespace>://<bucket>/<key>}.
  *
  * @author Álvaro Sánchez-Mariscal
- * @since 3.1.0
+ * @since 3.0.0
  */
 @Internal
 final class OracleCloudStorageResourceLoader extends AbstractObjectStorageResourceLoader {

--- a/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageResourceLoaderFactory.java
+++ b/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageResourceLoaderFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.oraclecloud;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.io.ResourceLoader;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+/**
+ * Registers the {@code os:} resource loader.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.1.0
+ */
+@Factory
+@Internal
+public class OracleCloudStorageResourceLoaderFactory {
+
+    @Singleton
+    @Requires(beans = OracleCloudStorageConfiguration.class)
+    ResourceLoader oracleCloudStorageResourceLoader(BeanContext beanContext) {
+        List<OracleCloudStorageConfiguration> configurations = beanContext.getBeansOfType(OracleCloudStorageConfiguration.class).stream()
+            .toList();
+        return new OracleCloudStorageResourceLoader(beanContext, configurations);
+    }
+}

--- a/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageResourceLoaderFactory.java
+++ b/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageResourceLoaderFactory.java
@@ -28,7 +28,7 @@ import java.util.List;
  * Registers the {@code os:} resource loader.
  *
  * @author Álvaro Sánchez-Mariscal
- * @since 3.1.0
+ * @since 3.0.0
  */
 @Factory
 @Internal

--- a/object-storage-oracle-cloud/src/test/groovy/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageResourceLoaderSpec.groovy
+++ b/object-storage-oracle-cloud/src/test/groovy/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageResourceLoaderSpec.groovy
@@ -1,0 +1,78 @@
+package io.micronaut.objectstorage.oraclecloud
+
+import com.oracle.bmc.Region
+import com.oracle.bmc.auth.RegionProvider
+import io.micronaut.objectstorage.ObjectStorageEntry
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.response.UploadResponse
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class OracleCloudStorageResourceLoaderSpec extends Specification {
+
+    void 'it resolves oracle cloud resources for the active region'() {
+        given:
+        def configuration = new OracleCloudStorageConfiguration('public-images')
+        configuration.bucket = 'public-images-bucket'
+        configuration.namespace = 'cliponaut'
+        def loader = new OracleCloudStorageResourceLoader(
+            [configuration],
+            ['public-images': new TestObjectStorageOperations(['avatars/logo.txt': 'oci-logo'])],
+            Stub(RegionProvider) {
+                getRegion() >> Region.US_ASHBURN_1
+            }
+        )
+
+        expect:
+        loader.supportsPrefix('os:us-ashburn-1:cliponaut://public-images-bucket/avatars/logo.txt')
+        loader.getResourceAsStream('os:us-ashburn-1:cliponaut://public-images-bucket/avatars/logo.txt').get().text == 'oci-logo'
+    }
+
+    void 'it ignores oracle cloud resources for other regions'() {
+        given:
+        def configuration = new OracleCloudStorageConfiguration('public-images')
+        configuration.bucket = 'public-images-bucket'
+        configuration.namespace = 'cliponaut'
+        def loader = new OracleCloudStorageResourceLoader(
+            [configuration],
+            ['public-images': new TestObjectStorageOperations(['avatars/logo.txt': 'oci-logo'])],
+            Stub(RegionProvider) {
+                getRegion() >> Region.US_ASHBURN_1
+            }
+        )
+
+        expect:
+        !loader.supportsPrefix('os:eu-frankfurt-1:cliponaut://public-images-bucket/avatars/logo.txt')
+        loader.getResourceAsStream('os:eu-frankfurt-1:cliponaut://public-images-bucket/avatars/logo.txt').empty
+    }
+
+    private static final class TestObjectStorageOperations implements ObjectStorageOperations<Object, Object, Object> {
+        private final Map<String, byte[]> contents
+
+        private TestObjectStorageOperations(Map<String, String> contents) {
+            this.contents = contents.collectEntries { key, value -> [(key): value.getBytes(StandardCharsets.UTF_8)] }
+        }
+
+        @Override
+        UploadResponse<Object> upload(io.micronaut.objectstorage.request.UploadRequest request) { throw new UnsupportedOperationException() }
+
+        @Override
+        UploadResponse<Object> upload(io.micronaut.objectstorage.request.UploadRequest request, java.util.function.Consumer<Object> requestConsumer) { throw new UnsupportedOperationException() }
+
+        @Override
+        Optional<ObjectStorageEntry<byte[]>> retrieve(String key) {
+            return Optional.ofNullable(contents.get(key)).map(bytes -> [
+                getKey        : { -> key },
+                getInputStream: { -> new ByteArrayInputStream(bytes) },
+                getNativeEntry: { -> bytes }
+            ] as ObjectStorageEntry<byte[]>)
+        }
+
+        @Override
+        Object delete(String key) { throw new UnsupportedOperationException() }
+
+        @Override
+        boolean exists(String key) { contents.containsKey(key) }
+    }
+}

--- a/src/main/docs/guide/aws.adoc
+++ b/src/main/docs/guide/aws.adoc
@@ -19,6 +19,13 @@ include::doc-examples/example-java/src/test/resources/application-ec2.yml[]
 
 The concrete implementation of `ObjectStorageOperations` is api:objectstorage.aws.AwsS3Operations[].
 
+You can also resolve objects through Micronaut's `ResourceLoader` abstraction:
+
+* Named storage URI: `pictures://avatars/logo.png`
+* AWS alias URI: `s3://pictures-bucket/avatars/logo.png`
+
+The `s3:` alias only resolves buckets that are already configured under `micronaut.object-storage.aws`.
+
 == Advanced configuration
 
 For configuration properties other than the specified above, you can add bean to your application that implements

--- a/src/main/docs/guide/azure.adoc
+++ b/src/main/docs/guide/azure.adoc
@@ -19,6 +19,14 @@ include::doc-examples/example-java/src/test/resources/application-azure.yml[]
 
 The concrete implementation of `ObjectStorageOperations` is api:objectstorage.azure.AzureBlobStorageOperations[].
 
+You can also resolve objects through Micronaut's `ResourceLoader` abstraction:
+
+* Named storage URI: `pictures://avatars/logo.png`
+* Azure alias URI: `azb:storageaccount://pictures/avatars/logo.png`
+
+The `azb:` alias only resolves configured storages, matching the account name from `endpoint` together with the
+configured container name.
+
 == Advanced configuration
 
 For configuration properties other than the specified above, you can add bean to your application that implements

--- a/src/main/docs/guide/gcp.adoc
+++ b/src/main/docs/guide/gcp.adoc
@@ -19,6 +19,13 @@ include::doc-examples/example-java/src/test/resources/application-gcp.yml[]
 
 The concrete implementation of `ObjectStorageOperations` is api:objectstorage.googlecloud.GoogleCloudStorageOperations[].
 
+You can also resolve objects through Micronaut's `ResourceLoader` abstraction:
+
+* Named storage URI: `pictures://avatars/logo.png`
+* Google Cloud alias URI: `gs://pictures-bucket/avatars/logo.png`
+
+The `gs:` alias only resolves buckets that are already configured under `micronaut.object-storage.gcp`.
+
 == Advanced configuration
 
 For configuration properties other than the specified above, you can add bean to your application that implements

--- a/src/main/docs/guide/oracleCloud.adoc
+++ b/src/main/docs/guide/oracleCloud.adoc
@@ -19,6 +19,14 @@ include::doc-examples/example-java/src/test/resources/application-oraclecloud.ym
 
 The concrete implementation of `ObjectStorageOperations` is api:objectstorage.oraclecloud.OracleCloudStorageOperations[]
 
+You can also resolve objects through Micronaut's `ResourceLoader` abstraction:
+
+* Named storage URI: `pictures://avatars/logo.png`
+* Oracle Cloud alias URI: `os:us-ashburn-1:my-namespace://pictures-bucket/avatars/logo.png`
+
+The `os:` alias only resolves configured storages and must match the active OCI region together with the configured
+namespace and bucket.
+
 == Advanced configuration
 
 For configuration properties other than the specified above, you can add bean to your application that implements

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -37,7 +37,7 @@ You then need to use `@Named("pictures")` or `@Named("logos")` to specify which 
 
 == Resolving resources by URI
 
-Configured storages also publish Micronaut api:io.micronaut.core.io.ResourceLoader[] beans, so you can resolve
+Configured storages also publish Micronaut's api:io.micronaut.core.io.ResourceLoader[] beans, so you can resolve
 objects through api:io.micronaut.core.io.ResourceResolver[] instead of injecting an
 api:objectstorage.ObjectStorageOperations[] bean directly.
 

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -35,6 +35,26 @@ micronaut:
 
 You then need to use `@Named("pictures")` or `@Named("logos")` to specify which of the object storages you want to use.
 
+== Resolving resources by URI
+
+Configured storages also publish Micronaut api:io.micronaut.core.io.ResourceLoader[] beans, so you can resolve
+objects through api:io.micronaut.core.io.ResourceResolver[] instead of injecting an
+api:objectstorage.ObjectStorageOperations[] bean directly.
+
+For the configuration above, the following URI resolves through the `pictures` storage:
+
+[source]
+----
+pictures://avatars/logo.png
+----
+
+This resolution stays additive to the existing API:
+
+* Existing `@Named` injection continues to work unchanged.
+* Provider-native aliases resolve only when the target bucket or container is already backed by a configured storage.
+* Storage names must not reuse reserved Micronaut prefixes such as `classpath`, `file`, `string`, or `base64`, and
+  they must not collide with the provider aliases `s3`, `gs`, `azb`, or `os`.
+
 == Uploading files
 
 snippet::example.ProfileService[project-base="doc-examples/example", source="main", indent="0", tags="upload"]
@@ -59,6 +79,14 @@ snippet::example.ProfileService[project-base="doc-examples/example", source="mai
 
 <1> The retrieve operation returns an api:objectstorage.ObjectStorageEntry[], from which you can get an `InputStream`.
     There is also a `getNativeEntry()` method that gives you access to the cloud vendor-specific response object.
+
+If you prefer URI-based resolution, you can retrieve the same object through api:io.micronaut.core.io.ResourceResolver[]:
+
+[source,java]
+----
+ResourceResolver resourceResolver = new ResourceResolver(resourceLoaders);
+Optional<InputStream> logo = resourceResolver.getResourceAsStream("pictures://avatars/logo.png");
+----
 
 == Deleting files
 


### PR DESCRIPTION
## Summary
- add shared object-storage `ResourceLoader` infrastructure plus named-storage loaders in core
- add provider alias loaders for AWS S3, GCP, Azure Blob Storage, and Oracle Cloud Storage
- document named and provider-native URI formats and cover them with regression tests across modules

## Verification
- `./gradlew :micronaut-object-storage-core:test --tests 'io.micronaut.objectstorage.resource.NamedObjectStorageResourceLoaderSpec'`
- `./gradlew :micronaut-object-storage-local:test --tests 'io.micronaut.objectstorage.local.LocalStorageResourceLoaderSpec'`
- `./gradlew :micronaut-object-storage-aws:test --tests 'io.micronaut.objectstorage.aws.AwsS3ResourceLoaderSpec'`
- `./gradlew :micronaut-object-storage-gcp:test --tests 'io.micronaut.objectstorage.googlecloud.GoogleCloudStorageResourceLoaderSpec'`
- `./gradlew :micronaut-object-storage-azure:test --tests 'io.micronaut.objectstorage.azure.AzureBlobStorageResourceLoaderSpec'`
- `./gradlew :micronaut-object-storage-oracle-cloud:test --tests 'io.micronaut.objectstorage.oraclecloud.OracleCloudStorageResourceLoaderSpec'`
- `./gradlew spotlessCheck japiCmp docs`

Closes #112
