### PR TITLE
docs: clarify stale worktree checks in agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Micronaut Object Storage Agent Notes
 
 - Default branch: `3.0.x`. There are no additional future maintenance branches in this checkout right now.
+- For routine or audit work, fetch `origin` and compare against `origin/3.0.x` before logging doc or workflow regressions; isolated worktrees can start from a stale local base.
 - Use `./gradlew` from the repository root. Prefer targeted module tasks while iterating and finish with repo-level verification such as `./gradlew check`.
 - The active Java toolchain is declared in [`.sdkmanrc`](.sdkmanrc). If SDKMAN is available, use `sdk env install` and `sdk env` before running Gradle.
 - Some tests require Docker because the repository uses Testcontainers-backed provider and emulator specs.


### PR DESCRIPTION
## Summary
- clarify that routine and audit work should fetch origin before treating local doc or workflow drift as a regression
- point agents at origin/3.0.x as the baseline for Object Storage repo checks

## Testing
- git diff --check