### PR TITLE
fix: harden local storage symlink path resolution

### DIFF
--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageEntry.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageEntry.java
@@ -22,9 +22,11 @@ import io.micronaut.objectstorage.ObjectStorageException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLConnection;
+import java.nio.channels.Channels;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Map;
 import java.util.Optional;
 
@@ -59,7 +61,7 @@ public class LocalStorageEntry implements ObjectStorageEntry<Path> {
     @Override
     public InputStream getInputStream() {
         try {
-            return Files.newInputStream(file, LinkOption.NOFOLLOW_LINKS);
+            return Channels.newInputStream(Files.newByteChannel(file, StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS));
         } catch (IOException e) {
             throw new ObjectStorageException("Error opening input stream for file: " + file, e);
         }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageEntry.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageEntry.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLConnection;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
@@ -58,7 +59,7 @@ public class LocalStorageEntry implements ObjectStorageEntry<Path> {
     @Override
     public InputStream getInputStream() {
         try {
-            return Files.newInputStream(file);
+            return Files.newInputStream(file, LinkOption.NOFOLLOW_LINKS);
         } catch (IOException e) {
             throw new ObjectStorageException("Error opening input stream for file: " + file, e);
         }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -36,6 +36,8 @@ import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileAttribute;
@@ -44,6 +46,7 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -112,8 +115,10 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     @NonNull
     public UploadResponse<LocalStorageFile> upload(@NonNull UploadRequest request,
                                                    @NonNull Consumer<LocalStorageFile> requestConsumer) {
-        Path file = storeFile(request);
-        storeMetadata(request);
+        Path file = resolveSafe(configuration.getPath(), request.getKey());
+        Path metadataFile = resolveSafe(metadataPath, request.getKey());
+        storeFile(file, request.getInputStream());
+        storeMetadata(metadataFile, request.getKey(), request.getMetadata());
         LocalStorageFile localFile = new LocalStorageFile(file);
         requestConsumer.accept(localFile);
         return UploadResponse.of(request.getKey(), UUID.randomUUID().toString(), localFile);
@@ -217,9 +222,11 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     @Override
     public void copy(@NonNull String sourceKey, @NonNull String destinationKey) {
         retrieveFile(sourceKey).ifPresent(source -> {
-            try (InputStream in = Files.newInputStream(source)) {
-                storeFile(destinationKey, in);
-                storeMetadata(destinationKey, retrieveMetadata(sourceKey));
+            Path destinationFile = resolveSafe(configuration.getPath(), destinationKey);
+            Path destinationMetadata = resolveSafe(metadataPath, destinationKey);
+            try (InputStream in = newInputStreamNoFollow(source)) {
+                storeFile(destinationFile, in);
+                storeMetadata(destinationMetadata, destinationKey, retrieveMetadata(sourceKey));
             } catch (IOException e) {
                 throw new ObjectStorageException("Error copying file: " + source, e);
             }
@@ -228,7 +235,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
 
     private Optional<Path> retrieveFile(String key) {
         Path file = resolveSafe(configuration.getPath(), key);
-        if (Files.exists(file)) {
+        if (Files.exists(file, LinkOption.NOFOLLOW_LINKS)) {
             return Optional.of(file);
         } else {
             return Optional.empty();
@@ -238,8 +245,8 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     private Map<String, String> retrieveMetadata(String key) {
         Properties metadataProperties = new Properties();
         Path metadata = resolveSafe(metadataPath, key).normalize();
-        if (Files.exists(metadata)) {
-            try (InputStream metadataIn = Files.newInputStream(metadata)) {
+        if (Files.exists(metadata, LinkOption.NOFOLLOW_LINKS)) {
+            try (InputStream metadataIn = newInputStreamNoFollow(metadata)) {
                 metadataProperties.load(metadataIn);
             } catch (IOException e) {
                 //no op
@@ -264,7 +271,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
 
     private void deleteMetadata(String key) {
         Path metadata = resolveSafe(metadataPath, key);
-        if (Files.exists(metadata)) {
+        if (Files.exists(metadata, LinkOption.NOFOLLOW_LINKS)) {
             try {
                 Files.delete(metadata);
             } catch (IOException e) {
@@ -273,14 +280,9 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         }
     }
 
-    private Path storeFile(UploadRequest request) {
-        return storeFile(request.getKey(), request.getInputStream());
-    }
-
-    private Path storeFile(String key, InputStream inputStream) {
-        Path file = resolveSafe(configuration.getPath(), key);
+    private Path storeFile(Path file, InputStream inputStream) {
         mkdirs(file.getParent());
-        try (OutputStream fileOut = newOutputStream(file)) {
+        try (OutputStream fileOut = newOutputStreamNoFollow(file)) {
             inputStream.transferTo(fileOut);
             return file;
         } catch (IOException e) {
@@ -288,16 +290,11 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         }
     }
 
-    private void storeMetadata(UploadRequest request) {
-        storeMetadata(request.getKey(), request.getMetadata());
-    }
-
-    private void storeMetadata(String key, Map<String, String> metadata) {
+    private void storeMetadata(Path metadataFilePath, String key, Map<String, String> metadata) {
         Properties metadataProperties = new Properties();
         metadataProperties.putAll(metadata);
-        Path metadataFilePath = resolveSafe(metadataPath, key);
         mkdirs(metadataFilePath.getParent());
-        try (OutputStream metadataOut = newOutputStream(metadataFilePath)) {
+        try (OutputStream metadataOut = newOutputStreamNoFollow(metadataFilePath)) {
             metadataProperties.store(metadataOut, "Metadata for file: " + key);
         } catch (IOException e) {
             //no op
@@ -324,20 +321,28 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         }
     }
 
-    private OutputStream newOutputStream(Path file) throws IOException {
+    private OutputStream newOutputStreamNoFollow(Path file) throws IOException {
         if (supportsPosixPermissions) {
             try {
-                return Channels.newOutputStream(FileChannel.open(
-                    file,
-                    EnumSet.of(StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW),
-                    FILE_PERMISSIONS_ATTRIBUTE
-                ));
+                Set<OpenOption> createOptions = new HashSet<>();
+                createOptions.add(StandardOpenOption.WRITE);
+                createOptions.add(StandardOpenOption.CREATE_NEW);
+                createOptions.add(LinkOption.NOFOLLOW_LINKS);
+                return Channels.newOutputStream(FileChannel.open(file, createOptions, FILE_PERMISSIONS_ATTRIBUTE));
             } catch (FileAlreadyExistsException ignored) {
                 Files.setPosixFilePermissions(file, FILE_PERMISSIONS);
-                return Files.newOutputStream(file, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+                return Channels.newOutputStream(FileChannel.open(
+                    file,
+                    Set.of(StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, LinkOption.NOFOLLOW_LINKS)
+                ));
             }
         }
-        return Files.newOutputStream(file);
+        return Channels.newOutputStream(Files.newByteChannel(file, Set.of(
+            StandardOpenOption.CREATE,
+            StandardOpenOption.TRUNCATE_EXISTING,
+            StandardOpenOption.WRITE,
+            LinkOption.NOFOLLOW_LINKS
+        )));
     }
 
     private static void createOwnerOnlyDirectory(Path directory) throws IOException {
@@ -353,10 +358,13 @@ public class LocalStorageOperations implements ObjectStorageOperations<
 
     private static Path resolveSafe(Path parent, String key) {
         validateKey(key);
-        Path file = parent.resolve(key).normalize();
-        if (!file.startsWith(parent)) {
+        Path normalizedParent = parent.normalize();
+        Path file = normalizedParent.resolve(key).normalize();
+        if (!file.startsWith(normalizedParent)) {
             throw new IllegalArgumentException("Path lies outside the configured bucket");
         }
+        rejectSymbolicLink(normalizedParent);
+        rejectSymbolicLinks(normalizedParent, file);
         return file;
     }
 
@@ -366,6 +374,24 @@ public class LocalStorageOperations implements ObjectStorageOperations<
             || (File.separatorChar != '/' && key.startsWith(METADATA_DIRECTORY + File.separator))) {
             throw new IllegalArgumentException("Key uses the reserved " + METADATA_DIRECTORY + " namespace: " + key);
         }
+    }
+
+    private static void rejectSymbolicLink(Path path) {
+        if (Files.isSymbolicLink(path)) {
+            throw new IllegalArgumentException("Path contains symbolic links");
+        }
+    }
+
+    private static void rejectSymbolicLinks(Path parent, Path file) {
+        Path current = parent;
+        for (Path segment : parent.relativize(file)) {
+            current = current.resolve(segment);
+            rejectSymbolicLink(current);
+        }
+    }
+
+    private static InputStream newInputStreamNoFollow(Path path) throws IOException {
+        return Channels.newInputStream(Files.newByteChannel(path, Set.of(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)));
     }
 
     /**

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -364,12 +364,10 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         if (!file.startsWith(normalizedParent)) {
             throw new IllegalArgumentException("Path lies outside the configured bucket");
         }
-        rejectSymbolicLink(normalizedParent);
         rejectSymbolicLinks(normalizedParent, file);
         return file;
     }
 
-<<<<<<< HEAD
     private static void validateKey(String key) {
         if (METADATA_DIRECTORY.equals(key)
             || key.startsWith(METADATA_DIRECTORY + "/")
@@ -377,9 +375,6 @@ public class LocalStorageOperations implements ObjectStorageOperations<
             throw new IllegalArgumentException("Key uses the reserved " + METADATA_DIRECTORY + " namespace: " + key);
         }
     }
-
-=======
->>>>>>> 44e991e (Harden local storage metadata symlink handling)
     private static void rejectSymbolicLink(Path path) {
         if (Files.isSymbolicLink(path)) {
             throw new IllegalArgumentException("Path contains symbolic links");
@@ -397,7 +392,6 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     private static InputStream newInputStreamNoFollow(Path path) throws IOException {
         return Channels.newInputStream(Files.newByteChannel(path, Set.of(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)));
     }
-
     /**
      * A simple wrapper around a path.
      * @param path Where on disk the local storage provider has stored the actual data.

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -375,6 +375,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
             throw new IllegalArgumentException("Key uses the reserved " + METADATA_DIRECTORY + " namespace: " + key);
         }
     }
+
     private static void rejectSymbolicLink(Path path) {
         if (Files.isSymbolicLink(path)) {
             throw new IllegalArgumentException("Path contains symbolic links");
@@ -392,6 +393,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     private static InputStream newInputStreamNoFollow(Path path) throws IOException {
         return Channels.newInputStream(Files.newByteChannel(path, Set.of(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)));
     }
+
     /**
      * A simple wrapper around a path.
      * @param path Where on disk the local storage provider has stored the actual data.

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -359,6 +359,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     private static Path resolveSafe(Path parent, String key) {
         validateKey(key);
         Path normalizedParent = parent.normalize();
+        rejectSymbolicLink(normalizedParent);
         Path file = normalizedParent.resolve(key).normalize();
         if (!file.startsWith(normalizedParent)) {
             throw new IllegalArgumentException("Path lies outside the configured bucket");
@@ -368,6 +369,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         return file;
     }
 
+<<<<<<< HEAD
     private static void validateKey(String key) {
         if (METADATA_DIRECTORY.equals(key)
             || key.startsWith(METADATA_DIRECTORY + "/")
@@ -376,6 +378,8 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         }
     }
 
+=======
+>>>>>>> 44e991e (Harden local storage metadata symlink handling)
     private static void rejectSymbolicLink(Path path) {
         if (Files.isSymbolicLink(path)) {
             throw new IllegalArgumentException("Path contains symbolic links");

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePathTraversalSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePathTraversalSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.objectstorage.local
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.objectstorage.request.ListObjectsRequest
+import io.micronaut.objectstorage.request.UploadRequest
 import spock.lang.Specification
 
 import java.nio.charset.StandardCharsets
@@ -41,6 +42,71 @@ class LocalStoragePathTraversalSpec extends Specification {
         then:
         listedKeys.keys.empty
         listedKeys.continuationToken.empty
+
+        cleanup:
+        ctx.close()
+        Files.walkFileTree(tmp, new SimpleFileVisitor<Path>() {
+            @Override
+            FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.delete(file)
+                return FileVisitResult.CONTINUE
+            }
+
+            @Override
+            FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                Files.delete(dir)
+                return FileVisitResult.CONTINUE
+            }
+        })
+    }
+
+    def 'symlink escapes are rejected for retrieve copy upload and delete'() {
+        given:
+        Path tmp = Files.createTempDirectory("micronaut-object-storage")
+        Path outside = tmp.resolve("outside")
+        Files.createDirectory(outside)
+        Path secret = outside.resolve("secret")
+        Files.writeString(secret, "bar")
+        Path bucket = tmp.resolve("bucket")
+        Files.createDirectory(bucket)
+        Path publicEntry = bucket.resolve("public")
+        Files.writeString(publicEntry, "baz")
+        Files.createSymbolicLink(bucket.resolve("secret-link"), secret)
+        Files.createSymbolicLink(bucket.resolve("outside-link"), outside)
+
+        ApplicationContext ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
+
+        when:
+        ctx.getBean(LocalStorageOperations).retrieve("public")
+
+        then:
+        noExceptionThrown()
+
+        when:
+        ctx.getBean(LocalStorageOperations).retrieve("secret-link")
+
+        then:
+        thrown IllegalArgumentException
+
+        when:
+        ctx.getBean(LocalStorageOperations).copy("outside-link/secret", "copied")
+
+        then:
+        thrown IllegalArgumentException
+
+        when:
+        ctx.getBean(LocalStorageOperations).upload(UploadRequest.fromBytes("evil".bytes, "outside-link/created", "text/plain"))
+
+        then:
+        thrown IllegalArgumentException
+        !Files.exists(outside.resolve("created"))
+
+        when:
+        ctx.getBean(LocalStorageOperations).delete("secret-link")
+
+        then:
+        thrown IllegalArgumentException
+        Files.exists(secret)
 
         cleanup:
         ctx.close()

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePathTraversalSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePathTraversalSpec.groovy
@@ -124,4 +124,44 @@ class LocalStoragePathTraversalSpec extends Specification {
             }
         })
     }
+
+    def 'symlinked metadata directory is rejected during upload'() {
+        given:
+        Path tmp = Files.createTempDirectory("micronaut-object-storage")
+        Path outside = tmp.resolve("outside")
+        Files.createDirectory(outside)
+        Path bucket = tmp.resolve("bucket")
+        Files.createDirectory(bucket)
+        Path metadataTarget = outside.resolve("metadata-target")
+        Files.createDirectory(metadataTarget)
+        Files.createSymbolicLink(bucket.resolve(LocalStorageOperations.METADATA_DIRECTORY), metadataTarget)
+
+        ApplicationContext ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
+        UploadRequest request = UploadRequest.fromBytes("evil".bytes, "public", "text/plain")
+        request.setMetadata(["owner": "mallory"])
+
+        when:
+        ctx.getBean(LocalStorageOperations).upload(request)
+
+        then:
+        thrown IllegalArgumentException
+        !Files.exists(bucket.resolve("public"))
+        !Files.exists(metadataTarget.resolve("public"))
+
+        cleanup:
+        ctx.close()
+        Files.walkFileTree(tmp, new SimpleFileVisitor<Path>() {
+            @Override
+            FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.delete(file)
+                return FileVisitResult.CONTINUE
+            }
+
+            @Override
+            FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                Files.delete(dir)
+                return FileVisitResult.CONTINUE
+            }
+        })
+    }
 }

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePathTraversalSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePathTraversalSpec.groovy
@@ -3,8 +3,10 @@ package io.micronaut.objectstorage.local
 import io.micronaut.context.ApplicationContext
 import io.micronaut.objectstorage.request.ListObjectsRequest
 import io.micronaut.objectstorage.request.UploadRequest
+import org.opentest4j.TestAbortedException
 import spock.lang.Specification
 
+import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
@@ -16,6 +18,7 @@ class LocalStoragePathTraversalSpec extends Specification {
     def 'path traversal'() {
         given:
         Path tmp = Files.createTempDirectory("micronaut-object-storage")
+        ApplicationContext ctx = null
         Path secret = tmp.resolve("secret")
         Files.writeString(secret, "bar")
         Path bucket = tmp.resolve("foo")
@@ -23,7 +26,7 @@ class LocalStoragePathTraversalSpec extends Specification {
         Path pub = bucket.resolve("public")
         Files.writeString(pub, "baz")
 
-        ApplicationContext ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
+        ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
 
         when:
         def publicEntry = ctx.getBean(LocalStorageOperations).retrieve("public")
@@ -44,25 +47,14 @@ class LocalStoragePathTraversalSpec extends Specification {
         listedKeys.continuationToken.empty
 
         cleanup:
-        ctx.close()
-        Files.walkFileTree(tmp, new SimpleFileVisitor<Path>() {
-            @Override
-            FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                Files.delete(file)
-                return FileVisitResult.CONTINUE
-            }
-
-            @Override
-            FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-                Files.delete(dir)
-                return FileVisitResult.CONTINUE
-            }
-        })
+        ctx?.close()
+        deleteRecursively(tmp)
     }
 
     def 'symlink escapes are rejected for retrieve copy upload and delete'() {
         given:
         Path tmp = Files.createTempDirectory("micronaut-object-storage")
+        ApplicationContext ctx = null
         Path outside = tmp.resolve("outside")
         Files.createDirectory(outside)
         Path secret = outside.resolve("secret")
@@ -71,10 +63,11 @@ class LocalStoragePathTraversalSpec extends Specification {
         Files.createDirectory(bucket)
         Path publicEntry = bucket.resolve("public")
         Files.writeString(publicEntry, "baz")
+        assumeSymbolicLinksSupported(tmp)
         Files.createSymbolicLink(bucket.resolve("secret-link"), secret)
         Files.createSymbolicLink(bucket.resolve("outside-link"), outside)
 
-        ApplicationContext ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
+        ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
 
         when:
         ctx.getBean(LocalStorageOperations).retrieve("public")
@@ -109,34 +102,24 @@ class LocalStoragePathTraversalSpec extends Specification {
         Files.exists(secret)
 
         cleanup:
-        ctx.close()
-        Files.walkFileTree(tmp, new SimpleFileVisitor<Path>() {
-            @Override
-            FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                Files.delete(file)
-                return FileVisitResult.CONTINUE
-            }
-
-            @Override
-            FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-                Files.delete(dir)
-                return FileVisitResult.CONTINUE
-            }
-        })
+        ctx?.close()
+        deleteRecursively(tmp)
     }
 
     def 'symlinked metadata directory is rejected during upload'() {
         given:
         Path tmp = Files.createTempDirectory("micronaut-object-storage")
+        ApplicationContext ctx = null
         Path outside = tmp.resolve("outside")
         Files.createDirectory(outside)
         Path bucket = tmp.resolve("bucket")
         Files.createDirectory(bucket)
         Path metadataTarget = outside.resolve("metadata-target")
         Files.createDirectory(metadataTarget)
+        assumeSymbolicLinksSupported(tmp)
         Files.createSymbolicLink(bucket.resolve(LocalStorageOperations.METADATA_DIRECTORY), metadataTarget)
 
-        ApplicationContext ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
+        ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
         UploadRequest request = UploadRequest.fromBytes("evil".bytes, "public", "text/plain")
         request.setMetadata(["owner": "mallory"])
 
@@ -149,8 +132,33 @@ class LocalStoragePathTraversalSpec extends Specification {
         !Files.exists(metadataTarget.resolve("public"))
 
         cleanup:
-        ctx.close()
-        Files.walkFileTree(tmp, new SimpleFileVisitor<Path>() {
+        ctx?.close()
+        deleteRecursively(tmp)
+    }
+
+    private static void assumeSymbolicLinksSupported(Path directory) {
+        Path target = directory.resolve("symlink-target-probe")
+        Path link = directory.resolve("symlink-link-probe")
+        try {
+            Files.writeString(target, "probe")
+            Files.createSymbolicLink(link, target.fileName)
+        } catch (UnsupportedOperationException | IOException | SecurityException ignored) {
+            throw new TestAbortedException("symbolic links are not supported in this environment")
+        } finally {
+            try {
+                Files.deleteIfExists(link)
+                Files.deleteIfExists(target)
+            } catch (IOException ignored) {
+                // no-op
+            }
+        }
+    }
+
+    private static void deleteRecursively(Path path) {
+        if (path == null || !Files.exists(path)) {
+            return
+        }
+        Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
             @Override
             FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                 Files.delete(file)


### PR DESCRIPTION
## Summary
- reject symlinked parent paths and symlink child segments when resolving local storage object and metadata destinations
- prevalidate both object and metadata targets before upload and copy writes so rejected metadata paths do not leave partial writes behind
- add regression coverage for symlink escapes across retrieve, copy, upload, and delete flows, including a symlinked `.metadata` parent case

## Verification
- ./gradlew :micronaut-object-storage-local:test --tests 'io.micronaut.objectstorage.local.LocalStoragePathTraversalSpec'\n- ./gradlew :micronaut-object-storage-local:test