### PR TITLE
fix: reject normalized local storage .metadata paths

### DIFF
--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -370,7 +370,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
 
     private static void validateKey(Path normalizedRelativePath, String key) {
         if (normalizedRelativePath.getNameCount() > 0
-            && METADATA_DIRECTORY.equals(normalizedRelativePath.getName(0).toString())) {
+            && METADATA_DIRECTORY.equalsIgnoreCase(normalizedRelativePath.getName(0).toString())) {
             throw new IllegalArgumentException("Key uses the reserved " + METADATA_DIRECTORY + " namespace: " + key);
         }
     }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -357,21 +357,20 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     }
 
     private static Path resolveSafe(Path parent, String key) {
-        validateKey(key);
         Path normalizedParent = parent.normalize();
         rejectSymbolicLink(normalizedParent);
         Path file = normalizedParent.resolve(key).normalize();
         if (!file.startsWith(normalizedParent)) {
             throw new IllegalArgumentException("Path lies outside the configured bucket");
         }
+        validateKey(normalizedParent.relativize(file), key);
         rejectSymbolicLinks(normalizedParent, file);
         return file;
     }
 
-    private static void validateKey(String key) {
-        if (METADATA_DIRECTORY.equals(key)
-            || key.startsWith(METADATA_DIRECTORY + "/")
-            || (File.separatorChar != '/' && key.startsWith(METADATA_DIRECTORY + File.separator))) {
+    private static void validateKey(Path normalizedRelativePath, String key) {
+        if (normalizedRelativePath.getNameCount() > 0
+            && METADATA_DIRECTORY.equals(normalizedRelativePath.getName(0).toString())) {
             throw new IllegalArgumentException("Key uses the reserved " + METADATA_DIRECTORY + " namespace: " + key);
         }
     }

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageReservedMetadataSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageReservedMetadataSpec.groovy
@@ -31,13 +31,16 @@ class LocalStorageReservedMetadataSpec extends Specification implements TestProp
         operations.upload(request)
 
         when:
-        operations.upload(UploadRequest.fromBytes('attacker'.bytes, '.metadata/foo.txt', 'text/plain'))
+        operations.upload(UploadRequest.fromBytes('attacker'.bytes, key, 'text/plain'))
 
         then:
         def ex = thrown(IllegalArgumentException)
-        ex.message == 'Key uses the reserved .metadata namespace: .metadata/foo.txt'
+        ex.message == "Key uses the reserved .metadata namespace: ${key}"
         operations.listObjects() == ['foo.txt'] as Set
         operations.retrieve('foo.txt').get().metadata == [owner: 'safe']
+
+        where:
+        key << blockedKeys()
     }
 
     void 'reserved metadata keys are rejected for direct object operations'() {
@@ -70,7 +73,7 @@ class LocalStorageReservedMetadataSpec extends Specification implements TestProp
         uploadException.message == "Key uses the reserved .metadata namespace: ${key}"
 
         where:
-        key << reservedKeys()
+        key << blockedKeys()
     }
 
     void 'listing never exposes the reserved metadata namespace'() {
@@ -83,10 +86,13 @@ class LocalStorageReservedMetadataSpec extends Specification implements TestProp
         operations.listObjects() == ['visible.txt'] as Set
     }
 
-    private static List<String> reservedKeys() {
+    private static List<String> blockedKeys() {
         def keys = ['.metadata', '.metadata/nested.txt']
+        keys.addAll(['foo/../.metadata/nested.txt', './.metadata/nested.txt'])
         if (File.separatorChar != '/') {
             keys << ".metadata${File.separator}nested.txt"
+            keys << "foo${File.separator}..${File.separator}.metadata${File.separator}nested.txt"
+            keys << ".${File.separator}.metadata${File.separator}nested.txt"
         }
         keys
     }

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageReservedMetadataSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageReservedMetadataSpec.groovy
@@ -87,12 +87,21 @@ class LocalStorageReservedMetadataSpec extends Specification implements TestProp
     }
 
     private static List<String> blockedKeys() {
-        def keys = ['.metadata', '.metadata/nested.txt']
-        keys.addAll(['foo/../.metadata/nested.txt', './.metadata/nested.txt'])
+        def keys = ['.metadata', '.Metadata', '.METADATA']
+                .collectMany { metadataDirectory ->
+                    [
+                            metadataDirectory,
+                            "${metadataDirectory}/nested.txt",
+                            "foo/../${metadataDirectory}/nested.txt",
+                            "./${metadataDirectory}/nested.txt"
+                    ]
+                }
         if (File.separatorChar != '/') {
-            keys << ".metadata${File.separator}nested.txt"
-            keys << "foo${File.separator}..${File.separator}.metadata${File.separator}nested.txt"
-            keys << ".${File.separator}.metadata${File.separator}nested.txt"
+            ['.metadata', '.Metadata', '.METADATA'].each { metadataDirectory ->
+                keys << "${metadataDirectory}${File.separator}nested.txt"
+                keys << "foo${File.separator}..${File.separator}${metadataDirectory}${File.separator}nested.txt"
+                keys << ".${File.separator}${metadataDirectory}${File.separator}nested.txt"
+            }
         }
         keys
     }


### PR DESCRIPTION
Closes #751

## Summary
- validate the normalized local-storage path before allowing access to object data or metadata
- reject keys that normalize into the reserved `.metadata` namespace even when the raw key does not start with `.metadata`
- add regression coverage for upload, retrieve, delete, and exists using normalized bypass inputs

## Verification
- `./gradlew --no-daemon --rerun-tasks :micronaut-object-storage-local:test --tests 'io.micronaut.objectstorage.local.LocalStorageReservedMetadataSpec' --tests 'io.micronaut.objectstorage.local.LocalStoragePathTraversalSpec'`