### PR TITLE
feat: add multipart upload lifecycle support

### DIFF
--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
@@ -505,8 +505,11 @@ public class AwsS3Operations implements ObjectStorageOperations<
             BytesUploadRequest request = (BytesUploadRequest) uploadRequest;
             return new RequestBodyWithSize(RequestBody.fromBytes(request.getBytes()), request.getBytes().length);
         } else {
-            byte[] inputBytes = inputStreamMapper.toByteArray(uploadRequest.getInputStream());
-            return new RequestBodyWithSize(RequestBody.fromBytes(inputBytes), inputBytes.length);
+            long size = uploadRequest.getContentSize()
+                .orElseThrow(() -> new ObjectStorageException(
+                    "Multipart uploads require UploadRequest#getContentSize() for streaming requests"
+                ));
+            return new RequestBodyWithSize(RequestBody.fromInputStream(uploadRequest.getInputStream(), size), size);
         }
     }
 

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3Operations.java
@@ -20,16 +20,28 @@ import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.objectstorage.InputStreamMapper;
+import io.micronaut.objectstorage.MultipartObjectStorageOperations;
+import io.micronaut.objectstorage.MultipartPart;
+import io.micronaut.objectstorage.MultipartUploadHandle;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.ObjectStorageOperations;
 import io.micronaut.objectstorage.configuration.ToggeableCondition;
-import io.micronaut.objectstorage.request.CreatePresignedUploadRequest;
+import io.micronaut.objectstorage.request.AbortMultipartUploadRequest;
 import io.micronaut.objectstorage.request.BytesUploadRequest;
+import io.micronaut.objectstorage.request.CompleteMultipartUploadRequest;
+import io.micronaut.objectstorage.request.CreateMultipartUploadRequest;
+import io.micronaut.objectstorage.request.CreatePresignedUploadRequest;
 import io.micronaut.objectstorage.request.FileUploadRequest;
+import io.micronaut.objectstorage.request.ListMultipartPartsRequest;
 import io.micronaut.objectstorage.request.ListObjectsRequest;
+import io.micronaut.objectstorage.request.UploadPartRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
+import io.micronaut.objectstorage.response.CompleteMultipartUploadResponse;
+import io.micronaut.objectstorage.response.CreateMultipartUploadResponse;
+import io.micronaut.objectstorage.response.ListMultipartPartsResponse;
 import io.micronaut.objectstorage.response.ListObjectsResponse;
 import io.micronaut.objectstorage.response.PresignedUpload;
+import io.micronaut.objectstorage.response.UploadPartResponse;
 import io.micronaut.objectstorage.response.UploadResponse;
 import org.jspecify.annotations.NonNull;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
@@ -37,6 +49,8 @@ import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
@@ -47,6 +61,8 @@ import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.NoSuchUploadException;
+import software.amazon.awssdk.services.s3.model.Part;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Object;
@@ -77,12 +93,16 @@ import java.util.function.Consumer;
 @Requires(condition = ToggeableCondition.class)
 @Requires(beans = AwsS3Configuration.class)
 public class AwsS3Operations implements ObjectStorageOperations<
-    PutObjectRequest.Builder, PutObjectResponse, DeleteObjectResponse> {
+    PutObjectRequest.Builder, PutObjectResponse, DeleteObjectResponse>, MultipartObjectStorageOperations<
+    software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse,
+    software.amazon.awssdk.services.s3.model.UploadPartResponse,
+    software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse> {
 
     private static final int DEFAULT_LIST_PAGE_SIZE = 1_000;
     private static final String LEGACY_CONTINUATION_TOKEN_PREFIX = "aws-s3:v1:";
     private static final String RAW_CONTINUATION_TOKEN_PREFIX = "aws-s3:v2:";
     private static final String CONTINUATION_TOKEN_PREFIX = "aws-s3:v3:";
+    private static final String MULTIPART_CONTINUATION_TOKEN_PREFIX = "aws-s3-multipart:v1:";
 
     private final S3Client s3Client;
     private final AwsS3Configuration configuration;
@@ -271,6 +291,131 @@ public class AwsS3Operations implements ObjectStorageOperations<
         }
     }
 
