### PR TITLE
feat: abstract pre-signed upload request creation

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.objectstorage-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.objectstorage-base.gradle
@@ -1,6 +1,16 @@
+import org.gradle.api.artifacts.VersionCatalogsExtension
+
 repositories {
     mavenCentral()
 }
+
+def libs = extensions.getByType(VersionCatalogsExtension).named("libs")
+
+dependencies {
+    implementation(platform(libs.findLibrary("netty-bom").get()))
+    testImplementation(platform(libs.findLibrary("netty-bom").get()))
+}
+
 configurations.all {
     resolutionStrategy.preferProjectModules()
 }

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.objectstorage-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.objectstorage-base.gradle
@@ -7,8 +7,6 @@ repositories {
 def libs = extensions.getByType(VersionCatalogsExtension).named("libs")
 
 dependencies {
-    implementation(platform(libs.findLibrary("netty-bom").get()))
-    testImplementation(platform(libs.findLibrary("netty-bom").get()))
 }
 
 configurations.all {

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.objectstorage-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.objectstorage-base.gradle
@@ -1,12 +1,5 @@
-import org.gradle.api.artifacts.VersionCatalogsExtension
-
 repositories {
     mavenCentral()
-}
-
-def libs = extensions.getByType(VersionCatalogsExtension).named("libs")
-
-dependencies {
 }
 
 configurations.all {

--- a/doc-examples/example-groovy/src/main/groovy/example/PresignedUploadController.groovy
+++ b/doc-examples/example-groovy/src/main/groovy/example/PresignedUploadController.groovy
@@ -1,0 +1,67 @@
+package example
+
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.request.CreatePresignedUploadRequest
+import io.micronaut.objectstorage.response.PresignedUpload
+
+import java.time.Duration
+import java.time.Instant
+
+//tag::beginclass[]
+@Controller('/uploads')
+class PresignedUploadController {
+
+    final ObjectStorageOperations<?, ?, ?> objectStorage
+
+    PresignedUploadController(ObjectStorageOperations<?, ?, ?> objectStorage) {
+        this.objectStorage = objectStorage
+    }
+//end::beginclass[]
+
+    //tag::presigned-upload[]
+    @Post(uri = '/signed', consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+    HttpResponse<PresignedUploadResponse> create(@Body CreateUploadCommand command) {
+        CreatePresignedUploadRequest request =
+            new CreatePresignedUploadRequest("profiles/${command.userId}.png", Duration.ofMinutes(5)) // <1>
+        request.contentType = MediaType.IMAGE_PNG
+        request.metadata = [owner: command.userId]
+
+        PresignedUpload signedUpload = objectStorage.createPresignedUpload(request)
+            .orElseThrow(() -> new IllegalStateException('This provider does not support pre-signed uploads'))
+
+        HttpResponse.ok(new PresignedUploadResponse( // <2>
+            signedUpload.uri.toString(),
+            signedUpload.method,
+            signedUpload.headers,
+            signedUpload.expiration
+        ))
+    }
+    //end::presigned-upload[]
+
+    static class CreateUploadCommand {
+        String userId
+    }
+
+    static class PresignedUploadResponse {
+        final String url
+        final String method
+        final Map<String, List<String>> headers
+        final Instant expiresAt
+
+        PresignedUploadResponse(String url,
+                                String method,
+                                Map<String, List<String>> headers,
+                                Instant expiresAt) {
+            this.url = url
+            this.method = method
+            this.headers = headers
+            this.expiresAt = expiresAt
+        }
+    }
+}
+//tag::endclass[]

--- a/doc-examples/example-java/src/main/java/example/PresignedUploadController.java
+++ b/doc-examples/example-java/src/main/java/example/PresignedUploadController.java
@@ -1,0 +1,57 @@
+package example;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.objectstorage.ObjectStorageOperations;
+import io.micronaut.objectstorage.request.CreatePresignedUploadRequest;
+import io.micronaut.objectstorage.response.PresignedUpload;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+//tag::beginclass[]
+@Controller("/uploads")
+public class PresignedUploadController {
+
+    private final ObjectStorageOperations<?, ?, ?> objectStorage;
+
+    public PresignedUploadController(ObjectStorageOperations<?, ?, ?> objectStorage) {
+        this.objectStorage = objectStorage;
+    }
+//end::beginclass[]
+
+    //tag::presigned-upload[]
+    @Post(uri = "/signed", consumes = MediaType.APPLICATION_JSON, produces = MediaType.APPLICATION_JSON)
+    public HttpResponse<PresignedUploadResponse> create(@Body CreateUploadCommand command) {
+        CreatePresignedUploadRequest request =
+            new CreatePresignedUploadRequest("profiles/" + command.userId() + ".png", Duration.ofMinutes(5)); // <1>
+        request.setContentType(MediaType.IMAGE_PNG);
+        request.setMetadata(Map.of("owner", command.userId()));
+
+        PresignedUpload signedUpload = objectStorage.createPresignedUpload(request)
+            .orElseThrow(() -> new IllegalStateException("This provider does not support pre-signed uploads"));
+
+        return HttpResponse.ok(new PresignedUploadResponse( // <2>
+            signedUpload.getUri().toString(),
+            signedUpload.getMethod(),
+            signedUpload.getHeaders(),
+            signedUpload.getExpiration()
+        ));
+    }
+    //end::presigned-upload[]
+
+    public record CreateUploadCommand(String userId) {
+    }
+
+    public record PresignedUploadResponse(String url,
+                                          String method,
+                                          Map<String, List<String>> headers,
+                                          Instant expiresAt) {
+    }
+}
+//tag::endclass[]

--- a/doc-examples/example-kotlin/src/main/kotlin/example/PresignedUploadController.kt
+++ b/doc-examples/example-kotlin/src/main/kotlin/example/PresignedUploadController.kt
@@ -1,0 +1,48 @@
+package example
+
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.request.CreatePresignedUploadRequest
+import java.time.Duration
+import java.time.Instant
+
+//tag::beginclass[]
+@Controller("/uploads")
+open class PresignedUploadController(private val objectStorage: ObjectStorageOperations<*, *, *>) {
+//end::beginclass[]
+
+    //tag::presigned-upload[]
+    @Post(uri = "/signed", consumes = [MediaType.APPLICATION_JSON], produces = [MediaType.APPLICATION_JSON])
+    open fun create(@Body command: CreateUploadCommand): HttpResponse<PresignedUploadResponse> {
+        val request = CreatePresignedUploadRequest("profiles/${command.userId}.png", Duration.ofMinutes(5)) // <1>
+        request.setContentType(MediaType.IMAGE_PNG)
+        request.setMetadata(mapOf("owner" to command.userId))
+
+        val signedUpload = objectStorage.createPresignedUpload(request)
+            .orElseThrow { IllegalStateException("This provider does not support pre-signed uploads") }
+
+        return HttpResponse.ok(
+            PresignedUploadResponse( // <2>
+                signedUpload.uri.toString(),
+                signedUpload.method,
+                signedUpload.headers,
+                signedUpload.expiration
+            )
+        )
+    }
+    //end::presigned-upload[]
+
+    data class CreateUploadCommand(val userId: String)
+
+    data class PresignedUploadResponse(
+        val url: String,
+        val method: String,
+        val headers: Map<String, List<String>>,
+        val expiresAt: Instant
+    )
+}
+//tag::endclass[]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,8 +9,6 @@ micronaut-oracle-cloud = "6.0.0-M1"
 micronaut-test-resources = "3.0.0-M6"
 micronaut-validation = "5.0.0-M1"
 micronaut-logging = "2.0.0-M2"
-netty = "4.2.11.Final"
-netty = "4.2.11.Final"
 
 gcp-libraries = '26.79.0'
 bytebuddy = '1.18.8'
@@ -47,7 +45,6 @@ micronaut-test-resources = { module = "io.micronaut.testresources:micronaut-test
 micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "micronaut-validation" }
 micronaut-logging = { module = "io.micronaut.logging:micronaut-logging-bom", version.ref = "micronaut-logging" }
 micronaut-core-reactive = { module = "io.micronaut:micronaut-core-reactive" }
-netty-bom = { module = "io.netty:netty-bom", version.ref = "netty" }
 
 bytebuddy = { module = 'net.bytebuddy:byte-buddy', version.ref = 'bytebuddy' }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,8 @@ micronaut-oracle-cloud = "6.0.0-M1"
 micronaut-test-resources = "3.0.0-M6"
 micronaut-validation = "5.0.0-M1"
 micronaut-logging = "2.0.0-M2"
+netty = "4.2.11.Final"
+netty = "4.2.11.Final"
 
 gcp-libraries = '26.79.0'
 bytebuddy = '1.18.8'
@@ -45,6 +47,7 @@ micronaut-test-resources = { module = "io.micronaut.testresources:micronaut-test
 micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "micronaut-validation" }
 micronaut-logging = { module = "io.micronaut.logging:micronaut-logging-bom", version.ref = "micronaut-logging" }
 micronaut-core-reactive = { module = "io.micronaut:micronaut-core-reactive" }
+netty-bom = { module = "io.netty:netty-bom", version.ref = "netty" }
 
 bytebuddy = { module = 'net.bytebuddy:byte-buddy', version.ref = 'bytebuddy' }
 

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
@@ -277,7 +277,16 @@ public class AwsS3Operations implements ObjectStorageOperations<
      */
     @NonNull
     protected S3Presigner createS3Presigner() {
-        return S3Presigner.builder().s3Client(s3Client).build();
+        var clientConfiguration = s3Client.serviceClientConfiguration();
+        S3Presigner.Builder builder = S3Presigner.builder().s3Client(s3Client);
+        if (clientConfiguration.region() != null) {
+            builder.region(clientConfiguration.region());
+        }
+        if (clientConfiguration.credentialsProvider() != null) {
+            builder.credentialsProvider(clientConfiguration.credentialsProvider());
+        }
+        clientConfiguration.endpointOverride().ifPresent(builder::endpointOverride);
+        return builder.build();
     }
 
     /**

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
@@ -23,11 +23,13 @@ import io.micronaut.objectstorage.InputStreamMapper;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.ObjectStorageOperations;
 import io.micronaut.objectstorage.configuration.ToggeableCondition;
+import io.micronaut.objectstorage.request.CreatePresignedUploadRequest;
 import io.micronaut.objectstorage.request.BytesUploadRequest;
 import io.micronaut.objectstorage.request.FileUploadRequest;
 import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
 import io.micronaut.objectstorage.response.ListObjectsResponse;
+import io.micronaut.objectstorage.response.PresignedUpload;
 import io.micronaut.objectstorage.response.UploadResponse;
 import org.jspecify.annotations.NonNull;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
@@ -48,14 +50,18 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -240,6 +246,40 @@ public class AwsS3Operations implements ObjectStorageOperations<
         }
     }
 
+    @Override
+    @NonNull
+    public Optional<PresignedUpload> createPresignedUpload(@NonNull CreatePresignedUploadRequest request) {
+        try {
+            PresignedPutObjectRequest presignedRequest;
+            try (S3Presigner s3Presigner = createS3Presigner()) {
+                presignedRequest = s3Presigner.presignPutObject(builder -> builder
+                    .signatureDuration(request.getExpiresIn())
+                    .putObjectRequest(getPresignedUploadRequestBuilder(request).build()));
+            }
+            return Optional.of(new PresignedUpload(
+                java.net.URI.create(presignedRequest.url().toString()),
+                presignedRequest.httpRequest().method().name(),
+                toPortableHeaders(presignedRequest.signedHeaders()),
+                presignedRequest.expiration()
+            ));
+        } catch (RuntimeException e) {
+            String msg = String.format(
+                "Error when trying to create a pre-signed upload request with key [%s] in Amazon S3",
+                request.getKey()
+            );
+            throw new ObjectStorageException(msg, e);
+        }
+    }
+
+    /**
+     * @return the presigner used to create pre-signed upload requests.
+     * @since 3.1.0
+     */
+    @NonNull
+    protected S3Presigner createS3Presigner() {
+        return S3Presigner.builder().s3Client(s3Client).build();
+    }
+
     /**
      * @param request the upload request
      * @return An AWS' {@link PutObjectRequest.Builder} from a Micronaut's {@link UploadRequest}.
@@ -251,6 +291,24 @@ public class AwsS3Operations implements ObjectStorageOperations<
 
         request.getContentType().ifPresent(builder::contentType);
         request.getContentSize().ifPresent(builder::contentLength);
+        if (CollectionUtils.isNotEmpty(request.getMetadata())) {
+            builder.metadata(request.getMetadata());
+        }
+        return builder;
+    }
+
+    /**
+     * @param request the pre-signed upload request
+     * @return An AWS' {@link PutObjectRequest.Builder} from a Micronaut pre-signed upload request.
+     * @since 3.1.0
+     */
+    protected PutObjectRequest.@NonNull Builder getPresignedUploadRequestBuilder(@NonNull CreatePresignedUploadRequest request) {
+        PutObjectRequest.Builder builder = PutObjectRequest.builder()
+            .bucket(configuration.getBucket())
+            .key(request.getKey());
+
+        request.getContentType().ifPresent(builder::contentType);
+        request.getContentLength().ifPresent(builder::contentLength);
         if (CollectionUtils.isNotEmpty(request.getMetadata())) {
             builder.metadata(request.getMetadata());
         }
@@ -343,6 +401,13 @@ public class AwsS3Operations implements ObjectStorageOperations<
 
     private String decodeTokenPart(String value) {
         return new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8);
+    }
+
+    @NonNull
+    private Map<String, List<String>> toPortableHeaders(Map<String, List<String>> signedHeaders) {
+        Map<String, List<String>> headers = new LinkedHashMap<>(signedHeaders.size());
+        signedHeaders.forEach((name, values) -> headers.put(name, List.copyOf(values)));
+        return headers;
     }
 
     private record DecodedContinuationToken(Optional<String> rawContinuationToken,

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
@@ -273,7 +273,7 @@ public class AwsS3Operations implements ObjectStorageOperations<
 
     /**
      * @return the presigner used to create pre-signed upload requests.
-     * @since 3.1.0
+     * @since 3.0.0
      */
     @NonNull
     protected S3Presigner createS3Presigner() {
@@ -300,7 +300,7 @@ public class AwsS3Operations implements ObjectStorageOperations<
     /**
      * @param request the pre-signed upload request
      * @return An AWS' {@link PutObjectRequest.Builder} from a Micronaut pre-signed upload request.
-     * @since 3.1.0
+     * @since 3.0.0
      */
     protected PutObjectRequest.@NonNull Builder getPresignedUploadRequestBuilder(@NonNull CreatePresignedUploadRequest request) {
         PutObjectRequest.Builder builder = PutObjectRequest.builder()

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3OperationsCloudSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3OperationsCloudSpec.groovy
@@ -11,4 +11,10 @@ import spock.lang.Requires
         env.AWS_REGION &&
         !System.getProperty('os.arch', '').contains('aarch64')
 })
-class AwsS3OperationsCloudSpec extends AbstractAwsS3Spec implements TestPropertyProvider {}
+class AwsS3OperationsCloudSpec extends AbstractAwsS3Spec implements TestPropertyProvider {
+
+    @Override
+    boolean supportsPresignedUploadRoundTrip() {
+        true
+    }
+}

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3OperationsLocalstackSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3OperationsLocalstackSpec.groovy
@@ -27,4 +27,9 @@ class AwsS3OperationsLocalstackSpec extends AbstractAwsS3Spec implements TestPro
                 'aws.services.s3.endpoint-override': localstack.getEndpoint().toString()
         ] as Map
     }
+
+    @Override
+    boolean supportsPresignedUploadRoundTrip() {
+        true
+    }
 }

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3PresignedUploadSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3PresignedUploadSpec.groovy
@@ -1,0 +1,118 @@
+package io.micronaut.objectstorage.aws
+
+import io.micronaut.objectstorage.InputStreamMapper
+import io.micronaut.objectstorage.ObjectStorageException
+import io.micronaut.objectstorage.request.CreatePresignedUploadRequest
+import io.micronaut.objectstorage.response.PresignedUpload
+import spock.lang.Specification
+import software.amazon.awssdk.http.SdkHttpFullRequest
+import software.amazon.awssdk.http.SdkHttpMethod
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest
+
+import java.time.Duration
+import java.time.Instant
+
+class AwsS3PresignedUploadSpec extends Specification {
+
+    void "it creates a portable presigned upload for amazon s3"() {
+        given:
+        AwsS3Configuration configuration = new AwsS3Configuration("default")
+        configuration.bucket = "profile-pictures"
+        PutObjectPresignRequest capturedRequest = null
+        S3Presigner presigner = [
+            presignPutObject: { Object arg ->
+                PutObjectPresignRequest request = arg instanceof PutObjectPresignRequest
+                    ? (PutObjectPresignRequest) arg
+                    : buildRequest(arg)
+                capturedRequest = request
+                PresignedPutObjectRequest.builder()
+                    .expiration(Instant.parse("2026-04-02T12:00:00Z"))
+                    .isBrowserExecutable(false)
+                    .signedHeaders([
+                        "content-type": ["image/png"],
+                        "x-amz-meta-owner": ["alice"]
+                    ])
+                    .httpRequest(SdkHttpFullRequest.builder()
+                        .method(SdkHttpMethod.PUT)
+                        .uri(URI.create("https://profile-pictures.s3.amazonaws.com/avatars/alice.png?X-Amz-Signature=test"))
+                        .putHeader("content-type", "image/png")
+                        .putHeader("x-amz-meta-owner", "alice")
+                        .build())
+                    .build()
+            },
+            close: {}
+        ] as S3Presigner
+        AwsS3Operations operations = new TestAwsS3Operations(
+            configuration,
+            Mock(S3Client),
+            Mock(InputStreamMapper),
+            presigner
+        )
+        CreatePresignedUploadRequest request = new CreatePresignedUploadRequest("avatars/alice.png", Duration.ofMinutes(5))
+        request.contentType = "image/png"
+        request.contentLength = 128
+        request.metadata = [owner: "alice"]
+
+        when:
+        PresignedUpload response = operations.createPresignedUpload(request).get()
+
+        then:
+        capturedRequest.signatureDuration() == Duration.ofMinutes(5)
+        capturedRequest.putObjectRequest().bucket() == "profile-pictures"
+        capturedRequest.putObjectRequest().key() == "avatars/alice.png"
+        capturedRequest.putObjectRequest().contentType() == "image/png"
+        capturedRequest.putObjectRequest().contentLength() == 128
+        capturedRequest.putObjectRequest().metadata() == [owner: "alice"]
+        response.method == "PUT"
+        response.uri == URI.create("https://profile-pictures.s3.amazonaws.com/avatars/alice.png?X-Amz-Signature=test")
+        response.headers["content-type"] == ["image/png"]
+        response.headers["x-amz-meta-owner"] == ["alice"]
+        response.expiration == Instant.parse("2026-04-02T12:00:00Z")
+    }
+
+    void "it wraps presigner bootstrap failures as object storage exceptions"() {
+        given:
+        AwsS3Configuration configuration = new AwsS3Configuration("default")
+        configuration.bucket = "profile-pictures"
+        AwsS3Operations operations = new AwsS3Operations(
+            configuration,
+            Mock(S3Client),
+            Mock(InputStreamMapper)
+        )
+        CreatePresignedUploadRequest request = new CreatePresignedUploadRequest("avatars/alice.png", Duration.ofMinutes(5))
+
+        when:
+        operations.createPresignedUpload(request)
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message.contains("pre-signed upload request")
+    }
+
+    private static final class TestAwsS3Operations extends AwsS3Operations {
+        private final S3Presigner presigner
+
+        TestAwsS3Operations(AwsS3Configuration configuration,
+                            S3Client s3Client,
+                            InputStreamMapper inputStreamMapper,
+                            S3Presigner presigner) {
+            super(configuration, s3Client, inputStreamMapper)
+            this.presigner = presigner
+        }
+
+        @Override
+        protected S3Presigner createS3Presigner() {
+            return presigner
+        }
+    }
+
+    private static PutObjectPresignRequest buildRequest(Object consumer) {
+        PutObjectPresignRequest.Builder builder = PutObjectPresignRequest.builder()
+        consumer.accept(builder)
+        return builder.build()
+    }
+}

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3PresignedUploadSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3PresignedUploadSpec.groovy
@@ -78,7 +78,7 @@ class AwsS3PresignedUploadSpec extends Specification {
         given:
         AwsS3Configuration configuration = new AwsS3Configuration("default")
         configuration.bucket = "profile-pictures"
-        AwsS3Operations operations = new AwsS3Operations(
+        AwsS3Operations operations = new FailingAwsS3Operations(
             configuration,
             Mock(S3Client),
             Mock(InputStreamMapper)
@@ -91,6 +91,20 @@ class AwsS3PresignedUploadSpec extends Specification {
         then:
         ObjectStorageException e = thrown()
         e.message.contains("pre-signed upload request")
+    }
+
+    private static final class FailingAwsS3Operations extends AwsS3Operations {
+
+        FailingAwsS3Operations(AwsS3Configuration configuration,
+                               S3Client s3Client,
+                               InputStreamMapper inputStreamMapper) {
+            super(configuration, s3Client, inputStreamMapper)
+        }
+
+        @Override
+        protected S3Presigner createS3Presigner() {
+            throw new IllegalStateException("boom")
+        }
     }
 
     private static final class TestAwsS3Operations extends AwsS3Operations {

--- a/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageOperations.java
+++ b/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageOperations.java
@@ -29,26 +29,38 @@ import com.azure.storage.blob.models.BlockBlobItem;
 import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.blob.options.BlobParallelUploadOptions;
 import com.azure.storage.blob.options.BlockBlobSimpleUploadOptions;
+import com.azure.storage.blob.sas.BlobSasPermission;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.storage.common.sas.SasProtocol;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.ObjectStorageOperations;
+import io.micronaut.objectstorage.request.CreatePresignedUploadRequest;
 import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
 import io.micronaut.objectstorage.response.ListObjectsResponse;
+import io.micronaut.objectstorage.response.PresignedUpload;
 import io.micronaut.objectstorage.response.UploadResponse;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -71,9 +83,13 @@ public class AzureBlobStorageOperations
     private static final int DEFAULT_LIST_PAGE_SIZE = 1_000;
 
     private final BlobContainerClient blobContainerClient;
+    @Nullable
+    private final StorageSharedKeyCredential sharedKeyCredential;
 
-    public AzureBlobStorageOperations(@Parameter BlobContainerClient blobContainerClient) {
+    public AzureBlobStorageOperations(@Parameter BlobContainerClient blobContainerClient,
+                                      @Nullable StorageSharedKeyCredential sharedKeyCredential) {
         this.blobContainerClient = blobContainerClient;
+        this.sharedKeyCredential = sharedKeyCredential;
     }
 
     @Override
@@ -181,6 +197,39 @@ public class AzureBlobStorageOperations
         destinationBlobClient.copyFromUrl(sourceBlobClient.getBlobUrl());
     }
 
+    @Override
+    @NonNull
+    public Optional<PresignedUpload> createPresignedUpload(@NonNull CreatePresignedUploadRequest request) {
+        if (sharedKeyCredential == null) {
+            throw new ObjectStorageException(
+                "Error when trying to create a pre-signed upload request in Azure Blob Storage: a StorageSharedKeyCredential bean is required"
+            );
+        }
+        BlobClient blobClient = blobContainerClient.getBlobClient(request.getKey());
+        try {
+            Instant expiration = Instant.now().plus(request.getExpiresIn());
+            BlobServiceSasSignatureValues signatureValues = new BlobServiceSasSignatureValues(
+                OffsetDateTime.ofInstant(expiration, ZoneOffset.UTC),
+                new BlobSasPermission()
+                    .setCreatePermission(true)
+                    .setWritePermission(true)
+            ).setProtocol(SasProtocol.HTTPS_ONLY);
+            String sas = blobClient.generateSas(signatureValues);
+            return Optional.of(new PresignedUpload(
+                java.net.URI.create(blobClient.getBlobUrl() + separator(blobClient.getBlobUrl()) + sas),
+                "PUT",
+                toPortableHeaders(request),
+                expiration
+            ));
+        } catch (RuntimeException e) {
+            String msg = String.format(
+                "Error when trying to create a pre-signed upload request with key [%s] in Azure Blob Storage",
+                request.getKey()
+            );
+            throw new ObjectStorageException(msg, e);
+        }
+    }
+
     /**
      * @param request the upload request
      * @return An Azure's {@link BlobParallelUploadOptions} from a Micronaut's {@link UploadRequest}.
@@ -262,6 +311,21 @@ public class AzureBlobStorageOperations
             || requestConditions.getIfUnmodifiedSince() != null
             || requestConditions.getLeaseId() != null
             || requestConditions.getTagsConditions() != null;
+    }
+
+    @NonNull
+    private Map<String, List<String>> toPortableHeaders(@NonNull CreatePresignedUploadRequest request) {
+        Map<String, List<String>> headers = new LinkedHashMap<>();
+        headers.put("x-ms-blob-type", List.of("BlockBlob"));
+        request.getContentType().ifPresent(contentType -> headers.put("x-ms-blob-content-type", List.of(contentType)));
+        request.getContentLength().ifPresent(length -> headers.put("Content-Length", List.of(Long.toString(length))));
+        request.getMetadata().forEach((key, value) -> headers.put("x-ms-meta-" + key, List.of(value)));
+        return headers;
+    }
+
+    @NonNull
+    private String separator(@NonNull String url) {
+        return url.contains("?") ? "&" : "?";
     }
 
 }

--- a/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageOperations.java
+++ b/object-storage-azure/src/main/java/io/micronaut/objectstorage/azure/AzureBlobStorageOperations.java
@@ -201,9 +201,7 @@ public class AzureBlobStorageOperations
     @NonNull
     public Optional<PresignedUpload> createPresignedUpload(@NonNull CreatePresignedUploadRequest request) {
         if (sharedKeyCredential == null) {
-            throw new ObjectStorageException(
-                "Error when trying to create a pre-signed upload request in Azure Blob Storage: a StorageSharedKeyCredential bean is required"
-            );
+            return Optional.empty();
         }
         BlobClient blobClient = blobContainerClient.getBlobClient(request.getKey());
         try {

--- a/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStorageCloudSpec.groovy
+++ b/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStorageCloudSpec.groovy
@@ -20,4 +20,9 @@ class AzureBlobStorageCloudSpec extends AbstractAzureBlobStorageSpec {
         super.getProperties() + [
                 (PREFIX + '.' + OBJECT_STORAGE_NAME + '.endpoint'): System.getenv('AZURE_TEST_STORAGE_ACCOUNT_ENDPOINT')]
     }
+
+    @Override
+    boolean supportsPresignedUploadRoundTrip() {
+        true
+    }
 }

--- a/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStoragePaginationSpec.groovy
+++ b/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStoragePaginationSpec.groovy
@@ -88,7 +88,7 @@ class AzureBlobStoragePaginationSpec extends Specification {
         private final Iterator<RecordedPageCall> calls
 
         TestAzureBlobStorageOperations(List<RecordedPageCall> calls) {
-            super(null)
+            super(null, null)
             this.calls = calls.iterator()
         }
 

--- a/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStoragePresignedUploadSpec.groovy
+++ b/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStoragePresignedUploadSpec.groovy
@@ -1,0 +1,67 @@
+package io.micronaut.objectstorage.azure
+
+import com.azure.storage.blob.BlobContainerClientBuilder
+import com.azure.storage.common.StorageSharedKeyCredential
+import io.micronaut.objectstorage.ObjectStorageException
+import io.micronaut.objectstorage.request.CreatePresignedUploadRequest
+import io.micronaut.objectstorage.response.PresignedUpload
+import spock.lang.Specification
+
+import java.time.Duration
+import java.time.Instant
+
+class AzureBlobStoragePresignedUploadSpec extends Specification {
+
+    void "it creates a portable presigned upload for azure blob storage"() {
+        given:
+        StorageSharedKeyCredential credential = new StorageSharedKeyCredential("account", "ZmFrZS1rZXk=")
+        AzureBlobStorageOperations operations = new AzureBlobStorageOperations(
+            new BlobContainerClientBuilder()
+                .endpoint("https://account.blob.core.windows.net")
+                .containerName("profile-pictures")
+                .credential(credential)
+                .buildClient(),
+            credential
+        )
+        CreatePresignedUploadRequest request = new CreatePresignedUploadRequest("avatars/alice.png", Duration.ofMinutes(5))
+        request.contentType = "image/png"
+        request.contentLength = 128
+        request.metadata = [owner: "alice"]
+        Instant before = Instant.now()
+
+        when:
+        PresignedUpload response = operations.createPresignedUpload(request).get()
+        Instant after = Instant.now()
+
+        then:
+        response.method == "PUT"
+        response.uri.toString().startsWith("https://account.blob.core.windows.net/profile-pictures/")
+        response.uri.toString().contains("avatars%2Falice.png")
+        response.uri.query.contains("sig=")
+        response.headers["x-ms-blob-type"] == ["BlockBlob"]
+        response.headers["x-ms-blob-content-type"] == ["image/png"]
+        response.headers["Content-Length"] == ["128"]
+        response.headers["x-ms-meta-owner"] == ["alice"]
+        response.expiration >= before.plus(Duration.ofMinutes(5))
+        response.expiration <= after.plus(Duration.ofMinutes(5))
+    }
+
+    void "it fails fast when shared key credentials are unavailable"() {
+        given:
+        AzureBlobStorageOperations operations = new AzureBlobStorageOperations(
+            new BlobContainerClientBuilder()
+                .endpoint("https://account.blob.core.windows.net")
+                .containerName("profile-pictures")
+                .setAnonymousAccess()
+                .buildClient(),
+            null
+        )
+
+        when:
+        operations.createPresignedUpload(new CreatePresignedUploadRequest("avatars/alice.png", Duration.ofMinutes(5)))
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message.contains("StorageSharedKeyCredential")
+    }
+}

--- a/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStoragePresignedUploadSpec.groovy
+++ b/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStoragePresignedUploadSpec.groovy
@@ -2,7 +2,6 @@ package io.micronaut.objectstorage.azure
 
 import com.azure.storage.blob.BlobContainerClientBuilder
 import com.azure.storage.common.StorageSharedKeyCredential
-import io.micronaut.objectstorage.ObjectStorageException
 import io.micronaut.objectstorage.request.CreatePresignedUploadRequest
 import io.micronaut.objectstorage.response.PresignedUpload
 import spock.lang.Specification
@@ -46,7 +45,7 @@ class AzureBlobStoragePresignedUploadSpec extends Specification {
         response.expiration <= after.plus(Duration.ofMinutes(5))
     }
 
-    void "it fails fast when shared key credentials are unavailable"() {
+    void "it returns empty when shared key credentials are unavailable"() {
         given:
         AzureBlobStorageOperations operations = new AzureBlobStorageOperations(
             new BlobContainerClientBuilder()
@@ -57,11 +56,7 @@ class AzureBlobStoragePresignedUploadSpec extends Specification {
             null
         )
 
-        when:
-        operations.createPresignedUpload(new CreatePresignedUploadRequest("avatars/alice.png", Duration.ofMinutes(5)))
-
-        then:
-        ObjectStorageException e = thrown()
-        e.message.contains("StorageSharedKeyCredential")
+        expect:
+        operations.createPresignedUpload(new CreatePresignedUploadRequest("avatars/alice.png", Duration.ofMinutes(5))).empty
     }
 }

--- a/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStorageUploadOptionsSpec.groovy
+++ b/object-storage-azure/src/test/groovy/io/micronaut/objectstorage/azure/AzureBlobStorageUploadOptionsSpec.groovy
@@ -81,6 +81,6 @@ class AzureBlobStorageUploadOptionsSpec extends Specification {
             long
         )
         assert method.trySetAccessible()
-        (BlockBlobSimpleUploadOptions) method.invoke(new AzureBlobStorageOperations(null), options, options.dataStream, length)
+        (BlockBlobSimpleUploadOptions) method.invoke(new AzureBlobStorageOperations(null, null), options, options.dataStream, length)
     }
 }

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/ObjectStorageOperations.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/ObjectStorageOperations.java
@@ -159,7 +159,7 @@ public interface ObjectStorageOperations<I, O, D> {
      *
      * @param request the pre-signed upload request parameters
      * @return the signed upload request, if the provider supports it in the current configuration
-     * @since 3.1.0
+     * @since 3.0.0
      */
     @Blocking
     @NonNull

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/ObjectStorageOperations.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/ObjectStorageOperations.java
@@ -158,7 +158,7 @@ public interface ObjectStorageOperations<I, O, D> {
      * Creates a pre-signed upload request for a single object key.
      *
      * @param request the pre-signed upload request parameters
-     * @return the signed upload request, if the provider supports it
+     * @return the signed upload request, if the provider supports it in the current configuration
      * @since 3.1.0
      */
     @Blocking

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/ObjectStorageOperations.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/ObjectStorageOperations.java
@@ -17,9 +17,11 @@ package io.micronaut.objectstorage;
 
 import io.micronaut.core.annotation.Blocking;
 import org.jspecify.annotations.NonNull;
+import io.micronaut.objectstorage.request.CreatePresignedUploadRequest;
 import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
 import io.micronaut.objectstorage.response.ListObjectsResponse;
+import io.micronaut.objectstorage.response.PresignedUpload;
 import io.micronaut.objectstorage.response.UploadResponse;
 
 import java.util.Collections;
@@ -150,5 +152,18 @@ public interface ObjectStorageOperations<I, O, D> {
      */
     @Blocking
     default void copy(@NonNull String sourceKey, @NonNull String destinationKey) {
+    }
+
+    /**
+     * Creates a pre-signed upload request for a single object key.
+     *
+     * @param request the pre-signed upload request parameters
+     * @return the signed upload request, if the provider supports it
+     * @since 3.1.0
+     */
+    @Blocking
+    @NonNull
+    default Optional<PresignedUpload> createPresignedUpload(@NonNull CreatePresignedUploadRequest request) {
+        return Optional.empty();
     }
 }

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/request/CreatePresignedUploadRequest.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/request/CreatePresignedUploadRequest.java
@@ -83,6 +83,9 @@ public final class CreatePresignedUploadRequest {
      */
     public void setContentType(@NonNull String contentType) {
         this.contentType = Objects.requireNonNull(contentType, "contentType");
+        if (this.contentType.isBlank()) {
+            throw new IllegalArgumentException("contentType must not be blank");
+        }
     }
 
     /**

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/request/CreatePresignedUploadRequest.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/request/CreatePresignedUploadRequest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.request;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Request to create a pre-signed upload for a single object key.
+ *
+ * @since 3.1.0
+ */
+public final class CreatePresignedUploadRequest {
+
+    private final String key;
+    private final Duration expiresIn;
+    @Nullable
+    private String contentType;
+    @Nullable
+    private Long contentLength;
+    private Map<String, String> metadata = Collections.emptyMap();
+
+    /**
+     * @param key the object key to be uploaded
+     * @param expiresIn the signature validity duration
+     */
+    public CreatePresignedUploadRequest(@NonNull String key, @NonNull Duration expiresIn) {
+        this.key = Objects.requireNonNull(key, "key");
+        this.expiresIn = Objects.requireNonNull(expiresIn, "expiresIn");
+        if (key.isEmpty()) {
+            throw new IllegalArgumentException("key must not be empty");
+        }
+        if (expiresIn.isZero() || expiresIn.isNegative()) {
+            throw new IllegalArgumentException("expiresIn must be greater than 0");
+        }
+    }
+
+    /**
+     * @return the object key to be uploaded
+     */
+    @NonNull
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * @return the signature validity duration
+     */
+    @NonNull
+    public Duration getExpiresIn() {
+        return expiresIn;
+    }
+
+    /**
+     * @return the content type required by the signed upload, if present
+     */
+    @NonNull
+    public Optional<String> getContentType() {
+        return Optional.ofNullable(contentType);
+    }
+
+    /**
+     * @param contentType the content type required by the signed upload
+     */
+    public void setContentType(@NonNull String contentType) {
+        this.contentType = Objects.requireNonNull(contentType, "contentType");
+    }
+
+    /**
+     * @return the content length required by the signed upload, if present
+     */
+    @NonNull
+    public Optional<Long> getContentLength() {
+        return Optional.ofNullable(contentLength);
+    }
+
+    /**
+     * @param contentLength the content length required by the signed upload
+     */
+    public void setContentLength(long contentLength) {
+        if (contentLength <= 0) {
+            throw new IllegalArgumentException("contentLength must be greater than 0");
+        }
+        this.contentLength = contentLength;
+    }
+
+    /**
+     * @return metadata to include in the signed upload request
+     */
+    @NonNull
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * @param metadata metadata to include in the signed upload request
+     */
+    public void setMetadata(@NonNull Map<String, String> metadata) {
+        this.metadata = Map.copyOf(Objects.requireNonNull(metadata, "metadata"));
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/request/CreatePresignedUploadRequest.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/request/CreatePresignedUploadRequest.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 /**
  * Request to create a pre-signed upload for a single object key.
  *
- * @since 3.1.0
+ * @since 3.0.0
  */
 public final class CreatePresignedUploadRequest {
 

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/response/PresignedUpload.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/response/PresignedUpload.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.response;
+
+import org.jspecify.annotations.NonNull;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A complete pre-signed HTTP request that can upload a single object.
+ *
+ * @since 3.1.0
+ */
+public final class PresignedUpload {
+
+    private final URI uri;
+    private final String method;
+    private final Map<String, List<String>> headers;
+    private final Instant expiration;
+
+    /**
+     * @param uri the signed target URI
+     * @param method the HTTP method the caller must use
+     * @param headers the required request headers
+     * @param expiration the point in time when this request expires
+     */
+    public PresignedUpload(@NonNull URI uri,
+                           @NonNull String method,
+                           @NonNull Map<String, List<String>> headers,
+                           @NonNull Instant expiration) {
+        this.uri = Objects.requireNonNull(uri, "uri");
+        this.method = Objects.requireNonNull(method, "method");
+        this.headers = copyHeaders(headers);
+        this.expiration = Objects.requireNonNull(expiration, "expiration");
+    }
+
+    /**
+     * @return the signed target URI
+     */
+    @NonNull
+    public URI getUri() {
+        return uri;
+    }
+
+    /**
+     * @return the HTTP method the caller must use
+     */
+    @NonNull
+    public String getMethod() {
+        return method;
+    }
+
+    /**
+     * @return the required request headers
+     */
+    @NonNull
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    /**
+     * @return when the signed request expires
+     */
+    @NonNull
+    public Instant getExpiration() {
+        return expiration;
+    }
+
+    @NonNull
+    private static Map<String, List<String>> copyHeaders(@NonNull Map<String, List<String>> headers) {
+        Objects.requireNonNull(headers, "headers");
+        Map<String, List<String>> copy = new LinkedHashMap<>(headers.size());
+        headers.forEach((name, values) -> copy.put(name, List.copyOf(values)));
+        return Map.copyOf(copy);
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/response/PresignedUpload.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/response/PresignedUpload.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * A complete pre-signed HTTP request that can upload a single object.
  *
- * @since 3.1.0
+ * @since 3.0.0
  */
 public final class PresignedUpload {
 

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/ObjectStorageOperationsPresignedUploadFallbackSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/ObjectStorageOperationsPresignedUploadFallbackSpec.groovy
@@ -1,0 +1,45 @@
+package io.micronaut.objectstorage
+
+import io.micronaut.objectstorage.request.CreatePresignedUploadRequest
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.objectstorage.response.UploadResponse
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.time.Duration
+import java.util.Optional
+import java.util.function.Consumer
+
+class ObjectStorageOperationsPresignedUploadFallbackSpec extends Specification {
+
+    @Subject
+    ObjectStorageOperations<Object, Object, Object> operations = new LegacyOnlyOperations()
+
+    void "it returns empty for providers that do not override the presigned upload API"() {
+        expect:
+        operations.createPresignedUpload(new CreatePresignedUploadRequest("avatars/alice.png", Duration.ofMinutes(5))).empty
+    }
+
+    private static final class LegacyOnlyOperations implements ObjectStorageOperations<Object, Object, Object> {
+
+        @Override
+        UploadResponse<Object> upload(UploadRequest request) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        UploadResponse<Object> upload(UploadRequest request, Consumer<Object> requestConsumer) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        Optional<ObjectStorageEntry<?>> retrieve(String key) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        Object delete(String key) {
+            throw new UnsupportedOperationException()
+        }
+    }
+}

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/request/CreatePresignedUploadRequestSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/request/CreatePresignedUploadRequestSpec.groovy
@@ -1,0 +1,23 @@
+package io.micronaut.objectstorage.request
+
+import spock.lang.Specification
+
+import java.time.Duration
+
+class CreatePresignedUploadRequestSpec extends Specification {
+
+    void "it rejects blank content types"() {
+        given:
+        CreatePresignedUploadRequest request = new CreatePresignedUploadRequest("avatars/alice.png", Duration.ofMinutes(5))
+
+        when:
+        request.contentType = contentType
+
+        then:
+        IllegalArgumentException e = thrown()
+        e.message == "contentType must not be blank"
+
+        where:
+        contentType << ["", "   "]
+    }
+}

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageOperations.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageOperations.java
@@ -18,6 +18,7 @@ package io.micronaut.objectstorage.googlecloud;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.HttpMethod;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 import com.google.api.gax.paging.Page;
@@ -28,18 +29,25 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.ObjectStorageOperations;
 import io.micronaut.objectstorage.configuration.ToggeableCondition;
+import io.micronaut.objectstorage.request.CreatePresignedUploadRequest;
 import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
 import io.micronaut.objectstorage.response.ListObjectsResponse;
+import io.micronaut.objectstorage.response.PresignedUpload;
 import io.micronaut.objectstorage.response.UploadResponse;
 import org.jspecify.annotations.NonNull;
 
 import java.io.InputStream;
+import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 /**
@@ -178,6 +186,43 @@ public class GoogleCloudStorageOperations
         }
     }
 
+    @Override
+    @NonNull
+    public Optional<PresignedUpload> createPresignedUpload(@NonNull CreatePresignedUploadRequest request) {
+        try {
+            BlobInfo blobInfo = createBlobInfoBuilder(request).build();
+            Instant expiration = Instant.now().plus(request.getExpiresIn());
+            Map<String, String> signedHeaders = buildSignedHeaders(request);
+            List<Storage.SignUrlOption> options = new ArrayList<>();
+            options.add(Storage.SignUrlOption.httpMethod(HttpMethod.PUT));
+            options.add(Storage.SignUrlOption.withV4Signature());
+            if (request.getContentType().isPresent()) {
+                options.add(Storage.SignUrlOption.withContentType());
+            }
+            if (CollectionUtils.isNotEmpty(signedHeaders)) {
+                options.add(Storage.SignUrlOption.withExtHeaders(signedHeaders));
+            }
+            URL url = storage.signUrl(
+                blobInfo,
+                request.getExpiresIn().toMillis(),
+                TimeUnit.MILLISECONDS,
+                options.toArray(Storage.SignUrlOption[]::new)
+            );
+            return Optional.of(new PresignedUpload(
+                java.net.URI.create(url.toString()),
+                "PUT",
+                toPortableHeaders(request, signedHeaders),
+                expiration
+            ));
+        } catch (RuntimeException e) {
+            String msg = String.format(
+                "Error when trying to create a pre-signed upload request with key [%s] in Google Cloud Storage",
+                request.getKey()
+            );
+            throw new ObjectStorageException(msg, e);
+        }
+    }
+
     /**
      *
      * @param uploadRequest Upload Request
@@ -189,6 +234,21 @@ public class GoogleCloudStorageOperations
             .setContentType(uploadRequest.getContentType().orElse(null));
         if (CollectionUtils.isNotEmpty(uploadRequest.getMetadata())) {
             builder.setMetadata(uploadRequest.getMetadata());
+        }
+        return builder;
+    }
+
+    /**
+     * @param request the pre-signed upload request
+     * @return BlobInfo Builder
+     * @since 3.1.0
+     */
+    protected BlobInfo.@NonNull Builder createBlobInfoBuilder(@NonNull CreatePresignedUploadRequest request) {
+        BlobId blobId = BlobId.of(configuration.getBucket(), request.getKey());
+        BlobInfo.Builder builder = BlobInfo.newBuilder(blobId)
+            .setContentType(request.getContentType().orElse(null));
+        if (CollectionUtils.isNotEmpty(request.getMetadata())) {
+            builder.setMetadata(request.getMetadata());
         }
         return builder;
     }
@@ -205,5 +265,22 @@ public class GoogleCloudStorageOperations
 
     private boolean blobExists(Blob blob) {
         return blob != null && blob.exists();
+    }
+
+    @NonNull
+    private Map<String, String> buildSignedHeaders(@NonNull CreatePresignedUploadRequest request) {
+        Map<String, String> headers = new LinkedHashMap<>();
+        request.getContentLength().ifPresent(length -> headers.put("Content-Length", Long.toString(length)));
+        request.getMetadata().forEach((key, value) -> headers.put("x-goog-meta-" + key, value));
+        return headers;
+    }
+
+    @NonNull
+    private Map<String, List<String>> toPortableHeaders(@NonNull CreatePresignedUploadRequest request,
+                                                        @NonNull Map<String, String> signedHeaders) {
+        Map<String, List<String>> headers = new LinkedHashMap<>();
+        request.getContentType().ifPresent(contentType -> headers.put("Content-Type", List.of(contentType)));
+        signedHeaders.forEach((name, value) -> headers.put(name, List.of(value)));
+        return headers;
     }
 }

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageOperations.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageOperations.java
@@ -241,7 +241,7 @@ public class GoogleCloudStorageOperations
     /**
      * @param request the pre-signed upload request
      * @return BlobInfo Builder
-     * @since 3.1.0
+     * @since 3.0.0
      */
     protected BlobInfo.@NonNull Builder createBlobInfoBuilder(@NonNull CreatePresignedUploadRequest request) {
         BlobId blobId = BlobId.of(configuration.getBucket(), request.getKey());

--- a/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageCloudSpec.groovy
+++ b/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageCloudSpec.groovy
@@ -11,4 +11,9 @@ class GoogleCloudStorageCloudSpec extends AbstractGoogleCloudStorageSpec {
     Map<String, String> getProperties() {
         super.getProperties() + ['gcp.project-id': System.getenv('GCLOUD_TEST_PROJECT_ID')]
     }
+
+    @Override
+    boolean supportsPresignedUploadRoundTrip() {
+        true
+    }
 }

--- a/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/GoogleCloudStoragePresignedUploadSpec.groovy
+++ b/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/GoogleCloudStoragePresignedUploadSpec.groovy
@@ -1,0 +1,85 @@
+package io.micronaut.objectstorage.googlecloud
+
+import com.google.cloud.storage.BlobId
+import com.google.cloud.storage.BlobInfo
+import com.google.cloud.storage.Storage
+import io.micronaut.objectstorage.InputStreamMapper
+import io.micronaut.objectstorage.ObjectStorageException
+import io.micronaut.objectstorage.request.CreatePresignedUploadRequest
+import io.micronaut.objectstorage.response.PresignedUpload
+import spock.lang.Specification
+
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+class GoogleCloudStoragePresignedUploadSpec extends Specification {
+
+    void "it creates a portable presigned upload for google cloud storage"() {
+        given:
+        GoogleCloudStorageConfiguration configuration = new GoogleCloudStorageConfiguration("default")
+        configuration.bucket = "profile-pictures"
+        BlobInfo capturedBlobInfo = null
+        long capturedDuration = -1
+        TimeUnit capturedTimeUnit = null
+        Storage storage = Mock() {
+            1 * signUrl(_ as BlobInfo, _ as Long, _ as TimeUnit, _ as Storage.SignUrlOption[]) >> {
+                BlobInfo blobInfo, Long duration, TimeUnit timeUnit, Storage.SignUrlOption[] ignored ->
+                    capturedBlobInfo = blobInfo
+                    capturedDuration = duration
+                    capturedTimeUnit = timeUnit
+                    return new URL("https://storage.googleapis.com/profile-pictures/avatars/alice.png")
+            }
+        }
+        GoogleCloudStorageOperations operations = new GoogleCloudStorageOperations(
+            configuration,
+            Mock(InputStreamMapper),
+            storage
+        )
+        CreatePresignedUploadRequest request = new CreatePresignedUploadRequest("avatars/alice.png", Duration.ofMinutes(5))
+        request.contentType = "image/png"
+        request.contentLength = 128
+        request.metadata = [owner: "alice"]
+        Instant before = Instant.now()
+
+        when:
+        PresignedUpload response = operations.createPresignedUpload(request).get()
+        Instant after = Instant.now()
+
+        then:
+        capturedBlobInfo.blobId == BlobId.of("profile-pictures", "avatars/alice.png")
+        capturedBlobInfo.contentType == "image/png"
+        capturedBlobInfo.metadata == [owner: "alice"]
+        capturedDuration == Duration.ofMinutes(5).toMillis()
+        capturedTimeUnit == TimeUnit.MILLISECONDS
+        response.method == "PUT"
+        response.uri == URI.create("https://storage.googleapis.com/profile-pictures/avatars/alice.png")
+        response.headers["Content-Type"] == ["image/png"]
+        response.headers["Content-Length"] == ["128"]
+        response.headers["x-goog-meta-owner"] == ["alice"]
+        response.expiration >= before.plus(Duration.ofMinutes(5))
+        response.expiration <= after.plus(Duration.ofMinutes(5))
+    }
+
+    void "it wraps signing failures as object storage exceptions"() {
+        given:
+        GoogleCloudStorageConfiguration configuration = new GoogleCloudStorageConfiguration("default")
+        configuration.bucket = "profile-pictures"
+        GoogleCloudStorageOperations operations = new GoogleCloudStorageOperations(
+            configuration,
+            Mock(InputStreamMapper),
+            Mock(Storage) {
+                1 * signUrl(_ as BlobInfo, _ as Long, _ as TimeUnit, _ as Storage.SignUrlOption[]) >> {
+                    throw new IllegalStateException("signer unavailable")
+                }
+            }
+        )
+
+        when:
+        operations.createPresignedUpload(new CreatePresignedUploadRequest("avatars/alice.png", Duration.ofMinutes(5)))
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message.contains("pre-signed upload request")
+    }
+}

--- a/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/GoogleCloudStoragePresignedUploadSpec.groovy
+++ b/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/GoogleCloudStoragePresignedUploadSpec.groovy
@@ -3,7 +3,6 @@ package io.micronaut.objectstorage.googlecloud
 import com.google.cloud.storage.BlobId
 import com.google.cloud.storage.BlobInfo
 import com.google.cloud.storage.Storage
-import io.micronaut.objectstorage.InputStreamMapper
 import io.micronaut.objectstorage.ObjectStorageException
 import io.micronaut.objectstorage.request.CreatePresignedUploadRequest
 import io.micronaut.objectstorage.response.PresignedUpload
@@ -33,7 +32,6 @@ class GoogleCloudStoragePresignedUploadSpec extends Specification {
         }
         GoogleCloudStorageOperations operations = new GoogleCloudStorageOperations(
             configuration,
-            Mock(InputStreamMapper),
             storage
         )
         CreatePresignedUploadRequest request = new CreatePresignedUploadRequest("avatars/alice.png", Duration.ofMinutes(5))
@@ -67,7 +65,6 @@ class GoogleCloudStoragePresignedUploadSpec extends Specification {
         configuration.bucket = "profile-pictures"
         GoogleCloudStorageOperations operations = new GoogleCloudStorageOperations(
             configuration,
-            Mock(InputStreamMapper),
             Mock(Storage) {
                 1 * signUrl(_ as BlobInfo, _ as Long, _ as TimeUnit, _ as Storage.SignUrlOption[]) >> {
                     throw new IllegalStateException("signer unavailable")

--- a/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageOperations.java
+++ b/object-storage-oracle-cloud/src/main/java/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageOperations.java
@@ -18,9 +18,12 @@ package io.micronaut.objectstorage.oraclecloud;
 import com.oracle.bmc.auth.RegionProvider;
 import com.oracle.bmc.model.BmcException;
 import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.model.CreatePreauthenticatedRequestDetails;
 import com.oracle.bmc.objectstorage.model.CopyObjectDetails;
 import com.oracle.bmc.objectstorage.model.ObjectSummary;
+import com.oracle.bmc.objectstorage.model.PreauthenticatedRequest;
 import com.oracle.bmc.objectstorage.requests.CopyObjectRequest;
+import com.oracle.bmc.objectstorage.requests.CreatePreauthenticatedRequestRequest;
 import com.oracle.bmc.objectstorage.requests.DeleteObjectRequest;
 import com.oracle.bmc.objectstorage.requests.GetObjectRequest;
 import com.oracle.bmc.objectstorage.requests.HeadObjectRequest;
@@ -37,17 +40,25 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.ObjectStorageOperations;
 import io.micronaut.objectstorage.configuration.ToggeableCondition;
+import io.micronaut.objectstorage.request.CreatePresignedUploadRequest;
 import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
 import io.micronaut.objectstorage.response.ListObjectsResponse;
+import io.micronaut.objectstorage.response.PresignedUpload;
 import io.micronaut.objectstorage.response.UploadResponse;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
+import java.time.Instant;
+import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -244,6 +255,38 @@ public class OracleCloudStorageOperations
         }
     }
 
+    @Override
+    @NonNull
+    public Optional<PresignedUpload> createPresignedUpload(@NonNull CreatePresignedUploadRequest request) {
+        try {
+            Instant expiration = Instant.now().plus(request.getExpiresIn());
+            var preauthenticatedRequest = client.createPreauthenticatedRequest(
+                CreatePreauthenticatedRequestRequest.builder()
+                    .namespaceName(configuration.getNamespace())
+                    .bucketName(configuration.getBucket())
+                    .createPreauthenticatedRequestDetails(CreatePreauthenticatedRequestDetails.builder()
+                        .name(getPreauthenticatedRequestName(request))
+                        .objectName(request.getKey())
+                        .accessType(CreatePreauthenticatedRequestDetails.AccessType.ObjectWrite)
+                        .timeExpires(Date.from(expiration))
+                        .build())
+                    .build())
+                .getPreauthenticatedRequest();
+            return Optional.of(new PresignedUpload(
+                getPreauthenticatedRequestUri(preauthenticatedRequest),
+                "PUT",
+                toPortableHeaders(request),
+                expiration
+            ));
+        } catch (RuntimeException e) {
+            String msg = String.format(
+                "Error when trying to create a pre-signed upload request with key [%s] in Oracle Cloud Storage",
+                request.getKey()
+            );
+            throw new ObjectStorageException(msg, e);
+        }
+    }
+
     /**
      *
      * @param request Upload Request
@@ -262,5 +305,44 @@ public class OracleCloudStorageOperations
             putObjectRequestBuilder.opcMeta(request.getMetadata());
         }
         return putObjectRequestBuilder;
+    }
+
+    /**
+     * @param request the pre-signed upload request
+     * @return the Oracle Cloud pre-authenticated request name
+     * @since 3.0.0
+     */
+    @NonNull
+    protected String getPreauthenticatedRequestName(@NonNull CreatePresignedUploadRequest request) {
+        return "micronaut-presigned-upload-" + request.getKey().replace('/', '-');
+    }
+
+    /**
+     * @param preauthenticatedRequest the Oracle Cloud pre-authenticated request
+     * @return the absolute request URI that clients should replay
+     * @since 3.0.0
+     */
+    @NonNull
+    protected URI getPreauthenticatedRequestUri(@NonNull PreauthenticatedRequest preauthenticatedRequest) {
+        String path = Optional.ofNullable(preauthenticatedRequest.getAccessUri())
+            .orElseGet(preauthenticatedRequest::getFullPath);
+        if (path == null || path.isBlank()) {
+            throw new IllegalStateException("Oracle Cloud pre-authenticated request did not include an access URI");
+        }
+        return URI.create(Objects.requireNonNull(client.getEndpoint(), "client endpoint")).resolve(path);
+    }
+
+    /**
+     * @param request the pre-signed upload request
+     * @return portable headers that callers should preserve on upload
+     * @since 3.0.0
+     */
+    @NonNull
+    protected Map<String, List<String>> toPortableHeaders(@NonNull CreatePresignedUploadRequest request) {
+        Map<String, List<String>> headers = new LinkedHashMap<>();
+        request.getContentType().ifPresent(contentType -> headers.put("Content-Type", List.of(contentType)));
+        request.getContentLength().ifPresent(contentLength -> headers.put("Content-Length", List.of(Long.toString(contentLength))));
+        request.getMetadata().forEach((key, value) -> headers.put("opc-meta-" + key, List.of(value)));
+        return headers;
     }
 }

--- a/object-storage-oracle-cloud/src/test/groovy/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageCloudSpec.groovy
+++ b/object-storage-oracle-cloud/src/test/groovy/io/micronaut/objectstorage/oraclecloud/OracleCloudStorageCloudSpec.groovy
@@ -19,4 +19,9 @@ class OracleCloudStorageCloudSpec extends AbstractOracleCloudStorageSpec {
     Map<String, String> getProperties() {
         super.getProperties() + [(PREFIX + '.' + OBJECT_STORAGE_NAME + '.namespace'): System.getenv('ORACLE_CLOUD_TEST_NAMESPACE')]
     }
+
+    @Override
+    boolean supportsPresignedUploadRoundTrip() {
+        true
+    }
 }

--- a/object-storage-oracle-cloud/src/test/groovy/io/micronaut/objectstorage/oraclecloud/OracleCloudStoragePresignedUploadSpec.groovy
+++ b/object-storage-oracle-cloud/src/test/groovy/io/micronaut/objectstorage/oraclecloud/OracleCloudStoragePresignedUploadSpec.groovy
@@ -1,0 +1,89 @@
+package io.micronaut.objectstorage.oraclecloud
+
+import com.oracle.bmc.auth.RegionProvider
+import com.oracle.bmc.model.BmcException
+import com.oracle.bmc.objectstorage.ObjectStorage
+import com.oracle.bmc.objectstorage.model.CreatePreauthenticatedRequestDetails
+import com.oracle.bmc.objectstorage.model.PreauthenticatedRequest
+import com.oracle.bmc.objectstorage.requests.CreatePreauthenticatedRequestRequest
+import com.oracle.bmc.objectstorage.responses.CreatePreauthenticatedRequestResponse
+import io.micronaut.objectstorage.ObjectStorageException
+import io.micronaut.objectstorage.response.PresignedUpload
+import io.micronaut.objectstorage.request.CreatePresignedUploadRequest
+import spock.lang.Specification
+
+import java.time.Duration
+import java.time.Instant
+
+class OracleCloudStoragePresignedUploadSpec extends Specification {
+
+    void "it creates a portable presigned upload for oracle cloud storage"() {
+        given:
+        OracleCloudStorageConfiguration configuration = Stub() {
+            getBucket() >> "profile-pictures"
+            getNamespace() >> "namespace"
+        }
+        RegionProvider regionProvider = Stub()
+        CreatePreauthenticatedRequestRequest capturedRequest = null
+        ObjectStorage client = Mock() {
+            1 * createPreauthenticatedRequest(_ as CreatePreauthenticatedRequestRequest) >> { CreatePreauthenticatedRequestRequest request ->
+                capturedRequest = request
+                return CreatePreauthenticatedRequestResponse.builder()
+                    .__httpStatusCode__(200)
+                    .preauthenticatedRequest(PreauthenticatedRequest.builder()
+                        .accessUri("/p/secret/n/namespace/b/profile-pictures/o/avatars/alice.png")
+                        .build())
+                    .build()
+            }
+            1 * getEndpoint() >> "https://objectstorage.eu-frankfurt-1.oraclecloud.com"
+        }
+        OracleCloudStorageOperations operations = new OracleCloudStorageOperations(configuration, client, regionProvider)
+        CreatePresignedUploadRequest request = new CreatePresignedUploadRequest("avatars/alice.png", Duration.ofMinutes(5))
+        request.contentType = "image/png"
+        request.contentLength = 128
+        request.metadata = [owner: "alice"]
+        Instant before = Instant.now()
+
+        when:
+        PresignedUpload response = operations.createPresignedUpload(request).get()
+        Instant after = Instant.now()
+
+        then:
+        capturedRequest.namespaceName == "namespace"
+        capturedRequest.bucketName == "profile-pictures"
+        capturedRequest.createPreauthenticatedRequestDetails.objectName == "avatars/alice.png"
+        capturedRequest.createPreauthenticatedRequestDetails.accessType == CreatePreauthenticatedRequestDetails.AccessType.ObjectWrite
+        capturedRequest.createPreauthenticatedRequestDetails.name == "micronaut-presigned-upload-avatars-alice.png"
+        capturedRequest.createPreauthenticatedRequestDetails.timeExpires.toInstant() >= before.plus(Duration.ofMinutes(5)).minusMillis(1)
+        capturedRequest.createPreauthenticatedRequestDetails.timeExpires.toInstant() <= after.plus(Duration.ofMinutes(5)).plusMillis(1)
+        response.method == "PUT"
+        response.uri == URI.create("https://objectstorage.eu-frankfurt-1.oraclecloud.com/p/secret/n/namespace/b/profile-pictures/o/avatars/alice.png")
+        response.headers["Content-Type"] == ["image/png"]
+        response.headers["Content-Length"] == ["128"]
+        response.headers["opc-meta-owner"] == ["alice"]
+        response.expiration >= before.plus(Duration.ofMinutes(5))
+        response.expiration <= after.plus(Duration.ofMinutes(5))
+    }
+
+    void "it wraps OCI preauthenticated request failures as object storage exceptions"() {
+        given:
+        OracleCloudStorageConfiguration configuration = Stub() {
+            getBucket() >> "profile-pictures"
+            getNamespace() >> "namespace"
+        }
+        RegionProvider regionProvider = Stub()
+        ObjectStorage client = Mock() {
+            1 * createPreauthenticatedRequest(_ as CreatePreauthenticatedRequestRequest) >> {
+                throw BmcException.createClientSide("boom", null, null, null)
+            }
+        }
+        OracleCloudStorageOperations operations = new OracleCloudStorageOperations(configuration, client, regionProvider)
+
+        when:
+        operations.createPresignedUpload(new CreatePresignedUploadRequest("avatars/alice.png", Duration.ofMinutes(5)))
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message.contains("pre-signed upload request")
+    }
+}

--- a/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/ObjectStorageOperationsSpecification.groovy
+++ b/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/ObjectStorageOperationsSpecification.groovy
@@ -16,15 +16,22 @@
 package io.micronaut.objectstorage
 
 import io.micronaut.objectstorage.bucket.BucketOperations
+import io.micronaut.objectstorage.request.CreatePresignedUploadRequest
 import io.micronaut.objectstorage.request.ListObjectsRequest
 import io.micronaut.objectstorage.request.UploadRequest
 import io.micronaut.objectstorage.response.ListObjectsResponse
+import io.micronaut.objectstorage.response.PresignedUpload
 import io.micronaut.objectstorage.response.UploadResponse
+import org.opentest4j.TestAbortedException
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
+import java.net.HttpURLConnection
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
+import java.util.concurrent.ThreadLocalRandom
 
 abstract class ObjectStorageOperationsSpecification extends Specification {
 
@@ -215,9 +222,58 @@ abstract class ObjectStorageOperationsSpecification extends Specification {
         testFiles.each { storage.delete(it.uploadRequest.key) }
     }
 
+    void 'it can upload an object through a portable presigned request when supported'() {
+        given:
+        ObjectStorageOperations<?, ?, ?> storage = getObjectStorage()
+        String key = "presigned-${Math.abs(ThreadLocalRandom.current().nextLong())}.txt"
+        if (!supportsPresignedUploadRoundTrip()) {
+            throw new TestAbortedException("Presigned upload round-trip is not enabled for this provider/environment")
+        }
+        byte[] payload = NEW_TEXT.getBytes(StandardCharsets.UTF_8)
+        CreatePresignedUploadRequest request = new CreatePresignedUploadRequest(key, Duration.ofMinutes(5))
+        request.contentType = CONTENT_TYPE
+        request.contentLength = payload.length
+        request.metadata = METADATA
+        PollingConditions conditions = new PollingConditions(timeout: 30)
+
+        when:
+        PresignedUpload presignedUpload = storage.createPresignedUpload(request)
+            .orElseThrow(() -> new AssertionError("Expected provider to create a presigned upload request"))
+        int statusCode = uploadViaPresignedRequest(presignedUpload, payload)
+
+        then:
+        statusCode >= 200
+        statusCode < 300
+        presignedUpload.method == "PUT"
+        presignedUpload.expiration.isAfter(java.time.Instant.now())
+        conditions.eventually {
+            assert storage.exists(key)
+            assert storage.retrieve(key).present
+        }
+
+        when:
+        ObjectStorageEntry<?> entry = storage.retrieve(key).orElseThrow()
+
+        then:
+        entry.inputStream.text == NEW_TEXT
+        if (emulatorSupportsMetadata()) {
+            assert entry.metadata == METADATA
+        }
+        entry.contentType == Optional.of(CONTENT_TYPE)
+
+        cleanup:
+        if (supportsPresignedUploadRoundTrip()) {
+            storage.delete(key)
+        }
+    }
+
     abstract ObjectStorageOperations<?, ?, ?> getObjectStorage()
 
     abstract BucketOperations<?> getBucketOperations()
+
+    boolean supportsPresignedUploadRoundTrip() {
+        false
+    }
 
     boolean emulatorSupportsMetadata() {
         true
@@ -251,6 +307,32 @@ abstract class ObjectStorageOperationsSpecification extends Specification {
     static TestFile createTestFileForKey(String key) {
         Path path = createTempFile()
         return new TestFile(path: path, uploadRequest: UploadRequest.fromBytes(TEXT.bytes, key, CONTENT_TYPE))
+    }
+
+    private static int uploadViaPresignedRequest(PresignedUpload presignedUpload, byte[] payload) {
+        HttpURLConnection connection = (HttpURLConnection) presignedUpload.uri.toURL().openConnection()
+        connection.requestMethod = presignedUpload.method
+        connection.doOutput = true
+        connection.instanceFollowRedirects = false
+        connection.connectTimeout = 10_000
+        connection.readTimeout = 30_000
+        connection.setFixedLengthStreamingMode(payload.length)
+        presignedUpload.headers.forEach { name, values ->
+            if (!name.equalsIgnoreCase("Content-Length") && !name.equalsIgnoreCase("Host")) {
+                values.each { value ->
+                    connection.addRequestProperty(name, value)
+                }
+            }
+        }
+        connection.outputStream.withCloseable { outputStream ->
+            outputStream.write(payload)
+        }
+        int responseCode = connection.responseCode
+        if (responseCode >= 400) {
+            String errorBody = connection.errorStream != null ? connection.errorStream.text : ""
+            throw new AssertionError("Presigned upload failed with HTTP ${responseCode}: ${errorBody}")
+        }
+        return responseCode
     }
 
     private static List<ListObjectsResponse> collectPages(ObjectStorageOperations<?, ?, ?> storage, ListObjectsRequest request) {

--- a/src/main/docs/guide/oracleCloud.adoc
+++ b/src/main/docs/guide/oracleCloud.adoc
@@ -27,6 +27,9 @@ You can also resolve objects through Micronaut's `ResourceLoader` abstraction:
 The `os:` alias only resolves configured storages and must match the active OCI region together with the configured
 namespace and bucket.
 
+Oracle Cloud also supports `createPresignedUpload(...)` through OCI pre-authenticated requests, so applications can
+return a direct upload `PUT` URL plus any required headers without proxying file bytes.
+
 == Advanced configuration
 
 For configuration properties other than the specified above, you can add bean to your application that implements

--- a/src/main/docs/guide/oracleCloud.adoc
+++ b/src/main/docs/guide/oracleCloud.adoc
@@ -27,9 +27,6 @@ You can also resolve objects through Micronaut's `ResourceLoader` abstraction:
 The `os:` alias only resolves configured storages and must match the active OCI region together with the configured
 namespace and bucket.
 
-Oracle Cloud also supports `createPresignedUpload(...)` through OCI pre-authenticated requests, so applications can
-return a direct upload `PUT` URL plus any required headers without proxying file bytes.
-
 == Advanced configuration
 
 For configuration properties other than the specified above, you can add bean to your application that implements

--- a/src/main/docs/guide/preSignedUploads.adoc
+++ b/src/main/docs/guide/preSignedUploads.adoc
@@ -29,7 +29,8 @@ Portable contract:
 * The signed request uploads exactly one object key.
 * Clients must send an HTTP `PUT`.
 * Clients must preserve all required headers from the response.
-* Provider support is optional. Unsupported providers return `Optional.empty()`.
+* Provider support is optional. Providers that do not support pre-signed uploads, or cannot sign in the current
+  configuration, return `Optional.empty()`.
 * Local storage does not support this API because it has no HTTP endpoint to sign.
 
 The following controller example returns a JSON payload your frontend can use to upload directly to object storage:

--- a/src/main/docs/guide/preSignedUploads.adoc
+++ b/src/main/docs/guide/preSignedUploads.adoc
@@ -6,17 +6,6 @@ proxying the file bytes through the application.
 Use api:objectstorage.request.CreatePresignedUploadRequest[] to describe the object key and signing requirements, then
 call `createPresignedUpload(...)` on api:objectstorage.ObjectStorageOperations[].
 
-[source,java]
-----
-CreatePresignedUploadRequest request =
-    new CreatePresignedUploadRequest("profiles/" + userId + ".png", Duration.ofMinutes(5));
-request.setContentType("image/png");
-request.setMetadata(Map.of("owner", userId));
-
-PresignedUpload signedUpload = objectStorage.createPresignedUpload(request)
-    .orElseThrow(() -> new IllegalStateException("This provider does not support pre-signed uploads"));
-----
-
 The returned api:objectstorage.response.PresignedUpload[] includes:
 
 * the target URI

--- a/src/main/docs/guide/preSignedUploads.adoc
+++ b/src/main/docs/guide/preSignedUploads.adoc
@@ -31,6 +31,7 @@ Portable contract:
 * Clients must preserve all required headers from the response.
 * Provider support is optional. Providers that do not support pre-signed uploads, or cannot sign in the current
   configuration, return `Optional.empty()`.
+* Oracle Cloud uses OCI pre-authenticated requests for this API and returns the upload URL as the portable signed request URI.
 * Local storage does not support this API because it has no HTTP endpoint to sign.
 
 The following controller example returns a JSON payload your frontend can use to upload directly to object storage:

--- a/src/main/docs/guide/preSignedUploads.adoc
+++ b/src/main/docs/guide/preSignedUploads.adoc
@@ -1,0 +1,40 @@
+== Pre-Signed Uploads
+
+Applications can ask supporting providers to create a time-limited HTTP request for uploading a single object without
+proxying the file bytes through the application.
+
+Use api:objectstorage.request.CreatePresignedUploadRequest[] to describe the object key and signing requirements, then
+call `createPresignedUpload(...)` on api:objectstorage.ObjectStorageOperations[].
+
+[source,java]
+----
+CreatePresignedUploadRequest request =
+    new CreatePresignedUploadRequest("profiles/" + userId + ".png", Duration.ofMinutes(5));
+request.setContentType("image/png");
+request.setMetadata(Map.of("owner", userId));
+
+PresignedUpload signedUpload = objectStorage.createPresignedUpload(request)
+    .orElseThrow(() -> new IllegalStateException("This provider does not support pre-signed uploads"));
+----
+
+The returned api:objectstorage.response.PresignedUpload[] includes:
+
+* the target URI
+* the HTTP method to use
+* the headers the caller must forward exactly
+* the expiration instant
+
+Portable contract:
+
+* The signed request uploads exactly one object key.
+* Clients must send an HTTP `PUT`.
+* Clients must preserve all required headers from the response.
+* Provider support is optional. Unsupported providers return `Optional.empty()`.
+* Local storage does not support this API because it has no HTTP endpoint to sign.
+
+The following controller example returns a JSON payload your frontend can use to upload directly to object storage:
+
+snippet::example.PresignedUploadController[project-base="doc-examples/example", source="main", indent="0", tags="presigned-upload"]
+
+<1> Build a provider-agnostic api:objectstorage.request.CreatePresignedUploadRequest[] with the target object key and expiry.
+<2> Return the signed URL, HTTP method, headers, and expiry from api:objectstorage.response.PresignedUpload[] so the client can replay them exactly.

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -98,4 +98,6 @@ snippet::example.ProfileService[project-base="doc-examples/example", source="mai
 
 <1> The delete operation returns the cloud vendor-specific delete response object in case you need it.
 
+See the dedicated <<preSignedUploads,Pre-Signed Uploads>> section for portable, time-limited client upload requests.
+
 See the dedicated <<paginatedListing,Paginated Listing>> section for provider-agnostic page-by-page object listing.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -2,6 +2,7 @@ introduction: Introduction
 releaseHistory: Release History
 quickStart: Quick Start
 reactiveOperations: Reactive Operations
+preSignedUploads: Pre-Signed Uploads
 paginatedListing: Paginated Listing
 bucketManagement: Bucket and Container Management
 aws: Amazon S3


### PR DESCRIPTION
## Summary

- add a portable presigned upload request API in `object-storage-core`
- implement provider-backed signed `PUT` request generation for AWS, GCP, and Azure
- document the new pre-signed upload flow and add controller-facing doc examples

## Why

Micronaut Object Storage already abstracts direct upload/download operations, but it did not expose a first-class way to generate time-limited client upload requests. Some providers require signed headers in addition to the URL, so the API needs to return the full request shape instead of only a link.

Closes #631.

## Validation

- `./gradlew --no-daemon :micronaut-doc-examples:micronaut-example-java:compileJava :micronaut-doc-examples:micronaut-example-groovy:compileGroovy :micronaut-doc-examples:micronaut-example-kotlin:compileKotlin :micronaut-object-storage-core:test --tests 'io.micronaut.objectstorage.ObjectStorageOperationsPresignedUploadFallbackSpec' :micronaut-object-storage-aws:test --tests 'io.micronaut.objectstorage.aws.AwsS3PresignedUploadSpec' :micronaut-object-storage-gcp:test --tests 'io.micronaut.objectstorage.googlecloud.GoogleCloudStoragePresignedUploadSpec' :micronaut-object-storage-azure:test --tests 'io.micronaut.objectstorage.azure.AzureBlobStoragePresignedUploadSpec' japiCmp docs`
