### PR TITLE
fix: declare provider workflow token permissions

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -25,6 +25,8 @@ jobs:
     strategy:
       matrix:
         java: ['25']
+    permissions:
+      contents: 'read'
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space

--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -25,6 +25,8 @@ jobs:
     strategy:
       matrix:
         java: ['25']
+    permissions:
+      contents: 'read'
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space


### PR DESCRIPTION
## Summary
- add explicit `permissions: contents: 'read'` to the repo-local AWS and Azure provider workflows
- align those workflows with the existing least-privilege pattern already used by the GCP and OCI workflows
- keep the trusted-event secret-bearing jobs on the minimum repository token scope instead of relying on repo defaults

## Verification
- `git diff --check`
- `python3` YAML parse for `.github/workflows/aws.yml` and `.github/workflows/azure.yml`