+    @Override
+    @NonNull
+    public CreateMultipartUploadResponse<software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse> createMultipartUpload(
+        @NonNull CreateMultipartUploadRequest request) {
+        software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest.Builder builder =
+            software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest.builder()
+                .bucket(configuration.getBucket())
+                .key(request.getKey());
+        request.getContentType().ifPresent(builder::contentType);
+        if (CollectionUtils.isNotEmpty(request.getMetadata())) {
+            builder.metadata(request.getMetadata());
+        }
+        try {
+            software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse response =
+                s3Client.createMultipartUpload(builder.build());
+            return CreateMultipartUploadResponse.of(
+                new MultipartUploadHandle(request.getKey(), response.uploadId()),
+                response
+            );
+        } catch (AwsServiceException | SdkClientException e) {
+            String msg = String.format("Error when trying to create a multipart upload with key [%s] in Amazon S3", request.getKey());
+            throw new ObjectStorageException(msg, e);
+        }
+    }
+
+    @Override
+    @NonNull
+    public UploadPartResponse<software.amazon.awssdk.services.s3.model.UploadPartResponse> uploadPart(@NonNull UploadPartRequest request) {
+        MultipartUploadHandle upload = request.getUpload();
+        RequestBodyWithSize requestBody = getMultipartRequestBody(request.getUploadRequest());
+        software.amazon.awssdk.services.s3.model.UploadPartRequest.Builder builder =
+            software.amazon.awssdk.services.s3.model.UploadPartRequest.builder()
+                .bucket(configuration.getBucket())
+                .key(upload.getKey())
+                .uploadId(upload.getUploadId())
+                .partNumber(request.getPartNumber())
+                .contentLength(requestBody.size());
+        try {
+            software.amazon.awssdk.services.s3.model.UploadPartResponse response =
+                s3Client.uploadPart(builder.build(), requestBody.requestBody());
+            MultipartPart part = new MultipartPart(
+                request.getPartNumber(),
+                response.eTag(),
+                requestBody.size(),
+                checksumFromUploadPartResponse(response)
+            );
+            return UploadPartResponse.of(part, response);
+        } catch (AwsServiceException | SdkClientException e) {
+            String msg = String.format(
+                "Error when trying to upload part [%d] for multipart upload [%s] in Amazon S3",
+                request.getPartNumber(),
+                upload.getUploadId()
+            );
+            throw new ObjectStorageException(msg, e);
+        }
+    }
+
+    @Override
+    @NonNull
+    public ListMultipartPartsResponse listParts(@NonNull ListMultipartPartsRequest request) {
+        MultipartUploadHandle upload = request.getUpload();
+        try {
+            software.amazon.awssdk.services.s3.model.ListPartsRequest.Builder builder =
+                software.amazon.awssdk.services.s3.model.ListPartsRequest.builder()
+                    .bucket(configuration.getBucket())
+                    .key(upload.getKey())
+                    .uploadId(upload.getUploadId())
+                    .maxParts(request.getPageSize());
+            decodeMultipartContinuationToken(request).ifPresent(builder::partNumberMarker);
+
+            software.amazon.awssdk.services.s3.model.ListPartsResponse response = s3Client.listParts(builder.build());
+            List<MultipartPart> parts = response.parts().stream().map(this::toMultipartPart).toList();
+            return new ListMultipartPartsResponse(parts, encodeMultipartContinuationToken(response.nextPartNumberMarker()));
+        } catch (AwsServiceException | SdkClientException e) {
+            String msg = String.format("Error when trying to list parts for multipart upload [%s] in Amazon S3", upload.getUploadId());
+            throw new ObjectStorageException(msg, e);
+        }
+    }
+
+    @Override
+    @NonNull
+    public CompleteMultipartUploadResponse<software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse> completeMultipartUpload(
+        @NonNull CompleteMultipartUploadRequest request) {
+        MultipartUploadHandle upload = request.getUpload();
+        CompletedMultipartUpload completedMultipartUpload = CompletedMultipartUpload.builder()
+            .parts(request.getParts().stream().map(part -> CompletedPart.builder()
+                .partNumber(part.getPartNumber())
+                .eTag(part.getETag())
+                .build()).toList())
+            .build();
+        try {
+            software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse response = s3Client.completeMultipartUpload(
+                software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest.builder()
+                    .bucket(configuration.getBucket())
+                    .key(upload.getKey())
+                    .uploadId(upload.getUploadId())
+                    .multipartUpload(completedMultipartUpload)
+                    .build()
+            );
+            return CompleteMultipartUploadResponse.of(upload, response.eTag(), response);
+        } catch (AwsServiceException | SdkClientException e) {
+            String msg = String.format("Error when trying to complete multipart upload [%s] in Amazon S3", upload.getUploadId());
+            throw new ObjectStorageException(msg, e);
+        }
+    }
+
+    @Override
+    public void abortMultipartUpload(@NonNull AbortMultipartUploadRequest request) {
+        MultipartUploadHandle upload = request.getUpload();
+        try {
+            s3Client.abortMultipartUpload(
+                software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest.builder()
+                    .bucket(configuration.getBucket())
+                    .key(upload.getKey())
+                    .uploadId(upload.getUploadId())
+                    .build()
+            );
+        } catch (NoSuchUploadException ignored) {
+            // Abort is required to be safe to retry.
+        } catch (AwsServiceException | SdkClientException e) {
+            String msg = String.format("Error when trying to abort multipart upload [%s] in Amazon S3", upload.getUploadId());
+            throw new ObjectStorageException(msg, e);
+        }
+    }
+
     /**
      * @return the presigner used to create pre-signed upload requests.
      * @since 3.0.0
@@ -349,6 +494,22 @@ public class AwsS3Operations implements ObjectStorageOperations<
         }
     }
 
+    @NonNull
+    private RequestBodyWithSize getMultipartRequestBody(@NonNull UploadRequest uploadRequest) {
+        if (uploadRequest instanceof FileUploadRequest) {
+            FileUploadRequest request = (FileUploadRequest) uploadRequest;
+            long size = request.getContentSize()
+                .orElseThrow(() -> new ObjectStorageException("Unable to determine multipart part size for file upload"));
+            return new RequestBodyWithSize(RequestBody.fromFile(request.getFile()), size);
+        } else if (uploadRequest instanceof BytesUploadRequest) {
+            BytesUploadRequest request = (BytesUploadRequest) uploadRequest;
+            return new RequestBodyWithSize(RequestBody.fromBytes(request.getBytes()), request.getBytes().length);
+        } else {
+            byte[] inputBytes = inputStreamMapper.toByteArray(uploadRequest.getInputStream());
+            return new RequestBodyWithSize(RequestBody.fromBytes(inputBytes), inputBytes.length);
+        }
+    }
+
     private DecodedContinuationToken decodeContinuationToken(ListObjectsRequest request) {
         String continuationToken = request.getContinuationToken().orElse(null);
         if (continuationToken == null || continuationToken.isEmpty()) {
@@ -419,7 +580,59 @@ public class AwsS3Operations implements ObjectStorageOperations<
         return headers;
     }
 
+    private Optional<Integer> decodeMultipartContinuationToken(ListMultipartPartsRequest request) {
+        String continuationToken = request.getContinuationToken().orElse(null);
+        if (continuationToken == null || continuationToken.isEmpty()) {
+            return Optional.empty();
+        }
+        try {
+            String rawToken = continuationToken;
+            if (continuationToken.startsWith(MULTIPART_CONTINUATION_TOKEN_PREFIX)) {
+                rawToken = new String(
+                    Base64.getUrlDecoder().decode(continuationToken.substring(MULTIPART_CONTINUATION_TOKEN_PREFIX.length())),
+                    StandardCharsets.UTF_8
+                );
+            }
+            return Optional.of(Integer.parseInt(rawToken));
+        } catch (IllegalArgumentException e) {
+            throw new ObjectStorageException("Invalid AWS S3 multipart continuation token", e);
+        }
+    }
+
+    private String encodeMultipartContinuationToken(Integer nextPartNumberMarker) {
+        if (nextPartNumberMarker == null || nextPartNumberMarker <= 0) {
+            return null;
+        }
+        return MULTIPART_CONTINUATION_TOKEN_PREFIX + Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(Integer.toString(nextPartNumberMarker).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private MultipartPart toMultipartPart(Part part) {
+        return new MultipartPart(
+            part.partNumber(),
+            part.eTag(),
+            part.size(),
+            firstNonEmpty(part.checksumCRC32(), part.checksumCRC32C(), part.checksumSHA1(), part.checksumSHA256())
+        );
+    }
+
+    private String checksumFromUploadPartResponse(software.amazon.awssdk.services.s3.model.UploadPartResponse response) {
+        return firstNonEmpty(response.checksumCRC32(), response.checksumCRC32C(), response.checksumSHA1(), response.checksumSHA256());
+    }
+
+    private String firstNonEmpty(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isEmpty()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
     private record DecodedContinuationToken(Optional<String> rawContinuationToken,
                                             Optional<String> startAfter) {
+    }
+
+    private record RequestBodyWithSize(RequestBody requestBody, long size) {
     }
 }

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AbstractAwsS3MultipartSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AbstractAwsS3MultipartSpec.groovy
@@ -1,0 +1,52 @@
+package io.micronaut.objectstorage.aws
+
+import io.micronaut.objectstorage.MultipartObjectStorageOperations
+import io.micronaut.objectstorage.MultipartObjectStorageOperationsSpecification
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+import jakarta.inject.Named
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.model.PutObjectResponse
+
+import static io.micronaut.objectstorage.aws.AwsS3Configuration.PREFIX
+
+abstract class AbstractAwsS3MultipartSpec extends MultipartObjectStorageOperationsSpecification implements TestPropertyProvider {
+
+    public static final String BUCKET_NAME = System.currentTimeMillis()
+    public static final String OBJECT_STORAGE_NAME = 'default'
+
+    @Inject
+    S3Client s3
+
+    @Inject
+    @Named(OBJECT_STORAGE_NAME)
+    AwsS3Operations awsS3Bucket
+
+    void setup() {
+        s3.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build() as CreateBucketRequest)
+    }
+
+    void cleanup() {
+        s3.deleteBucket(DeleteBucketRequest.builder().bucket(BUCKET_NAME).build() as DeleteBucketRequest)
+    }
+
+    @Override
+    ObjectStorageOperations<PutObjectRequest.Builder, PutObjectResponse, DeleteObjectResponse> getObjectStorage() {
+        return awsS3Bucket
+    }
+
+    @Override
+    MultipartObjectStorageOperations<?, ?, ?> getMultipartObjectStorage() {
+        return awsS3Bucket
+    }
+
+    @Override
+    Map<String, String> getProperties() {
+        [(PREFIX + '.' + OBJECT_STORAGE_NAME + '.bucket'): BUCKET_NAME]
+    }
+}

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AbstractAwsS3MultipartSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AbstractAwsS3MultipartSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.objectstorage.aws
 import io.micronaut.objectstorage.MultipartObjectStorageOperations
 import io.micronaut.objectstorage.MultipartObjectStorageOperationsSpecification
 import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.bucket.BucketOperations
 import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
 import jakarta.inject.Named
@@ -27,6 +28,10 @@ abstract class AbstractAwsS3MultipartSpec extends MultipartObjectStorageOperatio
     @Named(OBJECT_STORAGE_NAME)
     AwsS3Operations awsS3Bucket
 
+    @Inject
+    @Named(OBJECT_STORAGE_NAME)
+    AwsS3BucketOperations awsS3BucketOperations
+
     void setup() {
         s3.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build() as CreateBucketRequest)
     }
@@ -38,6 +43,11 @@ abstract class AbstractAwsS3MultipartSpec extends MultipartObjectStorageOperatio
     @Override
     ObjectStorageOperations<PutObjectRequest.Builder, PutObjectResponse, DeleteObjectResponse> getObjectStorage() {
         return awsS3Bucket
+    }
+
+    @Override
+    BucketOperations<?> getBucketOperations() {
+        return awsS3BucketOperations
     }
 
     @Override

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3MultipartOperationsLocalstackSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3MultipartOperationsLocalstackSpec.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.objectstorage.aws
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import org.testcontainers.localstack.LocalStackContainer
+import org.testcontainers.utility.DockerImageName
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+import static io.micronaut.objectstorage.test.ObjectStorageTestConstants.LOCAL_STACK_DOCKER_IMAGE
+
+@MicronautTest(startApplication = false)
+class AwsS3MultipartOperationsLocalstackSpec extends AbstractAwsS3MultipartSpec implements TestPropertyProvider {
+
+    @Shared
+    @AutoCleanup
+    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
+        .withServices("s3")
+
+    @Override
+    Map<String, String> getProperties() {
+        localstack.start()
+        super.getProperties() + [
+            'aws.accessKeyId': localstack.accessKey,
+            'aws.secretKey': localstack.secretKey,
+            'aws.region': localstack.region,
+            'aws.services.s3.endpoint-override': localstack.getEndpoint().toString()
+        ] as Map
+    }
+}

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3MultipartUploadRequestBodySpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3MultipartUploadRequestBodySpec.groovy
@@ -1,0 +1,97 @@
+package io.micronaut.objectstorage.aws
+
+import io.micronaut.objectstorage.InputStreamMapper
+import io.micronaut.objectstorage.MultipartUploadHandle
+import io.micronaut.objectstorage.ObjectStorageException
+import io.micronaut.objectstorage.request.UploadPartRequest
+import io.micronaut.objectstorage.request.UploadRequest
+import spock.lang.Specification
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.UploadPartResponse
+
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+
+class AwsS3MultipartUploadRequestBodySpec extends Specification {
+
+    void "it streams multipart parts when the upload request declares a content size"() {
+        given:
+        S3Client s3Client = Mock()
+        InputStreamMapper inputStreamMapper = Mock()
+        AwsS3Operations operations = new AwsS3Operations(configuration(), s3Client, inputStreamMapper)
+        UploadRequest uploadRequest = new StreamUploadRequest("videos/demo.mp4", [1, 2, 3, 4] as byte[], 4L)
+
+        when:
+        def response = operations.uploadPart(new UploadPartRequest(new MultipartUploadHandle("videos/demo.mp4", "upload-1"), 1, uploadRequest))
+
+        then:
+        1 * s3Client.uploadPart({
+            it.bucket() == "multipart-bucket" &&
+                it.key() == "videos/demo.mp4" &&
+                it.uploadId() == "upload-1" &&
+                it.partNumber() == 1 &&
+                it.contentLength() == 4L
+        }, _) >> UploadPartResponse.builder()
+            .eTag("etag-1")
+            .build()
+        0 * inputStreamMapper._
+        response.part.partNumber == 1
+        response.part.size == 4L
+        response.part.ETag == "etag-1"
+    }
+
+    void "it rejects streaming multipart parts without a content size"() {
+        given:
+        S3Client s3Client = Mock()
+        InputStreamMapper inputStreamMapper = Mock()
+        AwsS3Operations operations = new AwsS3Operations(configuration(), s3Client, inputStreamMapper)
+        UploadRequest uploadRequest = new StreamUploadRequest("videos/demo.mp4", [1, 2, 3, 4] as byte[], null)
+
+        when:
+        operations.uploadPart(new UploadPartRequest(new MultipartUploadHandle("videos/demo.mp4", "upload-1"), 1, uploadRequest))
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message == "Multipart uploads require UploadRequest#getContentSize() for streaming requests"
+        0 * s3Client._
+        0 * inputStreamMapper._
+    }
+
+    private static AwsS3Configuration configuration() {
+        AwsS3Configuration configuration = new AwsS3Configuration("default")
+        configuration.bucket = "multipart-bucket"
+        return configuration
+    }
+
+    private static final class StreamUploadRequest implements UploadRequest {
+        private final String key
+        private final byte[] bytes
+        private final Long contentSize
+
+        private StreamUploadRequest(String key, byte[] bytes, Long contentSize) {
+            this.key = key
+            this.bytes = bytes
+            this.contentSize = contentSize
+        }
+
+        @Override
+        Optional<String> getContentType() {
+            return Optional.empty()
+        }
+
+        @Override
+        String getKey() {
+            return key
+        }
+
+        @Override
+        Optional<Long> getContentSize() {
+            return Optional.ofNullable(contentSize)
+        }
+
+        @Override
+        InputStream getInputStream() {
+            return new ByteArrayInputStream(bytes)
+        }
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/MultipartObjectStorageOperations.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/MultipartObjectStorageOperations.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage;
+
+import io.micronaut.core.annotation.Blocking;
+import io.micronaut.objectstorage.request.AbortMultipartUploadRequest;
+import io.micronaut.objectstorage.request.CompleteMultipartUploadRequest;
+import io.micronaut.objectstorage.request.CreateMultipartUploadRequest;
+import io.micronaut.objectstorage.request.ListMultipartPartsRequest;
+import io.micronaut.objectstorage.request.UploadPartRequest;
+import io.micronaut.objectstorage.response.CompleteMultipartUploadResponse;
+import io.micronaut.objectstorage.response.CreateMultipartUploadResponse;
+import io.micronaut.objectstorage.response.ListMultipartPartsResponse;
+import io.micronaut.objectstorage.response.UploadPartResponse;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Portable multipart upload lifecycle operations.
+ *
+ * <p>This contract is additive to {@link ObjectStorageOperations}. Providers may implement it
+ * independently without affecting existing single-object upload consumers.</p>
+ *
+ * <p>Multipart upload handles are caller-owned resources until they are completed or aborted.
+ * Implementations must treat repeated abort requests as safe. Completing an upload requires an
+ * ordered part manifest, and retries are only safe when the same upload id and exact manifest are
+ * reused.</p>
+ *
+ * @param <C> Cloud vendor-specific create multipart upload response
+ * @param <U> Cloud vendor-specific upload part response
+ * @param <COMP> Cloud vendor-specific complete multipart upload response
+ * @since 3.0.0
+ */
+public interface MultipartObjectStorageOperations<C, U, COMP> {
+
+    /**
+     * Creates a new multipart upload and returns the opaque upload handle.
+     *
+     * @param request the create request
+     * @return the multipart upload handle and native response
+     * @throws ObjectStorageException if the multipart upload could not be created
+     */
+    @Blocking
+    @NonNull
+    CreateMultipartUploadResponse<C> createMultipartUpload(@NonNull CreateMultipartUploadRequest request);
+
+    /**
+     * Uploads a single part for an existing multipart upload.
+     *
+     * @param request the part upload request
+     * @return the uploaded part metadata and native response
+     * @throws ObjectStorageException if the part upload failed
+     */
+    @Blocking
+    @NonNull
+    UploadPartResponse<U> uploadPart(@NonNull UploadPartRequest request);
+
+    /**
+     * Lists uploaded parts for an in-progress multipart upload.
+     *
+     * @param request the list request
+     * @return the ordered parts in the current page and an optional continuation token
+     * @throws ObjectStorageException if listing fails
+     */
+    @Blocking
+    @NonNull
+    ListMultipartPartsResponse listParts(@NonNull ListMultipartPartsRequest request);
+
+    /**
+     * Completes a multipart upload using the provided ordered part manifest.
+     *
+     * @param request the complete request
+     * @return the completed upload response and native response
+     * @throws ObjectStorageException if completion fails
+     */
+    @Blocking
+    @NonNull
+    CompleteMultipartUploadResponse<COMP> completeMultipartUpload(@NonNull CompleteMultipartUploadRequest request);
+
+    /**
+     * Aborts an in-progress multipart upload.
+     *
+     * <p>This operation must be safe to retry.</p>
+     *
+     * @param request the abort request
+     * @throws ObjectStorageException if abort fails unexpectedly
+     */
+    @Blocking
+    void abortMultipartUpload(@NonNull AbortMultipartUploadRequest request);
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/MultipartPart.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/MultipartPart.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Portable multipart upload part metadata.
+ *
+ * @since 3.0.0
+ */
+public final class MultipartPart {
+
+    private final int partNumber;
+    private final String eTag;
+    private final long size;
+    @Nullable
+    private final String checksum;
+
+    /**
+     * @param partNumber the positive part number
+     * @param eTag the provider entity tag for the part
+     * @param size the uploaded part size in bytes
+     */
+    public MultipartPart(int partNumber, @NonNull String eTag, long size) {
+        this(partNumber, eTag, size, null);
+    }
+
+    /**
+     * @param partNumber the positive part number
+     * @param eTag the provider entity tag for the part
+     * @param size the uploaded part size in bytes
+     * @param checksum an optional portable checksum value
+     */
+    public MultipartPart(int partNumber, @NonNull String eTag, long size, @Nullable String checksum) {
+        if (partNumber <= 0) {
+            throw new IllegalArgumentException("partNumber must be greater than 0");
+        }
+        if (size < 0) {
+            throw new IllegalArgumentException("size must be greater than or equal to 0");
+        }
+        this.partNumber = partNumber;
+        this.eTag = Objects.requireNonNull(eTag, "eTag");
+        this.size = size;
+        this.checksum = normalize(checksum);
+    }
+
+    /**
+     * @return the positive part number
+     */
+    public int getPartNumber() {
+        return partNumber;
+    }
+
+    /**
+     * @return the provider entity tag for the part
+     */
+    @NonNull
+    public String getETag() {
+        return eTag;
+    }
+
+    /**
+     * @return the uploaded part size in bytes
+     */
+    public long getSize() {
+        return size;
+    }
+
+    /**
+     * @return an optional portable checksum value
+     */
+    @NonNull
+    public Optional<String> getChecksum() {
+        return Optional.ofNullable(checksum);
+    }
+
+    @Nullable
+    private static String normalize(@Nullable String value) {
+        return value == null || value.isEmpty() ? null : value;
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/MultipartUploadHandle.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/MultipartUploadHandle.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage;
+
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+
+/**
+ * Opaque multipart upload identity.
+ *
+ * @since 3.0.0
+ */
+public final class MultipartUploadHandle {
+
+    private final String key;
+    private final String uploadId;
+
+    /**
+     * @param key the target object key
+     * @param uploadId the opaque provider upload id
+     */
+    public MultipartUploadHandle(@NonNull String key, @NonNull String uploadId) {
+        this.key = Objects.requireNonNull(key, "key");
+        this.uploadId = Objects.requireNonNull(uploadId, "uploadId");
+    }
+
+    /**
+     * @return the target object key
+     */
+    @NonNull
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * @return the opaque provider upload id
+     */
+    @NonNull
+    public String getUploadId() {
+        return uploadId;
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/request/AbortMultipartUploadRequest.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/request/AbortMultipartUploadRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.request;
+
+import io.micronaut.objectstorage.MultipartUploadHandle;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+
+/**
+ * Multipart upload abort request.
+ *
+ * @since 3.0.0
+ */
+public final class AbortMultipartUploadRequest {
+
+    private final MultipartUploadHandle upload;
+
+    /**
+     * @param upload the multipart upload handle
+     */
+    public AbortMultipartUploadRequest(@NonNull MultipartUploadHandle upload) {
+        this.upload = Objects.requireNonNull(upload, "upload");
+    }
+
+    /**
+     * @return the multipart upload handle
+     */
+    @NonNull
+    public MultipartUploadHandle getUpload() {
+        return upload;
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/request/CompleteMultipartUploadRequest.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/request/CompleteMultipartUploadRequest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.request;
+
+import io.micronaut.objectstorage.MultipartPart;
+import io.micronaut.objectstorage.MultipartUploadHandle;
+import org.jspecify.annotations.NonNull;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Multipart upload completion request.
+ *
+ * @since 3.0.0
+ */
+public final class CompleteMultipartUploadRequest {
+
+    private final MultipartUploadHandle upload;
+    private final List<MultipartPart> parts;
+
+    /**
+     * @param upload the multipart upload handle
+     * @param parts the ordered part manifest to complete
+     */
+    public CompleteMultipartUploadRequest(@NonNull MultipartUploadHandle upload,
+                                          @NonNull List<MultipartPart> parts) {
+        this.upload = Objects.requireNonNull(upload, "upload");
+        Objects.requireNonNull(parts, "parts");
+        if (parts.isEmpty()) {
+            throw new IllegalArgumentException("parts must not be empty");
+        }
+        this.parts = validateOrdered(List.copyOf(parts));
+    }
+
+    /**
+     * @return the multipart upload handle
+     */
+    @NonNull
+    public MultipartUploadHandle getUpload() {
+        return upload;
+    }
+
+    /**
+     * @return the ordered part manifest
+     */
+    @NonNull
+    public List<MultipartPart> getParts() {
+        return parts;
+    }
+
+    @NonNull
+    private static List<MultipartPart> validateOrdered(@NonNull List<MultipartPart> parts) {
+        int previousPartNumber = 0;
+        for (MultipartPart part : parts) {
+            if (part.getPartNumber() <= previousPartNumber) {
+                throw new IllegalArgumentException("parts must be strictly ordered by part number");
+            }
+            previousPartNumber = part.getPartNumber();
+        }
+        return parts;
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/request/CreateMultipartUploadRequest.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/request/CreateMultipartUploadRequest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.request;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Multipart upload creation request.
+ *
+ * @since 3.0.0
+ */
+public final class CreateMultipartUploadRequest {
+
+    private final String key;
+    @Nullable
+    private final String contentType;
+    private final Map<String, String> metadata;
+
+    /**
+     * @param key the target object key
+     */
+    public CreateMultipartUploadRequest(@NonNull String key) {
+        this(key, null, Map.of());
+    }
+
+    /**
+     * @param key the target object key
+     * @param contentType the optional content type
+     */
+    public CreateMultipartUploadRequest(@NonNull String key, @Nullable String contentType) {
+        this(key, contentType, Map.of());
+    }
+
+    /**
+     * @param key the target object key
+     * @param contentType the optional content type
+     * @param metadata the optional object metadata
+     */
+    public CreateMultipartUploadRequest(@NonNull String key,
+                                        @Nullable String contentType,
+                                        @NonNull Map<String, String> metadata) {
+        this.key = Objects.requireNonNull(key, "key");
+        this.contentType = normalize(contentType);
+        this.metadata = Map.copyOf(Objects.requireNonNull(metadata, "metadata"));
+    }
+
+    /**
+     * @return the target object key
+     */
+    @NonNull
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * @return the optional content type
+     */
+    @NonNull
+    public Optional<String> getContentType() {
+        return Optional.ofNullable(contentType);
+    }
+
+    /**
+     * @return the optional object metadata
+     */
+    @NonNull
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    @Nullable
+    private static String normalize(@Nullable String value) {
+        return value == null || value.isEmpty() ? null : value;
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/request/ListMultipartPartsRequest.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/request/ListMultipartPartsRequest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.request;
+
+import io.micronaut.objectstorage.MultipartUploadHandle;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Multipart part listing request.
+ *
+ * @since 3.0.0
+ */
+public final class ListMultipartPartsRequest {
+
+    private final MultipartUploadHandle upload;
+    private final int pageSize;
+    @Nullable
+    private final String continuationToken;
+
+    /**
+     * @param upload the multipart upload handle
+     * @param pageSize the maximum number of parts to return
+     */
+    public ListMultipartPartsRequest(@NonNull MultipartUploadHandle upload, int pageSize) {
+        this(upload, pageSize, null);
+    }
+
+    /**
+     * @param upload the multipart upload handle
+     * @param pageSize the maximum number of parts to return
+     * @param continuationToken the opaque continuation token for the next page
+     */
+    public ListMultipartPartsRequest(@NonNull MultipartUploadHandle upload, int pageSize, @Nullable String continuationToken) {
+        if (pageSize <= 0) {
+            throw new IllegalArgumentException("pageSize must be greater than 0");
+        }
+        this.upload = Objects.requireNonNull(upload, "upload");
+        this.pageSize = pageSize;
+        this.continuationToken = normalize(continuationToken);
+    }
+
+    /**
+     * @return the multipart upload handle
+     */
+    @NonNull
+    public MultipartUploadHandle getUpload() {
+        return upload;
+    }
+
+    /**
+     * @return the maximum number of parts to return
+     */
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    /**
+     * @return the opaque continuation token for the next page, if present
+     */
+    @NonNull
+    public Optional<String> getContinuationToken() {
+        return Optional.ofNullable(continuationToken);
+    }
+
+    @Nullable
+    private static String normalize(@Nullable String value) {
+        return value == null || value.isEmpty() ? null : value;
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/request/UploadPartRequest.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/request/UploadPartRequest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.request;
+
+import io.micronaut.objectstorage.MultipartUploadHandle;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+
+/**
+ * Multipart part upload request.
+ *
+ * <p>The supplied {@link UploadRequest} must target the same key as the multipart upload handle.</p>
+ *
+ * @since 3.0.0
+ */
+public final class UploadPartRequest {
+
+    private final MultipartUploadHandle upload;
+    private final int partNumber;
+    private final UploadRequest uploadRequest;
+
+    /**
+     * @param upload the multipart upload handle
+     * @param partNumber the positive part number
+     * @param uploadRequest the payload upload request
+     */
+    public UploadPartRequest(@NonNull MultipartUploadHandle upload, int partNumber, @NonNull UploadRequest uploadRequest) {
+        this.upload = Objects.requireNonNull(upload, "upload");
+        if (partNumber <= 0) {
+            throw new IllegalArgumentException("partNumber must be greater than 0");
+        }
+        this.uploadRequest = Objects.requireNonNull(uploadRequest, "uploadRequest");
+        if (!upload.getKey().equals(uploadRequest.getKey())) {
+            throw new IllegalArgumentException("uploadRequest key must match the multipart upload key");
+        }
+        this.partNumber = partNumber;
+    }
+
+    /**
+     * @return the multipart upload handle
+     */
+    @NonNull
+    public MultipartUploadHandle getUpload() {
+        return upload;
+    }
+
+    /**
+     * @return the positive part number
+     */
+    public int getPartNumber() {
+        return partNumber;
+    }
+
+    /**
+     * @return the payload upload request
+     */
+    @NonNull
+    public UploadRequest getUploadRequest() {
+        return uploadRequest;
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/response/CompleteMultipartUploadResponse.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/response/CompleteMultipartUploadResponse.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.response;
+
+import io.micronaut.context.annotation.DefaultImplementation;
+import io.micronaut.objectstorage.MultipartUploadHandle;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Multipart upload completion response.
+ *
+ * @param <R> Cloud vendor-specific complete multipart upload response
+ * @since 3.0.0
+ */
+@DefaultImplementation(DefaultCompleteMultipartUploadResponse.class)
+public interface CompleteMultipartUploadResponse<R> {
+
+    /**
+     * Creates a multipart upload completion response.
+     *
+     * @param upload the multipart upload handle
+     * @param eTag the final object entity tag
+     * @param nativeResponse the native provider response
+     * @param <R> Cloud vendor-specific complete multipart upload response
+     * @return the response
+     */
+    @NonNull
+    static <R> CompleteMultipartUploadResponse<R> of(@NonNull MultipartUploadHandle upload,
+                                                     @NonNull String eTag,
+                                                     @NonNull R nativeResponse) {
+        return new DefaultCompleteMultipartUploadResponse<>(upload, eTag, nativeResponse);
+    }
+
+    /**
+     * @return the multipart upload handle
+     */
+    @NonNull
+    MultipartUploadHandle getUpload();
+
+    /**
+     * @return the final object entity tag
+     */
+    @NonNull
+    String getETag();
+
+    /**
+     * @return the native provider response
+     */
+    @NonNull
+    R getNativeResponse();
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/response/CreateMultipartUploadResponse.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/response/CreateMultipartUploadResponse.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.response;
+
+import io.micronaut.context.annotation.DefaultImplementation;
+import io.micronaut.objectstorage.MultipartUploadHandle;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Multipart upload creation response.
+ *
+ * @param <R> Cloud vendor-specific create multipart upload response
+ * @since 3.0.0
+ */
+@DefaultImplementation(DefaultCreateMultipartUploadResponse.class)
+public interface CreateMultipartUploadResponse<R> {
+
+    /**
+     * Creates a multipart upload creation response.
+     *
+     * @param upload the multipart upload handle
+     * @param nativeResponse the native provider response
+     * @param <R> Cloud vendor-specific create multipart upload response
+     * @return the response
+     */
+    @NonNull
+    static <R> CreateMultipartUploadResponse<R> of(@NonNull MultipartUploadHandle upload, @NonNull R nativeResponse) {
+        return new DefaultCreateMultipartUploadResponse<>(upload, nativeResponse);
+    }
+
+    /**
+     * @return the multipart upload handle
+     */
+    @NonNull
+    MultipartUploadHandle getUpload();
+
+    /**
+     * @return the native provider response
+     */
+    @NonNull
+    R getNativeResponse();
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/response/DefaultCompleteMultipartUploadResponse.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/response/DefaultCompleteMultipartUploadResponse.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.response;
+
+import io.micronaut.objectstorage.MultipartUploadHandle;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Default implementation of {@link CompleteMultipartUploadResponse}.
+ *
+ * @param <R> Cloud vendor-specific complete multipart upload response
+ */
+public class DefaultCompleteMultipartUploadResponse<R> implements CompleteMultipartUploadResponse<R> {
+
+    private final MultipartUploadHandle upload;
+    private final String eTag;
+    private final R nativeResponse;
+
+    protected DefaultCompleteMultipartUploadResponse(MultipartUploadHandle upload, String eTag, R nativeResponse) {
+        this.upload = upload;
+        this.eTag = eTag;
+        this.nativeResponse = nativeResponse;
+    }
+
+    @Override
+    @NonNull
+    public MultipartUploadHandle getUpload() {
+        return upload;
+    }
+
+    @Override
+    @NonNull
+    public String getETag() {
+        return eTag;
+    }
+
+    @Override
+    @NonNull
+    public R getNativeResponse() {
+        return nativeResponse;
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/response/DefaultCreateMultipartUploadResponse.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/response/DefaultCreateMultipartUploadResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.response;
+
+import io.micronaut.objectstorage.MultipartUploadHandle;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Default implementation of {@link CreateMultipartUploadResponse}.
+ *
+ * @param <R> Cloud vendor-specific create multipart upload response
+ */
+public class DefaultCreateMultipartUploadResponse<R> implements CreateMultipartUploadResponse<R> {
+
+    private final MultipartUploadHandle upload;
+    private final R nativeResponse;
+
+    protected DefaultCreateMultipartUploadResponse(MultipartUploadHandle upload, R nativeResponse) {
+        this.upload = upload;
+        this.nativeResponse = nativeResponse;
+    }
+
+    @Override
+    @NonNull
+    public MultipartUploadHandle getUpload() {
+        return upload;
+    }
+
+    @Override
+    @NonNull
+    public R getNativeResponse() {
+        return nativeResponse;
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/response/DefaultUploadPartResponse.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/response/DefaultUploadPartResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.response;
+
+import io.micronaut.objectstorage.MultipartPart;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Default implementation of {@link UploadPartResponse}.
+ *
+ * @param <R> Cloud vendor-specific upload part response
+ */
+public class DefaultUploadPartResponse<R> implements UploadPartResponse<R> {
+
+    private final MultipartPart part;
+    private final R nativeResponse;
+
+    protected DefaultUploadPartResponse(MultipartPart part, R nativeResponse) {
+        this.part = part;
+        this.nativeResponse = nativeResponse;
+    }
+
+    @Override
+    @NonNull
+    public MultipartPart getPart() {
+        return part;
+    }
+
+    @Override
+    @NonNull
+    public R getNativeResponse() {
+        return nativeResponse;
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/response/ListMultipartPartsResponse.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/response/ListMultipartPartsResponse.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.response;
+
+import io.micronaut.objectstorage.MultipartPart;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Paginated multipart part listing response.
+ *
+ * @since 3.0.0
+ */
+public final class ListMultipartPartsResponse {
+
+    private final List<MultipartPart> parts;
+    @Nullable
+    private final String continuationToken;
+
+    /**
+     * @param parts the ordered multipart parts in the current page
+     */
+    public ListMultipartPartsResponse(@NonNull List<MultipartPart> parts) {
+        this(parts, null);
+    }
+
+    /**
+     * @param parts the ordered multipart parts in the current page
+     * @param continuationToken the opaque continuation token for the next page
+     */
+    public ListMultipartPartsResponse(@NonNull List<MultipartPart> parts, @Nullable String continuationToken) {
+        this.parts = List.copyOf(parts);
+        this.continuationToken = continuationToken == null || continuationToken.isEmpty() ? null : continuationToken;
+    }
+
+    /**
+     * @return the ordered multipart parts in the current page
+     */
+    @NonNull
+    public List<MultipartPart> getParts() {
+        return parts;
+    }
+
+    /**
+     * @return the opaque continuation token for the next page, if present
+     */
+    @NonNull
+    public Optional<String> getContinuationToken() {
+        return Optional.ofNullable(continuationToken);
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/response/UploadPartResponse.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/response/UploadPartResponse.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.response;
+
+import io.micronaut.context.annotation.DefaultImplementation;
+import io.micronaut.objectstorage.MultipartPart;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Multipart part upload response.
+ *
+ * @param <R> Cloud vendor-specific upload part response
+ * @since 3.0.0
+ */
+@DefaultImplementation(DefaultUploadPartResponse.class)
+public interface UploadPartResponse<R> {
+
+    /**
+     * Creates a multipart upload part response.
+     *
+     * @param part the uploaded part metadata
+     * @param nativeResponse the native provider response
+     * @param <R> Cloud vendor-specific upload part response
+     * @return the response
+     */
+    @NonNull
+    static <R> UploadPartResponse<R> of(@NonNull MultipartPart part, @NonNull R nativeResponse) {
+        return new DefaultUploadPartResponse<>(part, nativeResponse);
+    }
+
+    /**
+     * @return the uploaded part metadata
+     */
+    @NonNull
+    MultipartPart getPart();
+
+    /**
+     * @return the native provider response
+     */
+    @NonNull
+    R getNativeResponse();
+}

--- a/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/MultipartObjectStorageOperationsSpecification.groovy
+++ b/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/MultipartObjectStorageOperationsSpecification.groovy
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage
+
+import io.micronaut.objectstorage.request.AbortMultipartUploadRequest
+import io.micronaut.objectstorage.request.CompleteMultipartUploadRequest
+import io.micronaut.objectstorage.request.CreateMultipartUploadRequest
+import io.micronaut.objectstorage.request.ListMultipartPartsRequest
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.objectstorage.request.UploadPartRequest
+import io.micronaut.objectstorage.response.ListMultipartPartsResponse
+import io.micronaut.objectstorage.response.UploadPartResponse
+import spock.util.concurrent.PollingConditions
+
+import java.nio.charset.StandardCharsets
+
+abstract class MultipartObjectStorageOperationsSpecification extends ObjectStorageOperationsSpecification {
+
+    private static final byte[] LARGE_FIRST_PART = ('a' * (5 * 1024 * 1024)).bytes
+    private static final String PART_ONE_TEXT = 'micro'
+    private static final String PART_TWO_TEXT = 'naut'
+    private static final String PART_THREE_TEXT = '-framework'
+
+    void 'it can create upload parts complete and retrieve multipart object'() {
+        given:
+        MultipartObjectStorageOperations<?, ?, ?> storage = getMultipartObjectStorage()
+        ObjectStorageOperations<?, ?, ?> objectStorage = getObjectStorage()
+        PollingConditions conditions = new PollingConditions(timeout: 10)
+        String key = "multipart/${System.nanoTime()}/combined.txt"
+
+        when:
+        def upload = storage.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE, METADATA)).upload
+        UploadPartResponse<?> firstPart = storage.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes(LARGE_FIRST_PART, key, CONTENT_TYPE)))
+        UploadPartResponse<?> secondPart = storage.uploadPart(new UploadPartRequest(upload, 2, UploadRequest.fromBytes(PART_TWO_TEXT.bytes, key, CONTENT_TYPE)))
+        def response = storage.completeMultipartUpload(new CompleteMultipartUploadRequest(upload, [firstPart.part, secondPart.part]))
+
+        then:
+        response.ETag
+        conditions.eventually {
+            assert objectStorage.retrieve(key).present
+        }
+        byte[] objectBytes = objectStorage.retrieve(key).get().inputStream.bytes
+        objectBytes.length == LARGE_FIRST_PART.length + PART_TWO_TEXT.bytes.length
+        objectBytes[0] == (byte) 'a'
+        objectBytes[LARGE_FIRST_PART.length - 1] == (byte) 'a'
+        new String(objectBytes, LARGE_FIRST_PART.length, PART_TWO_TEXT.bytes.length, StandardCharsets.UTF_8) == PART_TWO_TEXT
+
+        cleanup:
+        if (objectStorage.exists(key)) {
+            objectStorage.delete(key)
+        }
+    }
+
+    void 'it can list multipart parts with portable pagination semantics'() {
+        given:
+        MultipartObjectStorageOperations<?, ?, ?> storage = getMultipartObjectStorage()
+        String key = "multipart/${System.nanoTime()}/parts.txt"
+        def upload = storage.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE)).upload
+
+        and:
+        storage.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes(PART_ONE_TEXT.bytes, key, CONTENT_TYPE)))
+        storage.uploadPart(new UploadPartRequest(upload, 2, UploadRequest.fromBytes(PART_TWO_TEXT.bytes, key, CONTENT_TYPE)))
+        storage.uploadPart(new UploadPartRequest(upload, 3, UploadRequest.fromBytes(PART_THREE_TEXT.bytes, key, CONTENT_TYPE)))
+
+        when:
+        ListMultipartPartsRequest firstPageRequest = new ListMultipartPartsRequest(upload, 2)
+        ListMultipartPartsResponse firstPage = storage.listParts(firstPageRequest)
+        ListMultipartPartsResponse replayedFirstPage = storage.listParts(firstPageRequest)
+        List<ListMultipartPartsResponse> pages = collectMultipartPages(storage, firstPageRequest)
+        List<Integer> partNumbers = pages.collectMany { page -> page.parts*.partNumber }
+
+        then:
+        pages
+        pages.every { it.parts.size() <= firstPageRequest.pageSize }
+        replayedFirstPage.parts*.partNumber == firstPage.parts*.partNumber
+        replayedFirstPage.continuationToken == firstPage.continuationToken
+        pages.first().parts*.partNumber == firstPage.parts*.partNumber
+        pages.first().continuationToken == firstPage.continuationToken
+        pages.dropRight(1).every { it.parts }
+        adjacentMultipartPages(pages).every { pair -> !pair[0].parts*.partNumber.intersect(pair[1].parts*.partNumber) }
+        partNumbers == [1, 2, 3]
+        !pages.last().continuationToken.present
+
+        cleanup:
+        storage.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+    }
+
+    void 'abort multipart upload is safe to retry and removes the in progress upload'() {
+        given:
+        MultipartObjectStorageOperations<?, ?, ?> storage = getMultipartObjectStorage()
+        ObjectStorageOperations<?, ?, ?> objectStorage = getObjectStorage()
+        String key = "multipart/${System.nanoTime()}/abort.txt"
+        def upload = storage.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE)).upload
+        UploadPartResponse<?> uploadedPart = storage.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes(PART_ONE_TEXT.bytes, key, CONTENT_TYPE)))
+
+        when:
+        storage.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+        storage.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+
+        then:
+        !objectStorage.exists(key)
+
+        when:
+        storage.completeMultipartUpload(new CompleteMultipartUploadRequest(upload, [uploadedPart.part]))
+
+        then:
+        thrown(ObjectStorageException)
+    }
+
+    void 'complete multipart upload rejects misordered manifests'() {
+        given:
+        MultipartObjectStorageOperations<?, ?, ?> storage = getMultipartObjectStorage()
+        String key = "multipart/${System.nanoTime()}/misordered.txt"
+        def upload = storage.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE)).upload
+        UploadPartResponse<?> firstPart = storage.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes(PART_ONE_TEXT.bytes, key, CONTENT_TYPE)))
+        UploadPartResponse<?> secondPart = storage.uploadPart(new UploadPartRequest(upload, 2, UploadRequest.fromBytes(PART_TWO_TEXT.bytes, key, CONTENT_TYPE)))
+
+        when:
+        new CompleteMultipartUploadRequest(upload, [secondPart.part, firstPart.part])
+
+        then:
+        thrown(IllegalArgumentException)
+
+        cleanup:
+        storage.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+    }
+
+    void 'complete multipart upload rejects missing parts from the manifest'() {
+        given:
+        MultipartObjectStorageOperations<?, ?, ?> storage = getMultipartObjectStorage()
+        String key = "multipart/${System.nanoTime()}/missing-part.txt"
+        def upload = storage.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE)).upload
+        UploadPartResponse<?> uploadedPart = storage.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes(LARGE_FIRST_PART, key, CONTENT_TYPE)))
+        MultipartPart missingPart = new MultipartPart(2, 'missing-etag', PART_TWO_TEXT.bytes.length)
+
+        when:
+        storage.completeMultipartUpload(new CompleteMultipartUploadRequest(upload, [uploadedPart.part, missingPart]))
+
+        then:
+        thrown(ObjectStorageException)
+
+        cleanup:
+        storage.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+    }
+
+    abstract MultipartObjectStorageOperations<?, ?, ?> getMultipartObjectStorage()
+
+    private static List<ListMultipartPartsResponse> collectMultipartPages(MultipartObjectStorageOperations<?, ?, ?> storage,
+                                                                         ListMultipartPartsRequest request) {
+        List<ListMultipartPartsResponse> pages = []
+        ListMultipartPartsRequest currentRequest = request
+        Set<String> seenTokens = [] as Set
+        int maxPages = 8
+        while (true) {
+            ListMultipartPartsResponse page = storage.listParts(currentRequest)
+            pages << page
+            Optional<String> continuationToken = page.continuationToken
+            if (!continuationToken.present) {
+                return pages
+            }
+            assert seenTokens.add(continuationToken.get()): 'Repeated continuation token returned while collecting multipart pages'
+            assert pages.size() <= maxPages: 'Exceeded maximum expected multipart page count while collecting pages'
+            currentRequest = new ListMultipartPartsRequest(request.upload, request.pageSize, continuationToken.get())
+        }
+    }
+
+    private static List<List<ListMultipartPartsResponse>> adjacentMultipartPages(List<ListMultipartPartsResponse> pages) {
+        (0..<Math.max(pages.size() - 1, 0)).collect { index ->
+            [pages[index], pages[index + 1]]
+        }
+    }
+}

--- a/src/main/docs/guide/aws.adoc
+++ b/src/main/docs/guide/aws.adoc
@@ -18,6 +18,7 @@ include::doc-examples/example-java/src/test/resources/application-ec2.yml[]
 ----
 
 The concrete implementation of `ObjectStorageOperations` is api:objectstorage.aws.AwsS3Operations[].
+It also implements api:objectstorage.MultipartObjectStorageOperations[] for multipart upload lifecycle support.
 
 You can also resolve objects through Micronaut's `ResourceLoader` abstraction:
 
@@ -35,5 +36,8 @@ https://docs.micronaut.io/latest/guide/#events[`BeanCreatedEventListener`]. For 
 ----
 include::doc-examples/example-java/src/main/java/example/aws/S3ClientBuilderCustomizer.java[tags="class"]
 ----
+
+See api:objectstorage.MultipartObjectStorageOperations[] and the <<multipartUploads,Multipart Uploads>> guide for the
+portable multipart lifecycle contract.
 
 TIP: See the guide for https://guides.micronaut.io/latest/micronaut-object-storage-aws.html[Use the Micronaut Object Storage API to Store Files in Amazon S3] to learn more.

--- a/src/main/docs/guide/multipartUploads.adoc
+++ b/src/main/docs/guide/multipartUploads.adoc
@@ -1,0 +1,79 @@
+Multipart uploads are available through api:objectstorage.MultipartObjectStorageOperations[].
+This contract is additive to api:objectstorage.ObjectStorageOperations[] so existing single-object upload code does not change.
+
+The multipart lifecycle uses the following portable request and response types:
+
+- api:objectstorage.request.CreateMultipartUploadRequest[]
+- api:objectstorage.request.UploadPartRequest[]
+- api:objectstorage.request.ListMultipartPartsRequest[]
+- api:objectstorage.request.CompleteMultipartUploadRequest[]
+- api:objectstorage.request.AbortMultipartUploadRequest[]
+- api:objectstorage.MultipartUploadHandle[]
+- api:objectstorage.MultipartPart[]
+
+== Support Matrix
+
+[cols="1,1"]
+|===
+| Backend | Multipart lifecycle support
+
+| Amazon S3
+| Supported
+
+| Azure Blob Storage
+| Not yet supported
+
+| Google Cloud Storage
+| Not yet supported
+
+| Oracle Cloud Infrastructure Object Storage
+| Not yet supported
+
+| Local Storage
+| Not yet supported
+|===
+
+== Lifecycle Rules
+
+- `createMultipartUpload` returns an opaque upload id and does not imply any background cleanup guarantee.
+- In-progress multipart uploads remain caller-owned resources until they are completed or aborted.
+- `uploadPart` associates a numbered part with a previously created upload handle.
+- `listParts` is read-only and exposes provider pagination through opaque continuation tokens.
+- `completeMultipartUpload` requires a strictly ordered part manifest.
+- Retrying `completeMultipartUpload` is only safe when reusing the same upload id and exact part manifest.
+- `abortMultipartUpload` is safe to retry.
+
+== Example
+
+[source,java]
+----
+import io.micronaut.objectstorage.MultipartObjectStorageOperations;
+import io.micronaut.objectstorage.request.AbortMultipartUploadRequest;
+import io.micronaut.objectstorage.request.CompleteMultipartUploadRequest;
+import io.micronaut.objectstorage.request.CreateMultipartUploadRequest;
+import io.micronaut.objectstorage.request.UploadPartRequest;
+import io.micronaut.objectstorage.request.UploadRequest;
+
+MultipartObjectStorageOperations<?, ?, ?> multipart = ...
+
+var createResponse = multipart.createMultipartUpload(
+    new CreateMultipartUploadRequest("videos/demo.mp4", "video/mp4")
+);
+var upload = createResponse.getUpload();
+
+var firstPart = multipart.uploadPart(
+    new UploadPartRequest(upload, 1, UploadRequest.fromBytes(chunkOne, upload.getKey(), "video/mp4"))
+);
+var secondPart = multipart.uploadPart(
+    new UploadPartRequest(upload, 2, UploadRequest.fromBytes(chunkTwo, upload.getKey(), "video/mp4"))
+);
+
+try {
+    multipart.completeMultipartUpload(
+        new CompleteMultipartUploadRequest(upload, List.of(firstPart.getPart(), secondPart.getPart()))
+    );
+} catch (RuntimeException e) {
+    multipart.abortMultipartUpload(new AbortMultipartUploadRequest(upload));
+    throw e;
+}
+----

--- a/src/main/docs/guide/multipartUploads.adoc
+++ b/src/main/docs/guide/multipartUploads.adoc
@@ -53,6 +53,7 @@ import io.micronaut.objectstorage.request.CompleteMultipartUploadRequest;
 import io.micronaut.objectstorage.request.CreateMultipartUploadRequest;
 import io.micronaut.objectstorage.request.UploadPartRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
+import java.util.List;
 
 MultipartObjectStorageOperations<?, ?, ?> multipart = ...
 
@@ -77,3 +78,7 @@ try {
     throw e;
 }
 ----
+
+When uploading multipart parts from a stream-backed request instead of a file or byte array, provide
+the content size up front so providers such as Amazon S3 can stream the part without buffering it
+fully in memory.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -4,6 +4,7 @@ quickStart: Quick Start
 reactiveOperations: Reactive Operations
 preSignedUploads: Pre-Signed Uploads
 paginatedListing: Paginated Listing
+multipartUploads: Multipart Uploads
 bucketManagement: Bucket and Container Management
 aws: Amazon S3
 azure: Azure Blob Storage

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -4,6 +4,7 @@ quickStart: Quick Start
 reactiveOperations: Reactive Operations
 preSignedUploads: Pre-Signed Uploads
 paginatedListing: Paginated Listing
+multipartUploads: Multipart Uploads
 bucketManagement: Bucket and Container Management
 metadataPersistence: Metadata Persistence SPI
 aws: Amazon S3


### PR DESCRIPTION
## Summary
- add an additive `MultipartObjectStorageOperations` SPI and multipart request/response/value models in core
- implement the multipart lifecycle for AWS S3 and cover it with multipart TCK and LocalStack-backed specs
- document multipart lifecycle guarantees, caller cleanup expectations, and current backend support

## Verification
- `./gradlew --no-daemon -Dorg.gradle.jvmargs='-Xmx2g -XX:MaxMetaspaceSize=512m' :micronaut-object-storage-aws:test --tests 'io.micronaut.objectstorage.aws.AwsS3MultipartOperationsLocalstackSpec'`
- `./gradlew --no-daemon -Dorg.gradle.jvmargs='-Xmx2g -XX:MaxMetaspaceSize=512m' :micronaut-object-storage-core:test :micronaut-object-storage-core:japiCmp :micronaut-object-storage-tck:spotlessCheck :micronaut-object-storage-aws:spotlessCheck :micronaut-object-storage-aws:japiCmp docs`

Closes #755