### PR TITLE
fix: restrict local storage file permissions

### DIFF
--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -32,6 +32,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -87,9 +90,11 @@ public class LocalStorageOperations implements ObjectStorageOperations<
 
     private final LocalStorageConfiguration configuration;
     private final Path metadataPath;
+    private final boolean supportsPosixPermissions;
 
     public LocalStorageOperations(@Parameter LocalStorageConfiguration configuration) {
         this.configuration = configuration;
+        this.supportsPosixPermissions = configuration.getPath().getFileSystem().supportedFileAttributeViews().contains("posix");
         this.metadataPath = configuration.getPath().resolve(METADATA_DIRECTORY);
         boolean metadataDirectoryCreated = mkdirs(metadataPath);
         if (!metadataDirectoryCreated) {
@@ -301,10 +306,17 @@ public class LocalStorageOperations implements ObjectStorageOperations<
 
     private boolean mkdirs(Path path) {
         try {
-            if (supportsPosixPermissions(path)) {
-                Files.createDirectories(path, DIRECTORY_PERMISSIONS_ATTRIBUTE);
-            } else {
+            if (!supportsPosixPermissions) {
                 Files.createDirectories(path);
+                return true;
+            }
+            Path bucketPath = configuration.getPath();
+            Files.createDirectories(bucketPath, DIRECTORY_PERMISSIONS_ATTRIBUTE);
+            Files.setPosixFilePermissions(bucketPath, DIRECTORY_PERMISSIONS);
+            Path current = bucketPath;
+            for (Path part : bucketPath.relativize(path.normalize())) {
+                current = current.resolve(part);
+                createOwnerOnlyDirectory(current);
             }
             return true;
         } catch (IOException e) {
@@ -313,19 +325,30 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     }
 
     private OutputStream newOutputStream(Path file) throws IOException {
-        if (supportsPosixPermissions(file)) {
-            if (Files.notExists(file)) {
-                Files.createFile(file, FILE_PERMISSIONS_ATTRIBUTE);
-            } else {
+        if (supportsPosixPermissions) {
+            try {
+                return Channels.newOutputStream(FileChannel.open(
+                    file,
+                    EnumSet.of(StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW),
+                    FILE_PERMISSIONS_ATTRIBUTE
+                ));
+            } catch (FileAlreadyExistsException ignored) {
                 Files.setPosixFilePermissions(file, FILE_PERMISSIONS);
+                return Files.newOutputStream(file, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
             }
-            return Files.newOutputStream(file, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
         }
         return Files.newOutputStream(file);
     }
 
-    private boolean supportsPosixPermissions(Path path) {
-        return path.getFileSystem().supportedFileAttributeViews().contains("posix");
+    private static void createOwnerOnlyDirectory(Path directory) throws IOException {
+        try {
+            Files.createDirectory(directory, DIRECTORY_PERMISSIONS_ATTRIBUTE);
+        } catch (FileAlreadyExistsException ignored) {
+            if (!Files.isDirectory(directory)) {
+                throw ignored;
+            }
+        }
+        Files.setPosixFilePermissions(directory, DIRECTORY_PERMISSIONS);
     }
 
     private static Path resolveSafe(Path parent, String key) {

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -29,14 +29,18 @@ import io.micronaut.objectstorage.response.ListObjectsResponse;
 import io.micronaut.objectstorage.response.UploadResponse;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -67,6 +71,19 @@ public class LocalStorageOperations implements ObjectStorageOperations<
 
     public static final String METADATA_DIRECTORY = ".metadata";
     private static final int DEFAULT_LIST_PAGE_SIZE = 1_000;
+    private static final Set<PosixFilePermission> DIRECTORY_PERMISSIONS = EnumSet.of(
+        PosixFilePermission.OWNER_READ,
+        PosixFilePermission.OWNER_WRITE,
+        PosixFilePermission.OWNER_EXECUTE
+    );
+    private static final Set<PosixFilePermission> FILE_PERMISSIONS = EnumSet.of(
+        PosixFilePermission.OWNER_READ,
+        PosixFilePermission.OWNER_WRITE
+    );
+    private static final FileAttribute<Set<PosixFilePermission>> DIRECTORY_PERMISSIONS_ATTRIBUTE =
+        PosixFilePermissions.asFileAttribute(DIRECTORY_PERMISSIONS);
+    private static final FileAttribute<Set<PosixFilePermission>> FILE_PERMISSIONS_ATTRIBUTE =
+        PosixFilePermissions.asFileAttribute(FILE_PERMISSIONS);
 
     private final LocalStorageConfiguration configuration;
     private final Path metadataPath;
@@ -258,7 +275,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     private Path storeFile(String key, InputStream inputStream) {
         Path file = resolveSafe(configuration.getPath(), key);
         mkdirs(file.getParent());
-        try (OutputStream fileOut = Files.newOutputStream(file)) {
+        try (OutputStream fileOut = newOutputStream(file)) {
             inputStream.transferTo(fileOut);
             return file;
         } catch (IOException e) {
@@ -275,7 +292,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         metadataProperties.putAll(metadata);
         Path metadataFilePath = resolveSafe(metadataPath, key);
         mkdirs(metadataFilePath.getParent());
-        try (OutputStream metadataOut = new FileOutputStream(metadataFilePath.toFile())) {
+        try (OutputStream metadataOut = newOutputStream(metadataFilePath)) {
             metadataProperties.store(metadataOut, "Metadata for file: " + key);
         } catch (IOException e) {
             //no op
@@ -284,11 +301,31 @@ public class LocalStorageOperations implements ObjectStorageOperations<
 
     private boolean mkdirs(Path path) {
         try {
-            Files.createDirectories(path);
+            if (supportsPosixPermissions(path)) {
+                Files.createDirectories(path, DIRECTORY_PERMISSIONS_ATTRIBUTE);
+            } else {
+                Files.createDirectories(path);
+            }
             return true;
         } catch (IOException e) {
             return false;
         }
+    }
+
+    private OutputStream newOutputStream(Path file) throws IOException {
+        if (supportsPosixPermissions(file)) {
+            if (Files.notExists(file)) {
+                Files.createFile(file, FILE_PERMISSIONS_ATTRIBUTE);
+            } else {
+                Files.setPosixFilePermissions(file, FILE_PERMISSIONS);
+            }
+            return Files.newOutputStream(file, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+        }
+        return Files.newOutputStream(file);
+    }
+
+    private boolean supportsPosixPermissions(Path path) {
+        return path.getFileSystem().supportedFileAttributeViews().contains("posix");
     }
 
     private static Path resolveSafe(Path parent, String key) {

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageFilePermissionsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageFilePermissionsSpec.groovy
@@ -6,6 +6,7 @@ import spock.lang.Requires
 import spock.lang.Specification
 
 import java.io.IOException
+import java.nio.charset.StandardCharsets
 import java.nio.file.FileSystems
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
@@ -23,7 +24,7 @@ class LocalStorageFilePermissionsSpec extends Specification {
         Path bucket = root.resolve("bucket")
         ApplicationContext ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
         LocalStorageOperations operations = ctx.getBean(LocalStorageOperations)
-        UploadRequest request = UploadRequest.fromBytes('secret'.bytes, 'nested/object.txt', 'text/plain')
+        UploadRequest request = UploadRequest.fromBytes('secret'.getBytes(StandardCharsets.UTF_8), 'nested/deeper/object.txt', 'text/plain')
         request.metadata = [classification: 'internal']
 
         when:
@@ -33,9 +34,11 @@ class LocalStorageFilePermissionsSpec extends Specification {
         Files.getPosixFilePermissions(bucket) == ownerOnlyDirectoryPermissions()
         Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.METADATA_DIRECTORY)) == ownerOnlyDirectoryPermissions()
         Files.getPosixFilePermissions(bucket.resolve('nested')) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(bucket.resolve('nested/deeper')) == ownerOnlyDirectoryPermissions()
         Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('nested')) == ownerOnlyDirectoryPermissions()
-        Files.getPosixFilePermissions(bucket.resolve('nested/object.txt')) == ownerOnlyFilePermissions()
-        Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('nested/object.txt')) == ownerOnlyFilePermissions()
+        Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('nested/deeper')) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(bucket.resolve('nested/deeper/object.txt')) == ownerOnlyFilePermissions()
+        Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('nested/deeper/object.txt')) == ownerOnlyFilePermissions()
 
         cleanup:
         ctx?.close()

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageFilePermissionsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageFilePermissionsSpec.groovy
@@ -1,0 +1,73 @@
+package io.micronaut.objectstorage.local
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.objectstorage.request.UploadRequest
+import spock.lang.Requires
+import spock.lang.Specification
+
+import java.io.IOException
+import java.nio.file.FileSystems
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.PosixFilePermission
+
+@Requires({ FileSystems.default.supportedFileAttributeViews().contains('posix') })
+class LocalStorageFilePermissionsSpec extends Specification {
+
+    void 'configured bucket path uses owner only POSIX permissions for objects and metadata'() {
+        given:
+        Path root = Files.createTempDirectory("micronaut-object-storage-permissions")
+        Path bucket = root.resolve("bucket")
+        ApplicationContext ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
+        LocalStorageOperations operations = ctx.getBean(LocalStorageOperations)
+        UploadRequest request = UploadRequest.fromBytes('secret'.bytes, 'nested/object.txt', 'text/plain')
+        request.metadata = [classification: 'internal']
+
+        when:
+        operations.upload(request)
+
+        then:
+        Files.getPosixFilePermissions(bucket) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.METADATA_DIRECTORY)) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(bucket.resolve('nested')) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('nested')) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(bucket.resolve('nested/object.txt')) == ownerOnlyFilePermissions()
+        Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('nested/object.txt')) == ownerOnlyFilePermissions()
+
+        cleanup:
+        ctx?.close()
+        if (Files.exists(root)) {
+            Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+                @Override
+                FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file)
+                    return FileVisitResult.CONTINUE
+                }
+
+                @Override
+                FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.delete(dir)
+                    return FileVisitResult.CONTINUE
+                }
+            })
+        }
+    }
+
+    private static Set<PosixFilePermission> ownerOnlyDirectoryPermissions() {
+        [
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.OWNER_EXECUTE,
+        ] as Set<PosixFilePermission>
+    }
+
+    private static Set<PosixFilePermission> ownerOnlyFilePermissions() {
+        [
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE,
+        ] as Set<PosixFilePermission>
+    }
+}

--- a/src/main/docs/guide/local.adoc
+++ b/src/main/docs/guide/local.adoc
@@ -18,6 +18,10 @@ api:objectstorage.ObjectStorageOperations[].
 
 By default, it will create a temporary folder to store the files, but you can configure it to use a specific folder:
 
+On POSIX-capable file systems, configured bucket paths created by the local implementation use owner-only permissions for
+bucket subdirectories, stored objects, and `.metadata` files. On non-POSIX file systems, Micronaut cannot apply those
+permissions directly, so custom storage paths on shared hosts should be provisioned with restrictive ACLs by the caller.
+
 include::{includedir}configurationProperties/io.micronaut.objectstorage.local.LocalStorageConfiguration.adoc[]
 
 For example:


### PR DESCRIPTION
## Summary
- create local object and metadata directories with owner-only POSIX permissions when the filesystem supports them
- write stored objects and `.metadata` files with owner-only POSIX permissions for configured bucket paths
- document the POSIX hardening behavior and add a regression spec covering directory and file modes

## Verification
- ./gradlew :micronaut-object-storage-local:test --tests 'io.micronaut.objectstorage.local.LocalStorageFilePermissionsSpec'
- ./gradlew :micronaut-object-storage-local:check docs
