### PR TITLE
fix: confine rebased resource loader paths

### DIFF
--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/AbstractObjectStorageResourceLoader.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/AbstractObjectStorageResourceLoader.java
@@ -153,29 +153,42 @@ public abstract class AbstractObjectStorageResourceLoader implements ResourceLoa
     private static String normalizeRelativeLookupPath(String path) {
         boolean leadingSlash = path.startsWith("/");
         boolean trailingSlash = path.endsWith("/") && !path.isEmpty();
+        String candidate = trimRelativeLookupCandidate(path, leadingSlash, trailingSlash);
+        String normalized = normalizeRelativeLookupCandidate(candidate, path);
+        return restoreRelativeLookupDecorators(normalized, leadingSlash, trailingSlash);
+    }
+
+    private static String trimRelativeLookupCandidate(String path, boolean leadingSlash, boolean trailingSlash) {
         String candidate = leadingSlash ? path.substring(1) : path;
         if (trailingSlash && !candidate.isEmpty()) {
-            candidate = candidate.substring(0, candidate.length() - 1);
+            return candidate.substring(0, candidate.length() - 1);
         }
+        return candidate;
+    }
 
+    private static String normalizeRelativeLookupCandidate(String candidate, String path) {
         Deque<String> segments = new ArrayDeque<>();
-        if (!candidate.isEmpty()) {
-            for (String segment : candidate.split("/", -1)) {
-                if (".".equals(segment)) {
-                    continue;
-                }
-                if ("..".equals(segment)) {
-                    if (segments.isEmpty()) {
-                        throw new IllegalArgumentException("Relative resource path escapes the configured base path: " + path);
-                    }
-                    segments.removeLast();
-                    continue;
-                }
-                segments.addLast(segment);
-            }
+        for (String segment : candidate.split("/", -1)) {
+            applyRelativeLookupSegment(segments, segment, path);
         }
+        return String.join("/", segments);
+    }
 
-        String normalized = String.join("/", segments);
+    private static void applyRelativeLookupSegment(Deque<String> segments, String segment, String path) {
+        if (segment.isEmpty() || ".".equals(segment)) {
+            return;
+        }
+        if ("..".equals(segment)) {
+            if (segments.isEmpty()) {
+                throw new IllegalArgumentException("Relative resource path escapes the configured base path: " + path);
+            }
+            segments.removeLast();
+            return;
+        }
+        segments.addLast(segment);
+    }
+
+    private static String restoreRelativeLookupDecorators(String normalized, boolean leadingSlash, boolean trailingSlash) {
         if (leadingSlash) {
             normalized = "/" + normalized;
         }

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/AbstractObjectStorageResourceLoader.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/resource/AbstractObjectStorageResourceLoader.java
@@ -29,6 +29,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -72,7 +74,11 @@ public abstract class AbstractObjectStorageResourceLoader implements ResourceLoa
 
     @Override
     public boolean supportsPrefix(String path) {
-        if (resolveRelative(path).isPresent()) {
+        try {
+            if (resolveRelative(path).isPresent()) {
+                return true;
+            }
+        } catch (IllegalArgumentException e) {
             return true;
         }
         if (!hasRecognizedPrefix(path)) {
@@ -111,9 +117,10 @@ public abstract class AbstractObjectStorageResourceLoader implements ResourceLoa
         if (relativeBase == null || hasRecognizedPrefix(path) || !ObjectStorageResourceParser.isRelativePath(path)) {
             return Optional.empty();
         }
+        String normalizedRelativePath = normalizeRelativeLookupPath(path);
         return Optional.of(new ResolvedObjectStorageResource(
-            relativeBase.keyPrefix() + path,
-            relativeBase.externalPrefix() + path,
+            relativeBase.keyPrefix() + normalizedRelativePath,
+            relativeBase.externalPrefix() + normalizedRelativePath,
             relativeBase.operations()
         ));
     }
@@ -141,6 +148,41 @@ public abstract class AbstractObjectStorageResourceLoader implements ResourceLoa
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException("Invalid object storage URL: " + externalForm, e);
         }
+    }
+
+    private static String normalizeRelativeLookupPath(String path) {
+        boolean leadingSlash = path.startsWith("/");
+        boolean trailingSlash = path.endsWith("/") && !path.isEmpty();
+        String candidate = leadingSlash ? path.substring(1) : path;
+        if (trailingSlash && !candidate.isEmpty()) {
+            candidate = candidate.substring(0, candidate.length() - 1);
+        }
+
+        Deque<String> segments = new ArrayDeque<>();
+        if (!candidate.isEmpty()) {
+            for (String segment : candidate.split("/", -1)) {
+                if (".".equals(segment)) {
+                    continue;
+                }
+                if ("..".equals(segment)) {
+                    if (segments.isEmpty()) {
+                        throw new IllegalArgumentException("Relative resource path escapes the configured base path: " + path);
+                    }
+                    segments.removeLast();
+                    continue;
+                }
+                segments.addLast(segment);
+            }
+        }
+
+        String normalized = String.join("/", segments);
+        if (leadingSlash) {
+            normalized = "/" + normalized;
+        }
+        if (trailingSlash && (normalized.isEmpty() || normalized.charAt(normalized.length() - 1) != '/')) {
+            normalized = normalized + '/';
+        }
+        return normalized;
     }
 
     /**

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/resource/NamedObjectStorageResourceLoaderSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/resource/NamedObjectStorageResourceLoaderSpec.groovy
@@ -33,6 +33,27 @@ class NamedObjectStorageResourceLoaderSpec extends Specification {
         rebased.getResourceAsStream('logo.txt').get().text == 'logo-bytes'
         rebased.supportsPrefix('logo:v2.txt')
         rebased.getResourceAsStream('logo:v2.txt').get().text == 'logo-v2-bytes'
+        rebased.getResourceAsStream('nested/../logo.txt').get().text == 'logo-bytes'
+    }
+
+    void 'it rejects relative lookups that escape the rebased prefix'() {
+        given:
+        def operations = new TestObjectStorageOperations([
+            'avatars/logo.txt': 'logo-bytes',
+            'secret.txt': 'secret-bytes'
+        ])
+        def rebased = new NamedObjectStorageResourceLoader('public-images', operations)
+            .forBase('public-images://avatars/')
+
+        expect:
+        rebased.supportsPrefix('../secret.txt')
+
+        when:
+        rebased.getResourceAsStream('../secret.txt')
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('escapes the configured base path')
     }
 
     void 'it returns empty for missing objects'() {

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/resource/NamedObjectStorageResourceLoaderSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/resource/NamedObjectStorageResourceLoaderSpec.groovy
@@ -15,7 +15,9 @@ class NamedObjectStorageResourceLoaderSpec extends Specification {
         given:
         def operations = new TestObjectStorageOperations([
             'avatars/logo.txt': 'logo-bytes',
-            'avatars/logo:v2.txt': 'logo-v2-bytes'
+            'avatars/logo:v2.txt': 'logo-v2-bytes',
+            'avatars/nested/logo.txt': 'nested-logo-bytes',
+            'avatars/nested/': 'nested-dir-bytes'
         ])
         def loader = new NamedObjectStorageResourceLoader('public-images', operations)
 
@@ -31,9 +33,12 @@ class NamedObjectStorageResourceLoaderSpec extends Specification {
         then:
         rebased.supportsPrefix('logo.txt')
         rebased.getResourceAsStream('logo.txt').get().text == 'logo-bytes'
+        rebased.getResourceAsStream('./logo.txt').get().text == 'logo-bytes'
         rebased.supportsPrefix('logo:v2.txt')
         rebased.getResourceAsStream('logo:v2.txt').get().text == 'logo-v2-bytes'
+        rebased.getResourceAsStream('nested/./logo.txt').get().text == 'nested-logo-bytes'
         rebased.getResourceAsStream('nested/../logo.txt').get().text == 'logo-bytes'
+        rebased.getResourceAsStream('nested/').get().text == 'nested-dir-bytes'
     }
 
     void 'it rejects relative lookups that escape the rebased prefix'() {
@@ -54,6 +59,13 @@ class NamedObjectStorageResourceLoaderSpec extends Specification {
         then:
         def e = thrown(IllegalArgumentException)
         e.message.contains('escapes the configured base path')
+
+        when:
+        rebased.getResourceAsStream('nested//../../secret.txt')
+
+        then:
+        def e2 = thrown(IllegalArgumentException)
+        e2.message.contains('escapes the configured base path')
     }
 
     void 'it returns empty for missing objects'() {

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageResourceLoaderSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageResourceLoaderSpec.groovy
@@ -36,4 +36,33 @@ class LocalStorageResourceLoaderSpec extends Specification {
         cleanup:
         context.close()
     }
+
+    void 'it rejects rebased relative lookups that escape the configured base path'() {
+        given:
+        ApplicationContext context = ApplicationContext.run(
+            [
+                (PREFIX + '.public-images.path'): tempDir.toString()
+            ]
+        )
+        def operations = context.getBean(ObjectStorageOperations, Qualifiers.byName('public-images'))
+        operations.upload(UploadRequest.fromBytes('hello-loader'.bytes, 'avatars/logo.txt'))
+        operations.upload(UploadRequest.fromBytes('top-secret'.bytes, 'secret.txt'))
+        def rebased = new ResourceResolver(context.getBeansOfType(ResourceLoader).toList())
+            .getLoaderForBasePath('public-images://avatars/')
+            .get()
+
+        expect:
+        rebased.getResourceAsStream('nested/../logo.txt').get().text == 'hello-loader'
+        rebased.supportsPrefix('../secret.txt')
+
+        when:
+        rebased.getResourceAsStream('../secret.txt')
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('escapes the configured base path')
+
+        cleanup:
+        context.close()
+    }
 }


### PR DESCRIPTION
## Summary
- normalize relative lookups from `ResourceLoader.forBase(...)` before rebasing them onto object keys
- reject `..` segments that would escape the configured base prefix while preserving safe in-prefix traversal
- add shared and local-provider regression coverage for rebased resource-loader paths

## Verification
- `./gradlew --rerun-tasks :micronaut-object-storage-core:test --tests 'io.micronaut.objectstorage.resource.NamedObjectStorageResourceLoaderSpec' :micronaut-object-storage-local:test --tests 'io.micronaut.objectstorage.local.LocalStorageResourceLoaderSpec' :micronaut-object-storage-aws:test --tests 'io.micronaut.objectstorage.aws.AwsS3ResourceLoaderSpec' :micronaut-object-storage-azure:test --tests 'io.micronaut.objectstorage.azure.AzureBlobStorageResourceLoaderSpec' :micronaut-object-storage-gcp:test --tests 'io.micronaut.objectstorage.googlecloud.GoogleCloudStorageResourceLoaderSpec' :micronaut-object-storage-oracle-cloud:test --tests 'io.micronaut.objectstorage.oraclecloud.OracleCloudStorageResourceLoaderSpec'`