### PR TITLE
fix: reject reserved local storage metadata keys

### DIFF
--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -292,11 +292,20 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     }
 
     private static Path resolveSafe(Path parent, String key) {
+        validateKey(key);
         Path file = parent.resolve(key).normalize();
         if (!file.startsWith(parent)) {
             throw new IllegalArgumentException("Path lies outside the configured bucket");
         }
         return file;
+    }
+
+    private static void validateKey(String key) {
+        if (key.equals(METADATA_DIRECTORY)
+            || key.startsWith(METADATA_DIRECTORY + "/")
+            || (File.separatorChar != '/' && key.startsWith(METADATA_DIRECTORY + File.separator))) {
+            throw new IllegalArgumentException("Key uses the reserved " + METADATA_DIRECTORY + " namespace");
+        }
     }
 
     /**

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -301,10 +301,10 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     }
 
     private static void validateKey(String key) {
-        if (key.equals(METADATA_DIRECTORY)
+        if (METADATA_DIRECTORY.equals(key)
             || key.startsWith(METADATA_DIRECTORY + "/")
             || (File.separatorChar != '/' && key.startsWith(METADATA_DIRECTORY + File.separator))) {
-            throw new IllegalArgumentException("Key uses the reserved " + METADATA_DIRECTORY + " namespace");
+            throw new IllegalArgumentException("Key uses the reserved " + METADATA_DIRECTORY + " namespace: " + key);
         }
     }
 

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageReservedMetadataSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageReservedMetadataSpec.groovy
@@ -1,0 +1,79 @@
+package io.micronaut.objectstorage.local
+
+import io.micronaut.objectstorage.request.ListObjectsRequest
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class LocalStorageReservedMetadataSpec extends Specification implements TestPropertyProvider {
+
+    @Inject
+    LocalStorageOperations operations
+
+    @Override
+    Map<String, String> getProperties() {
+        [(LocalStorageConfiguration.PREFIX + '.default.enabled'): 'true']
+    }
+
+    void cleanup() {
+        operations.listObjects().each { operations.delete(it) }
+    }
+
+    void 'reserved metadata keys are rejected for upload without corrupting stored metadata'() {
+        given:
+        def request = UploadRequest.fromBytes('safe'.bytes, 'foo.txt', 'text/plain')
+        request.metadata = [owner: 'safe']
+        operations.upload(request)
+
+        when:
+        operations.upload(UploadRequest.fromBytes('attacker'.bytes, '.metadata/foo.txt', 'text/plain'))
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('.metadata')
+        operations.listObjects() == ['foo.txt'] as Set
+        operations.retrieve('foo.txt').get().metadata == [owner: 'safe']
+    }
+
+    void 'reserved metadata keys are rejected for direct object operations'() {
+        when:
+        operations.retrieve(key)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        operations.delete(key)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        operations.exists(key)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        operations.upload(UploadRequest.fromBytes('blocked'.bytes, key, 'text/plain'))
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        key << ['.metadata', '.metadata/nested.txt']
+    }
+
+    void 'listing never exposes the reserved metadata namespace'() {
+        given:
+        operations.upload(UploadRequest.fromBytes('visible'.bytes, 'visible.txt', 'text/plain'))
+
+        expect:
+        operations.listObjects(new ListObjectsRequest(5, '.metadata')).keys.empty
+        operations.listObjects(new ListObjectsRequest(5, '.metadata/')).keys.empty
+        operations.listObjects() == ['visible.txt'] as Set
+    }
+}

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageReservedMetadataSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageReservedMetadataSpec.groovy
@@ -7,6 +7,8 @@ import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import spock.lang.Specification
 
+import java.io.File
+
 @MicronautTest
 class LocalStorageReservedMetadataSpec extends Specification implements TestPropertyProvider {
 
@@ -33,7 +35,7 @@ class LocalStorageReservedMetadataSpec extends Specification implements TestProp
 
         then:
         def ex = thrown(IllegalArgumentException)
-        ex.message.contains('.metadata')
+        ex.message == 'Key uses the reserved .metadata namespace: .metadata/foo.txt'
         operations.listObjects() == ['foo.txt'] as Set
         operations.retrieve('foo.txt').get().metadata == [owner: 'safe']
     }
@@ -43,28 +45,32 @@ class LocalStorageReservedMetadataSpec extends Specification implements TestProp
         operations.retrieve(key)
 
         then:
-        thrown(IllegalArgumentException)
+        def retrieveException = thrown(IllegalArgumentException)
+        retrieveException.message == "Key uses the reserved .metadata namespace: ${key}"
 
         when:
         operations.delete(key)
 
         then:
-        thrown(IllegalArgumentException)
+        def deleteException = thrown(IllegalArgumentException)
+        deleteException.message == "Key uses the reserved .metadata namespace: ${key}"
 
         when:
         operations.exists(key)
 
         then:
-        thrown(IllegalArgumentException)
+        def existsException = thrown(IllegalArgumentException)
+        existsException.message == "Key uses the reserved .metadata namespace: ${key}"
 
         when:
         operations.upload(UploadRequest.fromBytes('blocked'.bytes, key, 'text/plain'))
 
         then:
-        thrown(IllegalArgumentException)
+        def uploadException = thrown(IllegalArgumentException)
+        uploadException.message == "Key uses the reserved .metadata namespace: ${key}"
 
         where:
-        key << ['.metadata', '.metadata/nested.txt']
+        key << reservedKeys()
     }
 
     void 'listing never exposes the reserved metadata namespace'() {
@@ -75,5 +81,13 @@ class LocalStorageReservedMetadataSpec extends Specification implements TestProp
         operations.listObjects(new ListObjectsRequest(5, '.metadata')).keys.empty
         operations.listObjects(new ListObjectsRequest(5, '.metadata/')).keys.empty
         operations.listObjects() == ['visible.txt'] as Set
+    }
+
+    private static List<String> reservedKeys() {
+        def keys = ['.metadata', '.metadata/nested.txt']
+        if (File.separatorChar != '/') {
+            keys << ".metadata${File.separator}nested.txt"
+        }
+        keys
     }
 }

--- a/src/main/docs/guide/local.adoc
+++ b/src/main/docs/guide/local.adoc
@@ -16,6 +16,9 @@ micronaut:
 NOTE: When added to the classpath, api:objectstorage.local.LocalStorageOperations[] becomes the primary implementation of
 api:objectstorage.ObjectStorageOperations[].
 
+NOTE: The local storage implementation reserves the `.metadata` key namespace for per-object metadata files. User object
+keys cannot be `.metadata` or start with `.metadata/`.
+
 By default, it will create a temporary folder to store the files, but you can configure it to use a specific folder:
 
 include::{includedir}configurationProperties/io.micronaut.objectstorage.local.LocalStorageConfiguration.adoc[]

--- a/src/main/docs/guide/local.adoc
+++ b/src/main/docs/guide/local.adoc
@@ -17,7 +17,7 @@ NOTE: When added to the classpath, api:objectstorage.local.LocalStorageOperation
 api:objectstorage.ObjectStorageOperations[].
 
 NOTE: The local storage implementation reserves the `.metadata` key namespace for per-object metadata files. User object
-keys cannot be `.metadata` or start with `.metadata/`.
+keys cannot be `.metadata` or start with `.metadata/` (or `.metadata\` on platforms where the file separator is `\`).
 
 By default, it will create a temporary folder to store the files, but you can configure it to use a specific folder:
 


### PR DESCRIPTION
## Summary
- reject user object keys equal to `.metadata` or prefixed with `.metadata/` before local filesystem access
- add regression coverage that preserves the metadata-overwrite reproducer and verifies reserved keys stay unreadable and unlistable
- document the reserved local metadata namespace in the local storage guide

## Verification
- ./gradlew :micronaut-object-storage-local:test --tests "io.micronaut.objectstorage.local.LocalStorageReservedMetadataSpec" --tests "io.micronaut.objectstorage.local.LocalStoragePathTraversalSpec" --tests "io.micronaut.objectstorage.local.LocalStoragePaginationSpec"
- ./gradlew :micronaut-object-storage-local:test
- ./gradlew docs