### PR TITLE
feat: add storage metadata persistence SPI

### DIFF
--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/internal/DefaultReactiveBucketMetadataOperations.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/internal/DefaultReactiveBucketMetadataOperations.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.internal;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.objectstorage.metadata.BucketMetadataEntry;
+import io.micronaut.objectstorage.metadata.BucketMetadataOperations;
+import io.micronaut.objectstorage.metadata.BucketMetadataWrite;
+import io.micronaut.objectstorage.metadata.ReactiveBucketMetadataOperations;
+import org.jspecify.annotations.NonNull;
+import org.reactivestreams.Publisher;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
+
+/**
+ * Executor-backed reactive adapter for the blocking bucket metadata contract.
+ *
+ * @param <T> The provider-native metadata representation type.
+ * @since 3.0.0
+ * @author Álvaro Sánchez-Mariscal
+ */
+@Internal
+public class DefaultReactiveBucketMetadataOperations<T> implements ReactiveBucketMetadataOperations<T> {
+
+    private final BucketMetadataOperations<T> delegate;
+    private final ExecutorService blockingExecutor;
+
+    public DefaultReactiveBucketMetadataOperations(BucketMetadataOperations<T> delegate,
+                                                   ExecutorService blockingExecutor) {
+        this.delegate = delegate;
+        this.blockingExecutor = blockingExecutor;
+    }
+
+    @Override
+    @NonNull
+    public Publisher<Optional<BucketMetadataEntry<T>>> retrieve(@NonNull String name) {
+        return supply(() -> delegate.retrieve(name));
+    }
+
+    @Override
+    @NonNull
+    public Publisher<Void> save(@NonNull BucketMetadataWrite write) {
+        return Publishers.onComplete(
+            Publishers.empty(),
+            () -> CompletableFuture.runAsync(() -> delegate.save(write), blockingExecutor)
+                .thenApply(ignored -> null)
+        );
+    }
+
+    @Override
+    @NonNull
+    public Publisher<Void> delete(@NonNull String name) {
+        return Publishers.onComplete(
+            Publishers.empty(),
+            () -> CompletableFuture.runAsync(() -> delegate.delete(name), blockingExecutor)
+                .thenApply(ignored -> null)
+        );
+    }
+
+    @Override
+    @NonNull
+    public Publisher<Boolean> exists(@NonNull String name) {
+        return supply(() -> delegate.exists(name));
+    }
+
+    private <E> Publisher<E> supply(Supplier<E> supplier) {
+        return Publishers.fromCompletableFuture(() -> CompletableFuture.supplyAsync(supplier, blockingExecutor));
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/internal/DefaultReactiveObjectMetadataOperations.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/internal/DefaultReactiveObjectMetadataOperations.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.internal;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.objectstorage.metadata.ObjectMetadataEntry;
+import io.micronaut.objectstorage.metadata.ObjectMetadataOperations;
+import io.micronaut.objectstorage.metadata.ObjectMetadataWrite;
+import io.micronaut.objectstorage.metadata.ReactiveObjectMetadataOperations;
+import org.jspecify.annotations.NonNull;
+import org.reactivestreams.Publisher;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
+
+/**
+ * Executor-backed reactive adapter for the blocking object metadata contract.
+ *
+ * @param <T> The provider-native metadata representation type.
+ * @since 3.0.0
+ * @author Álvaro Sánchez-Mariscal
+ */
+@Internal
+public class DefaultReactiveObjectMetadataOperations<T> implements ReactiveObjectMetadataOperations<T> {
+
+    private final ObjectMetadataOperations<T> delegate;
+    private final ExecutorService blockingExecutor;
+
+    public DefaultReactiveObjectMetadataOperations(ObjectMetadataOperations<T> delegate,
+                                                   ExecutorService blockingExecutor) {
+        this.delegate = delegate;
+        this.blockingExecutor = blockingExecutor;
+    }
+
+    @Override
+    @NonNull
+    public Publisher<Optional<ObjectMetadataEntry<T>>> retrieve(@NonNull String key) {
+        return supply(() -> delegate.retrieve(key));
+    }
+
+    @Override
+    @NonNull
+    public Publisher<Void> save(@NonNull ObjectMetadataWrite write) {
+        return Publishers.onComplete(
+            Publishers.empty(),
+            () -> CompletableFuture.runAsync(() -> delegate.save(write), blockingExecutor)
+                .thenApply(ignored -> null)
+        );
+    }
+
+    @Override
+    @NonNull
+    public Publisher<Void> delete(@NonNull String key) {
+        return Publishers.onComplete(
+            Publishers.empty(),
+            () -> CompletableFuture.runAsync(() -> delegate.delete(key), blockingExecutor)
+                .thenApply(ignored -> null)
+        );
+    }
+
+    @Override
+    @NonNull
+    public Publisher<Boolean> exists(@NonNull String key) {
+        return supply(() -> delegate.exists(key));
+    }
+
+    private <E> Publisher<E> supply(Supplier<E> supplier) {
+        return Publishers.fromCompletableFuture(() -> CompletableFuture.supplyAsync(supplier, blockingExecutor));
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/BucketMetadataEntry.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/BucketMetadataEntry.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Map;
+
+/**
+ * Portable bucket or container metadata snapshot.
+ *
+ * @param name The logical bucket or container name.
+ * @param metadata User metadata.
+ * @param attributes Portable custom attributes.
+ * @param nativeEntry The provider-native metadata representation.
+ * @param <T> The provider-native metadata representation type.
+ * @since 3.0.0
+ * @author Álvaro Sánchez-Mariscal
+ */
+public record BucketMetadataEntry<T>(
+    @NonNull String name,
+    @NonNull Map<String, String> metadata,
+    @NonNull Map<String, String> attributes,
+    @Nullable T nativeEntry
+) {
+    public BucketMetadataEntry {
+        metadata = Map.copyOf(metadata);
+        attributes = Map.copyOf(attributes);
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/BucketMetadataOperations.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/BucketMetadataOperations.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import io.micronaut.core.annotation.Blocking;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Optional;
+
+/**
+ * Portable metadata persistence contract for buckets and containers.
+ *
+ * <p>{@link #save(BucketMetadataWrite)} uses replace/upsert semantics for the portable metadata
+ * snapshot. {@link #delete(String)} is idempotent.</p>
+ *
+ * @param <T> The provider-native metadata representation type.
+ * @since 3.0.0
+ * @author Álvaro Sánchez-Mariscal
+ */
+public interface BucketMetadataOperations<T> {
+
+    /**
+     * Retrieves the stored metadata snapshot for a bucket or container.
+     *
+     * @param name The bucket or container name.
+     * @return The metadata entry, or {@link Optional#empty()} if no metadata snapshot exists.
+     */
+    @Blocking
+    @NonNull
+    Optional<BucketMetadataEntry<T>> retrieve(@NonNull String name);
+
+    /**
+     * Saves a metadata snapshot for a bucket or container.
+     *
+     * @param write The metadata snapshot to persist.
+     */
+    @Blocking
+    void save(@NonNull BucketMetadataWrite write);
+
+    /**
+     * Deletes the metadata snapshot for a bucket or container.
+     *
+     * @param name The bucket or container name.
+     */
+    @Blocking
+    void delete(@NonNull String name);
+
+    /**
+     * Checks whether a metadata snapshot exists for a bucket or container.
+     *
+     * @param name The bucket or container name.
+     * @return {@code true} if metadata exists for the bucket or container.
+     */
+    @Blocking
+    default boolean exists(@NonNull String name) {
+        return retrieve(name).isPresent();
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/BucketMetadataWrite.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/BucketMetadataWrite.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import org.jspecify.annotations.NonNull;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Portable bucket or container metadata write model.
+ *
+ * <p>This write model represents a full metadata snapshot. Implementations should treat save
+ * operations as replace/upsert, not patch/merge.</p>
+ *
+ * @param name The logical bucket or container name.
+ * @param metadata User metadata.
+ * @param attributes Portable custom attributes.
+ * @since 3.0.0
+ * @author Álvaro Sánchez-Mariscal
+ */
+public record BucketMetadataWrite(
+    @NonNull String name,
+    @NonNull Map<String, String> metadata,
+    @NonNull Map<String, String> attributes
+) {
+    public BucketMetadataWrite {
+        metadata = Map.copyOf(metadata);
+        attributes = Map.copyOf(attributes);
+    }
+
+    /**
+     * Creates a metadata write with metadata only.
+     *
+     * @param name The logical bucket or container name.
+     * @param metadata User metadata.
+     */
+    public BucketMetadataWrite(@NonNull String name, @NonNull Map<String, String> metadata) {
+        this(name, metadata, Collections.emptyMap());
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectMetadataEntry.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectMetadataEntry.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Portable object metadata snapshot.
+ *
+ * @param key The object key.
+ * @param metadata User metadata.
+ * @param attributes Portable custom attributes.
+ * @param contentType The optional content type.
+ * @param contentLength The optional content length.
+ * @param etag The optional entity tag.
+ * @param lastModified The optional last modified instant.
+ * @param nativeEntry The provider-native metadata representation.
+ * @param <T> The provider-native metadata representation type.
+ * @since 3.0.0
+ * @author Álvaro Sánchez-Mariscal
+ */
+public record ObjectMetadataEntry<T>(
+    @NonNull String key,
+    @NonNull Map<String, String> metadata,
+    @NonNull Map<String, String> attributes,
+    @Nullable String contentType,
+    @Nullable Long contentLength,
+    @Nullable String etag,
+    @Nullable Instant lastModified,
+    @Nullable T nativeEntry
+) {
+    public ObjectMetadataEntry {
+        metadata = Map.copyOf(metadata);
+        attributes = Map.copyOf(attributes);
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectMetadataOperations.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectMetadataOperations.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import io.micronaut.core.annotation.Blocking;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Optional;
+
+/**
+ * Portable metadata persistence contract for stored objects.
+ *
+ * <p>This contract is intentionally additive and does not widen
+ * {@code ObjectStorageOperations}. Implementations may persist metadata in a store that is separate
+ * from the raw object content.</p>
+ *
+ * <p>{@link #save(ObjectMetadataWrite)} uses replace/upsert semantics for the portable metadata
+ * snapshot. {@link #delete(String)} is idempotent.</p>
+ *
+ * @param <T> The provider-native metadata representation type.
+ * @since 3.0.0
+ * @author Álvaro Sánchez-Mariscal
+ */
+public interface ObjectMetadataOperations<T> {
+
+    /**
+     * Retrieves the stored metadata snapshot for an object.
+     *
+     * @param key The object key.
+     * @return The metadata entry, or {@link Optional#empty()} if no metadata snapshot exists.
+     */
+    @Blocking
+    @NonNull
+    Optional<ObjectMetadataEntry<T>> retrieve(@NonNull String key);
+
+    /**
+     * Saves a metadata snapshot for an object.
+     *
+     * @param write The metadata snapshot to persist.
+     */
+    @Blocking
+    void save(@NonNull ObjectMetadataWrite write);
+
+    /**
+     * Deletes the metadata snapshot for an object.
+     *
+     * @param key The object key.
+     */
+    @Blocking
+    void delete(@NonNull String key);
+
+    /**
+     * Checks whether a metadata snapshot exists for an object.
+     *
+     * @param key The object key.
+     * @return {@code true} if metadata exists for the object.
+     */
+    @Blocking
+    default boolean exists(@NonNull String key) {
+        return retrieve(key).isPresent();
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectMetadataWrite.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ObjectMetadataWrite.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Portable object metadata write model.
+ *
+ * <p>This write model represents a full metadata snapshot. Implementations should treat save
+ * operations as replace/upsert, not patch/merge.</p>
+ *
+ * @param key The object key.
+ * @param metadata User metadata.
+ * @param attributes Portable custom attributes.
+ * @param contentType The optional content type.
+ * @param contentLength The optional content length.
+ * @param etag The optional entity tag.
+ * @param lastModified The optional last modified instant.
+ * @since 3.0.0
+ * @author Álvaro Sánchez-Mariscal
+ */
+public record ObjectMetadataWrite(
+    @NonNull String key,
+    @NonNull Map<String, String> metadata,
+    @NonNull Map<String, String> attributes,
+    @Nullable String contentType,
+    @Nullable Long contentLength,
+    @Nullable String etag,
+    @Nullable Instant lastModified
+) {
+    public ObjectMetadataWrite {
+        metadata = Map.copyOf(metadata);
+        attributes = Map.copyOf(attributes);
+    }
+
+    /**
+     * Creates a metadata write with metadata only.
+     *
+     * @param key The object key.
+     * @param metadata User metadata.
+     */
+    public ObjectMetadataWrite(@NonNull String key, @NonNull Map<String, String> metadata) {
+        this(key, metadata, Collections.emptyMap(), null, null, null, null);
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ReactiveBucketMetadataOperations.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ReactiveBucketMetadataOperations.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import org.jspecify.annotations.NonNull;
+import org.reactivestreams.Publisher;
+
+import java.util.Optional;
+
+/**
+ * Reactive companion contract for bucket and container metadata persistence.
+ *
+ * @param <T> The provider-native metadata representation type.
+ * @since 3.0.0
+ * @author Álvaro Sánchez-Mariscal
+ */
+public interface ReactiveBucketMetadataOperations<T> {
+
+    /**
+     * Retrieves the stored metadata snapshot for a bucket or container.
+     *
+     * @param name The bucket or container name.
+     * @return A publisher that emits the metadata entry if one exists.
+     */
+    @NonNull
+    Publisher<Optional<BucketMetadataEntry<T>>> retrieve(@NonNull String name);
+
+    /**
+     * Saves a metadata snapshot for a bucket or container.
+     *
+     * @param write The metadata snapshot to persist.
+     * @return A completion-only publisher.
+     */
+    @NonNull
+    Publisher<Void> save(@NonNull BucketMetadataWrite write);
+
+    /**
+     * Deletes the metadata snapshot for a bucket or container.
+     *
+     * @param name The bucket or container name.
+     * @return A completion-only publisher.
+     */
+    @NonNull
+    Publisher<Void> delete(@NonNull String name);
+
+    /**
+     * Checks whether a metadata snapshot exists for a bucket or container.
+     *
+     * @param name The bucket or container name.
+     * @return A publisher that emits {@code true} if metadata exists for the bucket or container.
+     */
+    @NonNull
+    Publisher<Boolean> exists(@NonNull String name);
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ReactiveObjectMetadataOperations.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/metadata/ReactiveObjectMetadataOperations.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.metadata;
+
+import org.jspecify.annotations.NonNull;
+import org.reactivestreams.Publisher;
+
+import java.util.Optional;
+
+/**
+ * Reactive companion contract for object metadata persistence.
+ *
+ * @param <T> The provider-native metadata representation type.
+ * @since 3.0.0
+ * @author Álvaro Sánchez-Mariscal
+ */
+public interface ReactiveObjectMetadataOperations<T> {
+
+    /**
+     * Retrieves the stored metadata snapshot for an object.
+     *
+     * @param key The object key.
+     * @return A publisher that emits the metadata entry if one exists.
+     */
+    @NonNull
+    Publisher<Optional<ObjectMetadataEntry<T>>> retrieve(@NonNull String key);
+
+    /**
+     * Saves a metadata snapshot for an object.
+     *
+     * @param write The metadata snapshot to persist.
+     * @return A completion-only publisher.
+     */
+    @NonNull
+    Publisher<Void> save(@NonNull ObjectMetadataWrite write);
+
+    /**
+     * Deletes the metadata snapshot for an object.
+     *
+     * @param key The object key.
+     * @return A completion-only publisher.
+     */
+    @NonNull
+    Publisher<Void> delete(@NonNull String key);
+
+    /**
+     * Checks whether a metadata snapshot exists for an object.
+     *
+     * @param key The object key.
+     * @return A publisher that emits {@code true} if metadata exists for the object.
+     */
+    @NonNull
+    Publisher<Boolean> exists(@NonNull String key);
+}

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/internal/DefaultReactiveBucketMetadataOperationsSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/internal/DefaultReactiveBucketMetadataOperationsSpec.groovy
@@ -1,0 +1,57 @@
+package io.micronaut.objectstorage.internal
+
+import io.micronaut.objectstorage.metadata.BucketMetadataEntry
+import io.micronaut.objectstorage.metadata.BucketMetadataOperations
+import io.micronaut.objectstorage.metadata.BucketMetadataWrite
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+class DefaultReactiveBucketMetadataOperationsSpec extends Specification {
+
+    private final ExecutorService executor = Executors.newSingleThreadExecutor()
+
+    void cleanup() {
+        executor.shutdownNow()
+    }
+
+    void "reactive adapter delegates save and delete as completion-only publishers"() {
+        given:
+        BucketMetadataOperations<String> delegate = Mock()
+        DefaultReactiveBucketMetadataOperations<String> operations =
+            new DefaultReactiveBucketMetadataOperations<>(delegate, executor)
+        BucketMetadataWrite write = new BucketMetadataWrite("reports", [region: "test"], [owner: "cliponaut"])
+
+        when:
+        List<Void> saveSignals = Flux.from(operations.save(write)).collectList().block()
+        List<Void> deleteSignals = Flux.from(operations.delete("reports")).collectList().block()
+
+        then:
+        saveSignals.empty
+        deleteSignals.empty
+        1 * delegate.save(write)
+        1 * delegate.delete("reports")
+    }
+
+    void "reactive adapter emits retrieve and exists results"() {
+        given:
+        BucketMetadataOperations<String> delegate = Mock()
+        DefaultReactiveBucketMetadataOperations<String> operations =
+            new DefaultReactiveBucketMetadataOperations<>(delegate, executor)
+        BucketMetadataEntry<String> entry = new BucketMetadataEntry<>("reports", [region: "test"], [owner: "cliponaut"], "native")
+
+        when:
+        Optional<BucketMetadataEntry<String>> retrieveResult = Mono.from(operations.retrieve("reports")).block()
+        Boolean exists = Mono.from(operations.exists("reports")).block()
+
+        then:
+        retrieveResult.present
+        retrieveResult.get() == entry
+        exists
+        1 * delegate.retrieve("reports") >> Optional.of(entry)
+        1 * delegate.exists("reports") >> true
+    }
+}

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/internal/DefaultReactiveObjectMetadataOperationsSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/internal/DefaultReactiveObjectMetadataOperationsSpec.groovy
@@ -1,0 +1,58 @@
+package io.micronaut.objectstorage.internal
+
+import io.micronaut.objectstorage.metadata.ObjectMetadataEntry
+import io.micronaut.objectstorage.metadata.ObjectMetadataOperations
+import io.micronaut.objectstorage.metadata.ObjectMetadataWrite
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+class DefaultReactiveObjectMetadataOperationsSpec extends Specification {
+
+    private final ExecutorService executor = Executors.newSingleThreadExecutor()
+
+    void cleanup() {
+        executor.shutdownNow()
+    }
+
+    void "reactive adapter delegates save and delete as completion-only publishers"() {
+        given:
+        ObjectMetadataOperations<String> delegate = Mock()
+        DefaultReactiveObjectMetadataOperations<String> operations =
+            new DefaultReactiveObjectMetadataOperations<>(delegate, executor)
+        ObjectMetadataWrite write = new ObjectMetadataWrite("reports/2026.txt", [team: "core"], [owner: "cliponaut"], "text/plain", 42L, null, null)
+
+        when:
+        List<Void> saveSignals = Flux.from(operations.save(write)).collectList().block()
+        List<Void> deleteSignals = Flux.from(operations.delete("reports/2026.txt")).collectList().block()
+
+        then:
+        saveSignals.empty
+        deleteSignals.empty
+        1 * delegate.save(write)
+        1 * delegate.delete("reports/2026.txt")
+    }
+
+    void "reactive adapter emits retrieve and exists results"() {
+        given:
+        ObjectMetadataOperations<String> delegate = Mock()
+        DefaultReactiveObjectMetadataOperations<String> operations =
+            new DefaultReactiveObjectMetadataOperations<>(delegate, executor)
+        ObjectMetadataEntry<String> entry =
+            new ObjectMetadataEntry<>("reports/2026.txt", [team: "core"], [owner: "cliponaut"], "text/plain", 42L, "etag", null, "native")
+
+        when:
+        Optional<ObjectMetadataEntry<String>> retrieveResult = Mono.from(operations.retrieve("reports/2026.txt")).block()
+        Boolean exists = Mono.from(operations.exists("reports/2026.txt")).block()
+
+        then:
+        retrieveResult.present
+        retrieveResult.get() == entry
+        exists
+        1 * delegate.retrieve("reports/2026.txt") >> Optional.of(entry)
+        1 * delegate.exists("reports/2026.txt") >> true
+    }
+}

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperations.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.local;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.objectstorage.ObjectStorageException;
+import io.micronaut.objectstorage.metadata.BucketMetadataEntry;
+import io.micronaut.objectstorage.metadata.BucketMetadataOperations;
+import io.micronaut.objectstorage.metadata.BucketMetadataWrite;
+import org.jspecify.annotations.NonNull;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Properties;
+
+/**
+ * Local bucket metadata operations.
+ *
+ * @since 3.0.0
+ * @author Álvaro Sánchez-Mariscal
+ */
+@EachBean(LocalStorageConfiguration.class)
+final class LocalStorageBucketMetadataOperations implements BucketMetadataOperations<Path> {
+
+    private static final String BUCKETS_DIRECTORY = "buckets";
+
+    private final Path rootDirectory;
+    private final Path metadataRoot;
+    private final boolean supportsPosixPermissions;
+
+    LocalStorageBucketMetadataOperations(@Parameter LocalStorageConfiguration configuration) {
+        Path configuredBucketPath = configuration.getPath().toAbsolutePath().normalize();
+        this.rootDirectory = configuredBucketPath.getParent();
+        if (rootDirectory == null) {
+            throw new IllegalArgumentException("Local storage bucket metadata operations require a bucket path with a parent directory");
+        }
+        this.metadataRoot = rootDirectory.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve(BUCKETS_DIRECTORY);
+        this.supportsPosixPermissions = rootDirectory.getFileSystem().supportedFileAttributeViews().contains("posix");
+        if (!LocalStorageIoSupport.mkdirs(metadataRoot, metadataRoot, supportsPosixPermissions)) {
+            throw new ObjectStorageException("Error creating bucket metadata directory: " + metadataRoot);
+        }
+    }
+
+    @Override
+    @NonNull
+    public Optional<BucketMetadataEntry<Path>> retrieve(@NonNull String name) {
+        Path metadataFile = metadataFilePath(name);
+        if (!Files.exists(metadataFile, LinkOption.NOFOLLOW_LINKS)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(LocalStorageMetadataSupport.readBucketMetadata(metadataFile, name));
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error reading metadata for bucket: " + name, e);
+        }
+    }
+
+    @Override
+    public void save(@NonNull BucketMetadataWrite write) {
+        Path bucketPath = LocalStorageIoSupport.resolveBucketPath(rootDirectory, write.name());
+        if (!Files.isDirectory(bucketPath, LinkOption.NOFOLLOW_LINKS)) {
+            throw new ObjectStorageException("Cannot persist metadata for a missing bucket: " + write.name());
+        }
+        Path metadataFile = metadataFilePath(write.name());
+        if (!LocalStorageIoSupport.mkdirs(metadataRoot, metadataFile.getParent(), supportsPosixPermissions)) {
+            throw new ObjectStorageException("Error creating metadata directories for bucket: " + write.name());
+        }
+        Properties properties = LocalStorageMetadataSupport.toProperties(write);
+        try (OutputStream metadataOut = LocalStorageIoSupport.newOutputStreamNoFollow(metadataFile, supportsPosixPermissions)) {
+            properties.store(metadataOut, "Metadata for bucket: " + write.name());
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error storing metadata for bucket: " + write.name(), e);
+        }
+    }
+
+    @Override
+    public void delete(@NonNull String name) {
+        Path metadataFile = metadataFilePath(name);
+        if (Files.exists(metadataFile, LinkOption.NOFOLLOW_LINKS)) {
+            try {
+                Files.delete(metadataFile);
+            } catch (IOException e) {
+                throw new ObjectStorageException("Error deleting metadata for bucket: " + name, e);
+            }
+        }
+    }
+
+    private Path metadataFilePath(String name) {
+        return LocalStorageIoSupport.resolveSafe(metadataRoot, name);
+    }
+}

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperations.java
@@ -60,6 +60,9 @@ final class LocalStorageBucketMetadataOperations implements BucketMetadataOperat
             .resolve(LocalStorageOperations.METADATA_DIRECTORY);
         this.metadataRoot = metadataDirectory.resolve(BUCKETS_DIRECTORY);
         this.supportsPosixPermissions = rootDirectory.getFileSystem().supportedFileAttributeViews().contains("posix");
+        if (!LocalStorageIoSupport.mkdirs(metadataDirectory, metadataRoot, supportsPosixPermissions)) {
+            throw new ObjectStorageException("Error creating bucket metadata directory: " + metadataRoot);
+        }
     }
 
     @Override

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperations.java
@@ -17,7 +17,6 @@ package io.micronaut.objectstorage.local;
 
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
-import io.micronaut.context.annotation.Secondary;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.metadata.BucketMetadataEntry;
 import io.micronaut.objectstorage.metadata.BucketMetadataOperations;
@@ -39,7 +38,6 @@ import java.util.Properties;
  * @author Álvaro Sánchez-Mariscal
  */
 @EachBean(LocalStorageConfiguration.class)
-@Secondary
 final class LocalStorageBucketMetadataOperations implements BucketMetadataOperations<Path> {
 
     private static final String BUCKETS_DIRECTORY = "buckets";

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperations.java
@@ -17,6 +17,7 @@ package io.micronaut.objectstorage.local;
 
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Secondary;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.metadata.BucketMetadataEntry;
 import io.micronaut.objectstorage.metadata.BucketMetadataOperations;
@@ -38,11 +39,13 @@ import java.util.Properties;
  * @author Álvaro Sánchez-Mariscal
  */
 @EachBean(LocalStorageConfiguration.class)
+@Secondary
 final class LocalStorageBucketMetadataOperations implements BucketMetadataOperations<Path> {
 
     private static final String BUCKETS_DIRECTORY = "buckets";
 
     private final Path rootDirectory;
+    private final Path metadataDirectory;
     private final Path metadataRoot;
     private final boolean supportsPosixPermissions;
 
@@ -52,12 +55,11 @@ final class LocalStorageBucketMetadataOperations implements BucketMetadataOperat
         if (rootDirectory == null) {
             throw new IllegalArgumentException("Local storage bucket metadata operations require a bucket path with a parent directory");
         }
-        Path metadataDirectory = rootDirectory.resolve(LocalStorageOperations.METADATA_DIRECTORY);
+        this.metadataDirectory = rootDirectory
+            .resolve(LocalStorageOperations.INTERNAL_DIRECTORY)
+            .resolve(LocalStorageOperations.METADATA_DIRECTORY);
         this.metadataRoot = metadataDirectory.resolve(BUCKETS_DIRECTORY);
         this.supportsPosixPermissions = rootDirectory.getFileSystem().supportedFileAttributeViews().contains("posix");
-        if (!LocalStorageIoSupport.mkdirs(metadataDirectory, metadataRoot, supportsPosixPermissions)) {
-            throw new ObjectStorageException("Error creating bucket metadata directory: " + metadataRoot);
-        }
     }
 
     @Override
@@ -81,7 +83,7 @@ final class LocalStorageBucketMetadataOperations implements BucketMetadataOperat
             throw new ObjectStorageException("Cannot persist metadata for a missing bucket: " + write.name());
         }
         Path metadataFile = metadataFilePath(write.name());
-        if (!LocalStorageIoSupport.mkdirs(metadataRoot, metadataFile.getParent(), supportsPosixPermissions)) {
+        if (!LocalStorageIoSupport.mkdirs(metadataDirectory, metadataFile.getParent(), supportsPosixPermissions)) {
             throw new ObjectStorageException("Error creating metadata directories for bucket: " + write.name());
         }
         Properties properties = LocalStorageMetadataSupport.toProperties(write);
@@ -106,6 +108,7 @@ final class LocalStorageBucketMetadataOperations implements BucketMetadataOperat
 
     private Path metadataFilePath(String name) {
         LocalStorageIoSupport.resolveBucketPath(rootDirectory, name);
+        LocalStorageIoSupport.rejectSymbolicLinks(rootDirectory, metadataRoot);
         return LocalStorageIoSupport.resolveSafe(metadataRoot, name);
     }
 }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperations.java
@@ -52,9 +52,10 @@ final class LocalStorageBucketMetadataOperations implements BucketMetadataOperat
         if (rootDirectory == null) {
             throw new IllegalArgumentException("Local storage bucket metadata operations require a bucket path with a parent directory");
         }
-        this.metadataRoot = rootDirectory.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve(BUCKETS_DIRECTORY);
+        Path metadataDirectory = rootDirectory.resolve(LocalStorageOperations.METADATA_DIRECTORY);
+        this.metadataRoot = metadataDirectory.resolve(BUCKETS_DIRECTORY);
         this.supportsPosixPermissions = rootDirectory.getFileSystem().supportedFileAttributeViews().contains("posix");
-        if (!LocalStorageIoSupport.mkdirs(metadataRoot, metadataRoot, supportsPosixPermissions)) {
+        if (!LocalStorageIoSupport.mkdirs(metadataDirectory, metadataRoot, supportsPosixPermissions)) {
             throw new ObjectStorageException("Error creating bucket metadata directory: " + metadataRoot);
         }
     }
@@ -104,6 +105,7 @@ final class LocalStorageBucketMetadataOperations implements BucketMetadataOperat
     }
 
     private Path metadataFilePath(String name) {
+        LocalStorageIoSupport.resolveBucketPath(rootDirectory, name);
         return LocalStorageIoSupport.resolveSafe(metadataRoot, name);
     }
 }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketOperations.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.objectstorage.bucket.BucketEntry;
 import io.micronaut.objectstorage.bucket.BucketOperations;
+import io.micronaut.objectstorage.metadata.BucketMetadataOperations;
 import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
@@ -40,10 +41,10 @@ import java.util.Optional;
 @EachBean(LocalStorageConfiguration.class)
 final class LocalStorageBucketOperations implements BucketOperations<Path> {
     private final Path rootDirectory;
-    private final LocalStorageBucketMetadataOperations bucketMetadataOperations;
+    private final BucketMetadataOperations<Path> bucketMetadataOperations;
 
     LocalStorageBucketOperations(@Parameter LocalStorageConfiguration configuration,
-                                 LocalStorageBucketMetadataOperations bucketMetadataOperations) {
+                                 BucketMetadataOperations<Path> bucketMetadataOperations) {
         this.rootDirectory = configuration.getPath().toAbsolutePath().normalize().getParent();
         this.bucketMetadataOperations = bucketMetadataOperations;
         if (rootDirectory == null) {

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketOperations.java
@@ -17,8 +17,8 @@ package io.micronaut.objectstorage.local;
 
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
-import io.micronaut.objectstorage.bucket.BucketOperations;
 import io.micronaut.objectstorage.bucket.BucketEntry;
+import io.micronaut.objectstorage.bucket.BucketOperations;
 import org.jspecify.annotations.NonNull;
 
 import java.io.IOException;
@@ -40,9 +40,12 @@ import java.util.Optional;
 @EachBean(LocalStorageConfiguration.class)
 final class LocalStorageBucketOperations implements BucketOperations<Path> {
     private final Path rootDirectory;
+    private final LocalStorageBucketMetadataOperations bucketMetadataOperations;
 
-    LocalStorageBucketOperations(@Parameter LocalStorageConfiguration configuration) {
+    LocalStorageBucketOperations(@Parameter LocalStorageConfiguration configuration,
+                                 LocalStorageBucketMetadataOperations bucketMetadataOperations) {
         this.rootDirectory = configuration.getPath().toAbsolutePath().normalize().getParent();
+        this.bucketMetadataOperations = bucketMetadataOperations;
         if (rootDirectory == null) {
             throw new IllegalArgumentException("Local storage bucket operations require a bucket path with a parent directory");
         }
@@ -50,7 +53,7 @@ final class LocalStorageBucketOperations implements BucketOperations<Path> {
 
     @Override
     public void create(@NonNull String name) {
-        Path path = resolveDynamicBucketPath(name);
+        Path path = LocalStorageIoSupport.resolveBucketPath(rootDirectory, name);
         try {
             Files.createDirectories(path);
         } catch (IOException e) {
@@ -58,19 +61,10 @@ final class LocalStorageBucketOperations implements BucketOperations<Path> {
         }
     }
 
-    private Path resolveDynamicBucketPath(String name) {
-        Path path = rootDirectory.resolve(name).normalize();
-        if (!path.getParent().equals(rootDirectory) ||
-            !path.getFileName().toString().equals(name)) {
-            throw new IllegalArgumentException("Bucket name must not contain filesystem special characters");
-        }
-        return path;
-    }
-
     @Override
     @NonNull
     public Optional<BucketEntry<Path>> retrieve(@NonNull String name) {
-        Path path = resolveDynamicBucketPath(name);
+        Path path = LocalStorageIoSupport.resolveBucketPath(rootDirectory, name);
         if (!Files.isDirectory(path)) {
             return Optional.empty();
         }
@@ -79,7 +73,8 @@ final class LocalStorageBucketOperations implements BucketOperations<Path> {
 
     @Override
     public void delete(@NonNull String name) {
-        Path path = resolveDynamicBucketPath(name);
+        Path path = LocalStorageIoSupport.resolveBucketPath(rootDirectory, name);
+        bucketMetadataOperations.delete(name);
         try {
             deleteRecursively(path);
         } catch (NoSuchFileException ignored) {

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketOperations.java
@@ -74,9 +74,9 @@ final class LocalStorageBucketOperations implements BucketOperations<Path> {
     @Override
     public void delete(@NonNull String name) {
         Path path = LocalStorageIoSupport.resolveBucketPath(rootDirectory, name);
-        bucketMetadataOperations.delete(name);
         try {
             deleteRecursively(path);
+            bucketMetadataOperations.delete(name);
         } catch (NoSuchFileException ignored) {
             // Deleting a missing bucket is a no-op.
         } catch (IOException e) {

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageIoSupport.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageIoSupport.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.local;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+
+final class LocalStorageIoSupport {
+
+    private static final Set<PosixFilePermission> DIRECTORY_PERMISSIONS = EnumSet.of(
+        PosixFilePermission.OWNER_READ,
+        PosixFilePermission.OWNER_WRITE,
+        PosixFilePermission.OWNER_EXECUTE
+    );
+    private static final Set<PosixFilePermission> FILE_PERMISSIONS = EnumSet.of(
+        PosixFilePermission.OWNER_READ,
+        PosixFilePermission.OWNER_WRITE
+    );
+    private static final FileAttribute<Set<PosixFilePermission>> DIRECTORY_PERMISSIONS_ATTRIBUTE =
+        PosixFilePermissions.asFileAttribute(DIRECTORY_PERMISSIONS);
+    private static final FileAttribute<Set<PosixFilePermission>> FILE_PERMISSIONS_ATTRIBUTE =
+        PosixFilePermissions.asFileAttribute(FILE_PERMISSIONS);
+
+    private LocalStorageIoSupport() {
+    }
+
+    static boolean mkdirs(Path rootPath, Path path, boolean supportsPosixPermissions) {
+        try {
+            if (!supportsPosixPermissions) {
+                Files.createDirectories(path);
+                return true;
+            }
+            Path normalizedRoot = rootPath.normalize();
+            Path normalizedPath = path.normalize();
+            Files.createDirectories(normalizedRoot, DIRECTORY_PERMISSIONS_ATTRIBUTE);
+            Files.setPosixFilePermissions(normalizedRoot, DIRECTORY_PERMISSIONS);
+            Path current = normalizedRoot;
+            for (Path part : normalizedRoot.relativize(normalizedPath)) {
+                current = current.resolve(part);
+                createOwnerOnlyDirectory(current);
+            }
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    static OutputStream newOutputStreamNoFollow(Path file, boolean supportsPosixPermissions) throws IOException {
+        if (supportsPosixPermissions) {
+            try {
+                Set<OpenOption> createOptions = new HashSet<>();
+                createOptions.add(StandardOpenOption.WRITE);
+                createOptions.add(StandardOpenOption.CREATE_NEW);
+                createOptions.add(LinkOption.NOFOLLOW_LINKS);
+                return Channels.newOutputStream(FileChannel.open(file, createOptions, FILE_PERMISSIONS_ATTRIBUTE));
+            } catch (FileAlreadyExistsException ignored) {
+                Files.setPosixFilePermissions(file, FILE_PERMISSIONS);
+                return Channels.newOutputStream(FileChannel.open(
+                    file,
+                    Set.of(StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, LinkOption.NOFOLLOW_LINKS)
+                ));
+            }
+        }
+        return Channels.newOutputStream(Files.newByteChannel(file, Set.of(
+            StandardOpenOption.CREATE,
+            StandardOpenOption.TRUNCATE_EXISTING,
+            StandardOpenOption.WRITE,
+            LinkOption.NOFOLLOW_LINKS
+        )));
+    }
+
+    static InputStream newInputStreamNoFollow(Path path) throws IOException {
+        return Channels.newInputStream(Files.newByteChannel(path, Set.of(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)));
+    }
+
+    static Path resolveSafe(Path parent, String key) {
+        Path normalizedParent = parent.normalize();
+        rejectSymbolicLink(normalizedParent);
+        Path file = normalizedParent.resolve(key).normalize();
+        if (!file.startsWith(normalizedParent)) {
+            throw new IllegalArgumentException("Path lies outside the configured bucket");
+        }
+        validateKey(normalizedParent.relativize(file), key);
+        rejectSymbolicLinks(normalizedParent, file);
+        return file;
+    }
+
+    static Path resolveBucketPath(Path rootDirectory, String name) {
+        rejectSymbolicLink(rootDirectory);
+        Path path = rootDirectory.resolve(name).normalize();
+        if (!path.getParent().equals(rootDirectory) ||
+            !path.getFileName().toString().equals(name)) {
+            throw new IllegalArgumentException("Bucket name must not contain filesystem special characters");
+        }
+        rejectSymbolicLinks(rootDirectory, path);
+        return path;
+    }
+
+    private static void createOwnerOnlyDirectory(Path directory) throws IOException {
+        try {
+            Files.createDirectory(directory, DIRECTORY_PERMISSIONS_ATTRIBUTE);
+        } catch (FileAlreadyExistsException ignored) {
+            if (!Files.isDirectory(directory)) {
+                throw ignored;
+            }
+        }
+        Files.setPosixFilePermissions(directory, DIRECTORY_PERMISSIONS);
+    }
+
+    private static void validateKey(Path normalizedRelativePath, String key) {
+        if (normalizedRelativePath.getNameCount() > 0
+            && LocalStorageOperations.METADATA_DIRECTORY.equalsIgnoreCase(normalizedRelativePath.getName(0).toString())) {
+            throw new IllegalArgumentException("Key uses the reserved " + LocalStorageOperations.METADATA_DIRECTORY + " namespace: " + key);
+        }
+    }
+
+    private static void rejectSymbolicLink(Path path) {
+        if (Files.isSymbolicLink(path)) {
+            throw new IllegalArgumentException("Path contains symbolic links");
+        }
+    }
+
+    private static void rejectSymbolicLinks(Path parent, Path file) {
+        Path current = parent;
+        for (Path segment : parent.relativize(file)) {
+            current = current.resolve(segment);
+            rejectSymbolicLink(current);
+        }
+    }
+}

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageIoSupport.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageIoSupport.java
@@ -120,6 +120,9 @@ final class LocalStorageIoSupport {
             !path.getFileName().toString().equals(name)) {
             throw new IllegalArgumentException("Bucket name must not contain filesystem special characters");
         }
+        if (LocalStorageOperations.METADATA_DIRECTORY.equalsIgnoreCase(name)) {
+            throw new IllegalArgumentException("Bucket name uses the reserved " + LocalStorageOperations.METADATA_DIRECTORY + " namespace: " + name);
+        }
         rejectSymbolicLinks(rootDirectory, path);
         return path;
     }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageIoSupport.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageIoSupport.java
@@ -97,6 +97,13 @@ final class LocalStorageIoSupport {
         )));
     }
 
+    static Path createTempFile(Path directory, String prefix, String suffix, boolean supportsPosixPermissions) throws IOException {
+        if (supportsPosixPermissions) {
+            return Files.createTempFile(directory, prefix, suffix, FILE_PERMISSIONS_ATTRIBUTE);
+        }
+        return Files.createTempFile(directory, prefix, suffix);
+    }
+
     static InputStream newInputStreamNoFollow(Path path) throws IOException {
         return Channels.newInputStream(Files.newByteChannel(path, Set.of(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)));
     }
@@ -120,8 +127,9 @@ final class LocalStorageIoSupport {
             !path.getFileName().toString().equals(name)) {
             throw new IllegalArgumentException("Bucket name must not contain filesystem special characters");
         }
-        if (LocalStorageOperations.METADATA_DIRECTORY.equalsIgnoreCase(name)) {
-            throw new IllegalArgumentException("Bucket name uses the reserved " + LocalStorageOperations.METADATA_DIRECTORY + " namespace: " + name);
+        String reservedNamespace = LocalStorageOperations.reservedLocalStorageNamespace(name).orElse(null);
+        if (reservedNamespace != null) {
+            throw new IllegalArgumentException("Bucket name uses the reserved " + reservedNamespace + " namespace: " + name);
         }
         rejectSymbolicLinks(rootDirectory, path);
         return path;
@@ -139,9 +147,11 @@ final class LocalStorageIoSupport {
     }
 
     private static void validateKey(Path normalizedRelativePath, String key) {
-        if (normalizedRelativePath.getNameCount() > 0
-            && LocalStorageOperations.METADATA_DIRECTORY.equalsIgnoreCase(normalizedRelativePath.getName(0).toString())) {
-            throw new IllegalArgumentException("Key uses the reserved " + LocalStorageOperations.METADATA_DIRECTORY + " namespace: " + key);
+        if (normalizedRelativePath.getNameCount() > 0) {
+            String reservedNamespace = LocalStorageOperations.reservedLocalStorageNamespace(normalizedRelativePath.getName(0).toString()).orElse(null);
+            if (reservedNamespace != null) {
+                throw new IllegalArgumentException("Key uses the reserved " + reservedNamespace + " namespace: " + key);
+            }
         }
     }
 
@@ -151,7 +161,7 @@ final class LocalStorageIoSupport {
         }
     }
 
-    private static void rejectSymbolicLinks(Path parent, Path file) {
+    static void rejectSymbolicLinks(Path parent, Path file) {
         Path current = parent;
         for (Path segment : parent.relativize(file)) {
             current = current.resolve(segment);

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMetadataSupport.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMetadataSupport.java
@@ -103,7 +103,7 @@ final class LocalStorageMetadataSupport {
     }
 
     private static Map<String, String> readLegacyMetadata(Properties properties) {
-        Map<String, String> metadata = new HashMap<>(properties.size());
+        Map<String, String> metadata = HashMap.newHashMap(properties.size());
         for (String name : properties.stringPropertyNames()) {
             metadata.put(name, properties.getProperty(name));
         }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMetadataSupport.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMetadataSupport.java
@@ -31,6 +31,8 @@ import java.util.Properties;
 
 final class LocalStorageMetadataSupport {
 
+    private static final String FORMAT_MARKER_KEY = "micronaut.local.metadata.format";
+    private static final String STRUCTURED_FORMAT_VERSION = "structured-v1";
     private static final String METADATA_PREFIX = "metadata.";
     private static final String ATTRIBUTE_PREFIX = "attribute.";
     private static final String SYSTEM_PREFIX = "system.";
@@ -70,6 +72,7 @@ final class LocalStorageMetadataSupport {
 
     static Properties toProperties(ObjectMetadataWrite write) {
         Properties properties = new Properties();
+        properties.setProperty(FORMAT_MARKER_KEY, STRUCTURED_FORMAT_VERSION);
         putPrefixed(properties, METADATA_PREFIX, write.metadata());
         putPrefixed(properties, ATTRIBUTE_PREFIX, write.attributes());
         putIfPresent(properties, CONTENT_TYPE_KEY, write.contentType());
@@ -81,6 +84,7 @@ final class LocalStorageMetadataSupport {
 
     static Properties toProperties(BucketMetadataWrite write) {
         Properties properties = new Properties();
+        properties.setProperty(FORMAT_MARKER_KEY, STRUCTURED_FORMAT_VERSION);
         putPrefixed(properties, METADATA_PREFIX, write.metadata());
         putPrefixed(properties, ATTRIBUTE_PREFIX, write.attributes());
         return properties;
@@ -95,9 +99,7 @@ final class LocalStorageMetadataSupport {
     }
 
     private static boolean isStructured(Properties properties) {
-        return properties.stringPropertyNames().stream().anyMatch(name ->
-            name.startsWith(METADATA_PREFIX) || name.startsWith(ATTRIBUTE_PREFIX) || name.startsWith(SYSTEM_PREFIX)
-        );
+        return STRUCTURED_FORMAT_VERSION.equals(properties.getProperty(FORMAT_MARKER_KEY));
     }
 
     private static Map<String, String> readLegacyMetadata(Properties properties) {

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMetadataSupport.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMetadataSupport.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.local;
+
+import io.micronaut.objectstorage.metadata.BucketMetadataEntry;
+import io.micronaut.objectstorage.metadata.BucketMetadataWrite;
+import io.micronaut.objectstorage.metadata.ObjectMetadataEntry;
+import io.micronaut.objectstorage.metadata.ObjectMetadataWrite;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+final class LocalStorageMetadataSupport {
+
+    private static final String METADATA_PREFIX = "metadata.";
+    private static final String ATTRIBUTE_PREFIX = "attribute.";
+    private static final String SYSTEM_PREFIX = "system.";
+    private static final String CONTENT_TYPE_KEY = SYSTEM_PREFIX + "contentType";
+    private static final String CONTENT_LENGTH_KEY = SYSTEM_PREFIX + "contentLength";
+    private static final String ETAG_KEY = SYSTEM_PREFIX + "etag";
+    private static final String LAST_MODIFIED_KEY = SYSTEM_PREFIX + "lastModified";
+
+    private LocalStorageMetadataSupport() {
+    }
+
+    static ObjectMetadataEntry<Path> readObjectMetadata(Path metadataFile, String key) throws IOException {
+        Properties properties = loadProperties(metadataFile);
+        boolean structured = isStructured(properties);
+        return new ObjectMetadataEntry<>(
+            key,
+            structured ? readPrefixed(properties, METADATA_PREFIX) : readLegacyMetadata(properties),
+            structured ? readPrefixed(properties, ATTRIBUTE_PREFIX) : Map.of(),
+            structured ? nullIfEmpty(properties.getProperty(CONTENT_TYPE_KEY)) : null,
+            structured ? parseLong(properties.getProperty(CONTENT_LENGTH_KEY)) : null,
+            structured ? nullIfEmpty(properties.getProperty(ETAG_KEY)) : null,
+            structured ? parseInstant(properties.getProperty(LAST_MODIFIED_KEY)) : null,
+            metadataFile
+        );
+    }
+
+    static BucketMetadataEntry<Path> readBucketMetadata(Path metadataFile, String name) throws IOException {
+        Properties properties = loadProperties(metadataFile);
+        boolean structured = isStructured(properties);
+        return new BucketMetadataEntry<>(
+            name,
+            structured ? readPrefixed(properties, METADATA_PREFIX) : readLegacyMetadata(properties),
+            structured ? readPrefixed(properties, ATTRIBUTE_PREFIX) : Map.of(),
+            metadataFile
+        );
+    }
+
+    static Properties toProperties(ObjectMetadataWrite write) {
+        Properties properties = new Properties();
+        putPrefixed(properties, METADATA_PREFIX, write.metadata());
+        putPrefixed(properties, ATTRIBUTE_PREFIX, write.attributes());
+        putIfPresent(properties, CONTENT_TYPE_KEY, write.contentType());
+        putIfPresent(properties, CONTENT_LENGTH_KEY, write.contentLength());
+        putIfPresent(properties, ETAG_KEY, write.etag());
+        putIfPresent(properties, LAST_MODIFIED_KEY, write.lastModified());
+        return properties;
+    }
+
+    static Properties toProperties(BucketMetadataWrite write) {
+        Properties properties = new Properties();
+        putPrefixed(properties, METADATA_PREFIX, write.metadata());
+        putPrefixed(properties, ATTRIBUTE_PREFIX, write.attributes());
+        return properties;
+    }
+
+    private static Properties loadProperties(Path metadataFile) throws IOException {
+        Properties properties = new Properties();
+        try (InputStream metadataIn = LocalStorageIoSupport.newInputStreamNoFollow(metadataFile)) {
+            properties.load(metadataIn);
+        }
+        return properties;
+    }
+
+    private static boolean isStructured(Properties properties) {
+        return properties.stringPropertyNames().stream().anyMatch(name ->
+            name.startsWith(METADATA_PREFIX) || name.startsWith(ATTRIBUTE_PREFIX) || name.startsWith(SYSTEM_PREFIX)
+        );
+    }
+
+    private static Map<String, String> readLegacyMetadata(Properties properties) {
+        Map<String, String> metadata = new HashMap<>(properties.size());
+        for (String name : properties.stringPropertyNames()) {
+            metadata.put(name, properties.getProperty(name));
+        }
+        return metadata;
+    }
+
+    private static Map<String, String> readPrefixed(Properties properties, String prefix) {
+        Map<String, String> values = new HashMap<>();
+        for (String name : properties.stringPropertyNames()) {
+            if (name.startsWith(prefix)) {
+                values.put(name.substring(prefix.length()), properties.getProperty(name));
+            }
+        }
+        return values;
+    }
+
+    private static void putPrefixed(Properties properties, String prefix, Map<String, String> values) {
+        values.forEach((key, value) -> properties.setProperty(prefix + key, value));
+    }
+
+    private static void putIfPresent(Properties properties, String key, @Nullable Object value) {
+        if (value != null) {
+            properties.setProperty(key, value.toString());
+        }
+    }
+
+    @Nullable
+    private static Long parseLong(@Nullable String value) {
+        return value == null || value.isEmpty() ? null : Long.parseLong(value);
+    }
+
+    @Nullable
+    private static Instant parseInstant(@Nullable String value) {
+        return value == null || value.isEmpty() ? null : Instant.parse(value);
+    }
+
+    @Nullable
+    private static String nullIfEmpty(@Nullable String value) {
+        return value == null || value.isEmpty() ? null : value;
+    }
+}

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageObjectMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageObjectMetadataOperations.java
@@ -53,6 +53,9 @@ final class LocalStorageObjectMetadataOperations implements ObjectMetadataOperat
             .resolve(LocalStorageOperations.INTERNAL_DIRECTORY)
             .resolve(LocalStorageOperations.METADATA_DIRECTORY);
         this.supportsPosixPermissions = bucketPath.getFileSystem().supportedFileAttributeViews().contains("posix");
+        if (!LocalStorageIoSupport.mkdirs(bucketPath, metadataRoot, supportsPosixPermissions)) {
+            throw new ObjectStorageException("Error creating metadata directory: " + metadataRoot);
+        }
     }
 
     @Override

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageObjectMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageObjectMetadataOperations.java
@@ -17,6 +17,7 @@ package io.micronaut.objectstorage.local;
 
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Secondary;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.metadata.ObjectMetadataEntry;
 import io.micronaut.objectstorage.metadata.ObjectMetadataOperations;
@@ -39,6 +40,7 @@ import java.util.Properties;
  * @author Álvaro Sánchez-Mariscal
  */
 @EachBean(LocalStorageConfiguration.class)
+@Secondary
 final class LocalStorageObjectMetadataOperations implements ObjectMetadataOperations<Path> {
 
     private final Path bucketPath;
@@ -47,11 +49,10 @@ final class LocalStorageObjectMetadataOperations implements ObjectMetadataOperat
 
     LocalStorageObjectMetadataOperations(@Parameter LocalStorageConfiguration configuration) {
         this.bucketPath = configuration.getPath();
-        this.metadataRoot = bucketPath.resolve(LocalStorageOperations.METADATA_DIRECTORY);
+        this.metadataRoot = bucketPath
+            .resolve(LocalStorageOperations.INTERNAL_DIRECTORY)
+            .resolve(LocalStorageOperations.METADATA_DIRECTORY);
         this.supportsPosixPermissions = bucketPath.getFileSystem().supportedFileAttributeViews().contains("posix");
-        if (!LocalStorageIoSupport.mkdirs(bucketPath, metadataRoot, supportsPosixPermissions)) {
-            throw new ObjectStorageException("Error creating metadata directory: " + metadataRoot);
-        }
     }
 
     @Override
@@ -97,10 +98,11 @@ final class LocalStorageObjectMetadataOperations implements ObjectMetadataOperat
     }
 
     private Path metadataFilePath(String key) {
+        LocalStorageIoSupport.rejectSymbolicLinks(bucketPath, metadataRoot);
         return LocalStorageIoSupport.resolveSafe(metadataRoot, key);
     }
 
-    Path prepareMetadataTarget(String key) {
+    private Path prepareMetadataTarget(String key) {
         Path metadataFile = metadataFilePath(key);
         if (!LocalStorageIoSupport.mkdirs(metadataRoot, metadataFile.getParent(), supportsPosixPermissions)) {
             throw new ObjectStorageException("Error creating metadata directories for object: " + key);

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageObjectMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageObjectMetadataOperations.java
@@ -17,7 +17,6 @@ package io.micronaut.objectstorage.local;
 
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
-import io.micronaut.context.annotation.Secondary;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.metadata.ObjectMetadataEntry;
 import io.micronaut.objectstorage.metadata.ObjectMetadataOperations;
@@ -40,7 +39,6 @@ import java.util.Properties;
  * @author Álvaro Sánchez-Mariscal
  */
 @EachBean(LocalStorageConfiguration.class)
-@Secondary
 final class LocalStorageObjectMetadataOperations implements ObjectMetadataOperations<Path> {
 
     private final Path bucketPath;

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageObjectMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageObjectMetadataOperations.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.local;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.objectstorage.ObjectStorageException;
+import io.micronaut.objectstorage.metadata.ObjectMetadataEntry;
+import io.micronaut.objectstorage.metadata.ObjectMetadataOperations;
+import io.micronaut.objectstorage.metadata.ObjectMetadataWrite;
+import org.jspecify.annotations.NonNull;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Properties;
+
+/**
+ * Local object metadata operations.
+ *
+ * @since 3.0.0
+ * @author Álvaro Sánchez-Mariscal
+ */
+@EachBean(LocalStorageConfiguration.class)
+final class LocalStorageObjectMetadataOperations implements ObjectMetadataOperations<Path> {
+
+    private final Path bucketPath;
+    private final Path metadataRoot;
+    private final boolean supportsPosixPermissions;
+
+    LocalStorageObjectMetadataOperations(@Parameter LocalStorageConfiguration configuration) {
+        this.bucketPath = configuration.getPath();
+        this.metadataRoot = bucketPath.resolve(LocalStorageOperations.METADATA_DIRECTORY);
+        this.supportsPosixPermissions = bucketPath.getFileSystem().supportedFileAttributeViews().contains("posix");
+        if (!LocalStorageIoSupport.mkdirs(metadataRoot, metadataRoot, supportsPosixPermissions)) {
+            throw new ObjectStorageException("Error creating metadata directory: " + metadataRoot);
+        }
+    }
+
+    @Override
+    @NonNull
+    public Optional<ObjectMetadataEntry<Path>> retrieve(@NonNull String key) {
+        Path metadataFile = metadataFilePath(key);
+        if (!Files.exists(metadataFile, LinkOption.NOFOLLOW_LINKS)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(LocalStorageMetadataSupport.readObjectMetadata(metadataFile, key));
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error reading metadata for object: " + key, e);
+        }
+    }
+
+    @Override
+    public void save(@NonNull ObjectMetadataWrite write) {
+        Path objectFile = LocalStorageIoSupport.resolveSafe(bucketPath, write.key());
+        if (!Files.exists(objectFile, LinkOption.NOFOLLOW_LINKS)) {
+            throw new ObjectStorageException("Cannot persist metadata for a missing object: " + write.key());
+        }
+        Path metadataFile = prepareMetadataTarget(write.key());
+        ObjectMetadataWrite effectiveWrite = enrich(write, objectFile);
+        Properties properties = LocalStorageMetadataSupport.toProperties(effectiveWrite);
+        try (OutputStream metadataOut = LocalStorageIoSupport.newOutputStreamNoFollow(metadataFile, supportsPosixPermissions)) {
+            properties.store(metadataOut, "Metadata for file: " + write.key());
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error storing metadata for object: " + write.key(), e);
+        }
+    }
+
+    @Override
+    public void delete(@NonNull String key) {
+        Path metadataFile = metadataFilePath(key);
+        if (Files.exists(metadataFile, LinkOption.NOFOLLOW_LINKS)) {
+            try {
+                Files.delete(metadataFile);
+            } catch (IOException e) {
+                throw new ObjectStorageException("Error deleting metadata for object: " + key, e);
+            }
+        }
+    }
+
+    private Path metadataFilePath(String key) {
+        return LocalStorageIoSupport.resolveSafe(metadataRoot, key);
+    }
+
+    Path prepareMetadataTarget(String key) {
+        Path metadataFile = metadataFilePath(key);
+        if (!LocalStorageIoSupport.mkdirs(metadataRoot, metadataFile.getParent(), supportsPosixPermissions)) {
+            throw new ObjectStorageException("Error creating metadata directories for object: " + key);
+        }
+        return metadataFile;
+    }
+
+    private ObjectMetadataWrite enrich(ObjectMetadataWrite write, Path objectFile) {
+        try {
+            Long contentLength = write.contentLength() != null ? write.contentLength() : Files.size(objectFile);
+            Instant lastModified = write.lastModified() != null
+                ? write.lastModified()
+                : Files.getLastModifiedTime(objectFile, LinkOption.NOFOLLOW_LINKS).toInstant();
+            return new ObjectMetadataWrite(
+                write.key(),
+                write.metadata(),
+                write.attributes(),
+                write.contentType(),
+                contentLength,
+                write.etag(),
+                lastModified
+            );
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error inspecting object while saving metadata: " + write.key(), e);
+        }
+    }
+}

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageObjectMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageObjectMetadataOperations.java
@@ -49,7 +49,7 @@ final class LocalStorageObjectMetadataOperations implements ObjectMetadataOperat
         this.bucketPath = configuration.getPath();
         this.metadataRoot = bucketPath.resolve(LocalStorageOperations.METADATA_DIRECTORY);
         this.supportsPosixPermissions = bucketPath.getFileSystem().supportedFileAttributeViews().contains("posix");
-        if (!LocalStorageIoSupport.mkdirs(metadataRoot, metadataRoot, supportsPosixPermissions)) {
+        if (!LocalStorageIoSupport.mkdirs(bucketPath, metadataRoot, supportsPosixPermissions)) {
             throw new ObjectStorageException("Error creating metadata directory: " + metadataRoot);
         }
     }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -29,6 +29,7 @@ import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
 import io.micronaut.objectstorage.response.ListObjectsResponse;
 import io.micronaut.objectstorage.response.UploadResponse;
+import jakarta.inject.Inject;
 import org.jspecify.annotations.NonNull;
 
 import java.io.File;
@@ -78,6 +79,20 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     private final ObjectMetadataOperations<Path> objectMetadataOperations;
     private final boolean supportsPosixPermissions;
 
+    /**
+     * Create local storage operations.
+     *
+     * @param configuration The local storage configuration.
+     * @param objectMetadataOperations The local object metadata operations.
+     * @deprecated Use {@link #LocalStorageOperations(LocalStorageConfiguration, ObjectMetadataOperations)} instead.
+     */
+    @Deprecated(since = "3.0.0")
+    public LocalStorageOperations(@Parameter LocalStorageConfiguration configuration,
+                                  LocalStorageObjectMetadataOperations objectMetadataOperations) {
+        this(configuration, (ObjectMetadataOperations<Path>) objectMetadataOperations);
+    }
+
+    @Inject
     public LocalStorageOperations(@Parameter LocalStorageConfiguration configuration,
                                   ObjectMetadataOperations<Path> objectMetadataOperations) {
         this.configuration = configuration;

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -23,6 +23,7 @@ import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.ObjectStorageOperations;
 import io.micronaut.objectstorage.configuration.ToggeableCondition;
 import io.micronaut.objectstorage.metadata.ObjectMetadataEntry;
+import io.micronaut.objectstorage.metadata.ObjectMetadataOperations;
 import io.micronaut.objectstorage.metadata.ObjectMetadataWrite;
 import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
@@ -34,9 +35,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -65,15 +69,17 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     LocalStorageOperations.LocalStorageFile,
     LocalStorageOperations.LocalStorageFile> {
 
-    public static final String METADATA_DIRECTORY = ".metadata";
+    static final String INTERNAL_DIRECTORY = ".mn-storage";
+    static final String METADATA_DIRECTORY = "metadata";
+    static final String SNAPSHOT_DIRECTORY = "snapshots";
     private static final int DEFAULT_LIST_PAGE_SIZE = 1_000;
 
     private final LocalStorageConfiguration configuration;
-    private final LocalStorageObjectMetadataOperations objectMetadataOperations;
+    private final ObjectMetadataOperations<Path> objectMetadataOperations;
     private final boolean supportsPosixPermissions;
 
     public LocalStorageOperations(@Parameter LocalStorageConfiguration configuration,
-                                  LocalStorageObjectMetadataOperations objectMetadataOperations) {
+                                  ObjectMetadataOperations<Path> objectMetadataOperations) {
         this.configuration = configuration;
         this.objectMetadataOperations = objectMetadataOperations;
         this.supportsPosixPermissions = configuration.getPath().getFileSystem().supportedFileAttributeViews().contains("posix");
@@ -90,17 +96,26 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     public UploadResponse<LocalStorageFile> upload(@NonNull UploadRequest request,
                                                    @NonNull Consumer<LocalStorageFile> requestConsumer) {
         Path file = LocalStorageIoSupport.resolveSafe(configuration.getPath(), request.getKey());
-        objectMetadataOperations.prepareMetadataTarget(request.getKey());
-        storeFile(file, request.getInputStream());
-        objectMetadataOperations.save(new ObjectMetadataWrite(
-            request.getKey(),
-            request.getMetadata(),
-            Map.of(),
-            request.getContentType().orElse(null),
-            request.getContentSize().orElse(null),
-            null,
-            null
-        ));
+        StoredFileSnapshot snapshot = snapshotStoredFile(file);
+        RuntimeException failure = null;
+        try {
+            storeFile(file, request.getInputStream());
+            objectMetadataOperations.save(new ObjectMetadataWrite(
+                request.getKey(),
+                request.getMetadata(),
+                Map.of(),
+                request.getContentType().orElse(null),
+                request.getContentSize().orElse(null),
+                null,
+                null
+            ));
+        } catch (RuntimeException e) {
+            failure = e;
+            restoreStoredFileAfterFailure(file, snapshot, e);
+            throw e;
+        } finally {
+            deleteSnapshot(snapshot, failure);
+        }
         LocalStorageFile localFile = new LocalStorageFile(file);
         requestConsumer.accept(localFile);
         return UploadResponse.of(request.getKey(), UUID.randomUUID().toString(), localFile);
@@ -122,8 +137,24 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     @NonNull
     public LocalStorageFile delete(@NonNull String key) {
         Optional<Path> file = retrieveFile(key);
-        deleteFile(key);
-        objectMetadataOperations.delete(key);
+        if (file.isEmpty()) {
+            objectMetadataOperations.delete(key);
+            return new LocalStorageFile(null);
+        }
+        file.ifPresent(path -> {
+            StoredFileSnapshot snapshot = snapshotStoredFile(path);
+            RuntimeException failure = null;
+            try {
+                deleteFile(path);
+                objectMetadataOperations.delete(key);
+            } catch (RuntimeException e) {
+                failure = e;
+                restoreStoredFileAfterFailure(path, snapshot, e);
+                throw e;
+            } finally {
+                deleteSnapshot(snapshot, failure);
+            }
+        });
         return new LocalStorageFile(file.orElse(null));
     }
 
@@ -161,7 +192,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
                 if (File.separatorChar != '/') {
                     key = key.replace(File.separatorChar, '/');
                 }
-                if (key.startsWith(METADATA_DIRECTORY)) {
+                if (isReservedLocalStorageKey(key)) {
                     return;
                 }
                 if (prefix != null && !key.startsWith(prefix)) {
@@ -209,23 +240,35 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     public void copy(@NonNull String sourceKey, @NonNull String destinationKey) {
         retrieveFile(sourceKey).ifPresent(source -> {
             Path destinationFile = LocalStorageIoSupport.resolveSafe(configuration.getPath(), destinationKey);
-            objectMetadataOperations.prepareMetadataTarget(destinationKey);
+            StoredFileSnapshot snapshot = snapshotStoredFile(destinationFile);
+            RuntimeException failure = null;
             try (InputStream in = newInputStreamNoFollow(source)) {
-                storeFile(destinationFile, in);
-                objectMetadataOperations.retrieve(sourceKey).ifPresentOrElse(entry ->
-                    objectMetadataOperations.save(new ObjectMetadataWrite(
-                        destinationKey,
-                        entry.metadata(),
-                        entry.attributes(),
-                        entry.contentType(),
-                        entry.contentLength(),
-                        entry.etag(),
-                        entry.lastModified()
-                    )),
-                    () -> objectMetadataOperations.delete(destinationKey)
-                );
+                try {
+                    storeFile(destinationFile, in);
+                    objectMetadataOperations.retrieve(sourceKey).ifPresentOrElse(entry ->
+                        objectMetadataOperations.save(new ObjectMetadataWrite(
+                            destinationKey,
+                            entry.metadata(),
+                            entry.attributes(),
+                            entry.contentType(),
+                            entry.contentLength(),
+                            entry.etag(),
+                            entry.lastModified()
+                        )),
+                        () -> objectMetadataOperations.delete(destinationKey)
+                    );
+                } catch (RuntimeException e) {
+                    failure = e;
+                    restoreStoredFileAfterFailure(destinationFile, snapshot, e);
+                    throw e;
+                }
             } catch (IOException e) {
-                throw new ObjectStorageException("Error copying file: " + source, e);
+                ObjectStorageException objectStorageException = new ObjectStorageException("Error copying file: " + source, e);
+                failure = objectStorageException;
+                restoreStoredFileAfterFailure(destinationFile, snapshot, objectStorageException);
+                throw objectStorageException;
+            } finally {
+                deleteSnapshot(snapshot, failure);
             }
         });
     }
@@ -239,14 +282,129 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         }
     }
 
-    private void deleteFile(String key) {
-        retrieveFile(key).ifPresent(path -> {
-            try {
-                Files.delete(path);
-            } catch (IOException e) {
-                throw new ObjectStorageException("Error deleting file: " + path, e);
+    private void deleteFile(Path path) {
+        try {
+            Files.delete(path);
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error deleting file: " + path, e);
+        }
+    }
+
+    private StoredFileSnapshot snapshotStoredFile(Path file) {
+        if (!Files.exists(file, LinkOption.NOFOLLOW_LINKS)) {
+            return StoredFileSnapshot.empty();
+        }
+        Path snapshotDirectory = snapshotDirectory();
+        List<Path> cleanupDirectories = snapshotCleanupDirectories(snapshotDirectory);
+        Path snapshot = null;
+        try {
+            LocalStorageIoSupport.rejectSymbolicLinks(configuration.getPath().normalize(), snapshotDirectory.normalize());
+            mkdirs(snapshotDirectory);
+            LocalStorageIoSupport.rejectSymbolicLinks(configuration.getPath().normalize(), snapshotDirectory.normalize());
+            snapshot = LocalStorageIoSupport.createTempFile(
+                snapshotDirectory,
+                "micronaut-object-storage-local",
+                ".snapshot",
+                supportsPosixPermissions
+            );
+            try (InputStream in = newInputStreamNoFollow(file);
+                 OutputStream out = Files.newOutputStream(snapshot)) {
+                in.transferTo(out);
             }
-        });
+            return new StoredFileSnapshot(snapshot, cleanupDirectories);
+        } catch (IOException e) {
+            if (snapshot != null) {
+                try {
+                    Files.deleteIfExists(snapshot);
+                } catch (IOException cleanupFailure) {
+                    e.addSuppressed(cleanupFailure);
+                }
+            }
+            deleteEmptySnapshotDirectories(cleanupDirectories, e);
+            throw new ObjectStorageException("Error snapshotting file before update: " + file, e);
+        }
+    }
+
+    private void restoreStoredFileAfterFailure(Path file, StoredFileSnapshot snapshot, RuntimeException failure) {
+        try {
+            // Restore only the local file state; metadata-store transactionality belongs to the metadata implementation.
+            if (snapshot.exists()) {
+                moveSnapshotReplacing(snapshot.path(), file);
+            } else {
+                Files.deleteIfExists(file);
+            }
+        } catch (IOException | RuntimeException e) {
+            failure.addSuppressed(e);
+        }
+    }
+
+    private void moveSnapshotReplacing(Path snapshot, Path file) throws IOException {
+        try {
+            Files.move(snapshot, file, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException e) {
+            try {
+                Files.move(snapshot, file, StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException fallbackFailure) {
+                fallbackFailure.addSuppressed(e);
+                throw fallbackFailure;
+            }
+        }
+    }
+
+    private void deleteSnapshot(StoredFileSnapshot snapshot, RuntimeException failure) {
+        if (snapshot.exists()) {
+            try {
+                Files.deleteIfExists(snapshot.path());
+            } catch (IOException e) {
+                if (failure != null) {
+                    failure.addSuppressed(e);
+                } else {
+                    throw new ObjectStorageException("Error deleting temporary file snapshot: " + snapshot.path(), e);
+                }
+            }
+        }
+        deleteEmptySnapshotDirectories(snapshot.cleanupDirectories(), failure);
+    }
+
+    private Path snapshotDirectory() {
+        return internalDirectory().resolve(SNAPSHOT_DIRECTORY);
+    }
+
+    private List<Path> snapshotCleanupDirectories(Path snapshotDirectory) {
+        return List.of(snapshotDirectory, internalDirectory());
+    }
+
+    private Path internalDirectory() {
+        return configuration.getPath().resolve(INTERNAL_DIRECTORY);
+    }
+
+    static Optional<String> reservedLocalStorageNamespace(String name) {
+        if (INTERNAL_DIRECTORY.equalsIgnoreCase(name)) {
+            return Optional.of(INTERNAL_DIRECTORY);
+        }
+        return Optional.empty();
+    }
+
+    private static boolean isReservedLocalStorageKey(String key) {
+        int separator = key.indexOf('/');
+        String firstSegment = separator >= 0 ? key.substring(0, separator) : key;
+        return reservedLocalStorageNamespace(firstSegment).isPresent();
+    }
+
+    private void deleteEmptySnapshotDirectories(List<Path> directories, Throwable failure) {
+        for (Path directory : directories) {
+            try {
+                Files.deleteIfExists(directory);
+            } catch (DirectoryNotEmptyException ignored) {
+                // Another temporary snapshot still uses this directory.
+            } catch (IOException e) {
+                if (failure != null) {
+                    failure.addSuppressed(e);
+                } else {
+                    throw new ObjectStorageException("Error deleting temporary snapshot directory: " + directory, e);
+                }
+            }
+        }
     }
 
     private Path storeFile(Path file, InputStream inputStream) {
@@ -276,4 +434,14 @@ public class LocalStorageOperations implements ObjectStorageOperations<
      * @param path Where on disk the local storage provider has stored the actual data.
      */
     public record LocalStorageFile(Path path) { }
+
+    private record StoredFileSnapshot(Path path, List<Path> cleanupDirectories) {
+        static StoredFileSnapshot empty() {
+            return new StoredFileSnapshot(null, List.of());
+        }
+
+        boolean exists() {
+            return path != null;
+        }
+    }
 }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -238,39 +238,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
 
     @Override
     public void copy(@NonNull String sourceKey, @NonNull String destinationKey) {
-        retrieveFile(sourceKey).ifPresent(source -> {
-            Path destinationFile = LocalStorageIoSupport.resolveSafe(configuration.getPath(), destinationKey);
-            StoredFileSnapshot snapshot = snapshotStoredFile(destinationFile);
-            RuntimeException failure = null;
-            try (InputStream in = newInputStreamNoFollow(source)) {
-                try {
-                    storeFile(destinationFile, in);
-                    objectMetadataOperations.retrieve(sourceKey).ifPresentOrElse(entry ->
-                        objectMetadataOperations.save(new ObjectMetadataWrite(
-                            destinationKey,
-                            entry.metadata(),
-                            entry.attributes(),
-                            entry.contentType(),
-                            entry.contentLength(),
-                            entry.etag(),
-                            entry.lastModified()
-                        )),
-                        () -> objectMetadataOperations.delete(destinationKey)
-                    );
-                } catch (RuntimeException e) {
-                    failure = e;
-                    restoreStoredFileAfterFailure(destinationFile, snapshot, e);
-                    throw e;
-                }
-            } catch (IOException e) {
-                ObjectStorageException objectStorageException = new ObjectStorageException("Error copying file: " + source, e);
-                failure = objectStorageException;
-                restoreStoredFileAfterFailure(destinationFile, snapshot, objectStorageException);
-                throw objectStorageException;
-            } finally {
-                deleteSnapshot(snapshot, failure);
-            }
-        });
+        retrieveFile(sourceKey).ifPresent(source -> copyStoredFile(sourceKey, source, destinationKey));
     }
 
     private Optional<Path> retrieveFile(String key) {
@@ -290,39 +258,78 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         }
     }
 
+    private void copyStoredFile(String sourceKey, Path source, String destinationKey) {
+        Path destinationFile = LocalStorageIoSupport.resolveSafe(configuration.getPath(), destinationKey);
+        StoredFileSnapshot snapshot = snapshotStoredFile(destinationFile);
+        RuntimeException failure = null;
+        try (InputStream in = newInputStreamNoFollow(source)) {
+            storeFile(destinationFile, in);
+            copyObjectMetadata(sourceKey, destinationKey);
+        } catch (IOException e) {
+            ObjectStorageException objectStorageException = new ObjectStorageException("Error copying file: " + source, e);
+            failure = objectStorageException;
+            restoreStoredFileAfterFailure(destinationFile, snapshot, objectStorageException);
+            throw objectStorageException;
+        } catch (RuntimeException e) {
+            failure = e;
+            restoreStoredFileAfterFailure(destinationFile, snapshot, e);
+            throw e;
+        } finally {
+            deleteSnapshot(snapshot, failure);
+        }
+    }
+
+    private void copyObjectMetadata(String sourceKey, String destinationKey) {
+        objectMetadataOperations.retrieve(sourceKey).ifPresentOrElse(entry ->
+            objectMetadataOperations.save(new ObjectMetadataWrite(
+                destinationKey,
+                entry.metadata(),
+                entry.attributes(),
+                entry.contentType(),
+                entry.contentLength(),
+                entry.etag(),
+                entry.lastModified()
+            )),
+            () -> objectMetadataOperations.delete(destinationKey)
+        );
+    }
+
     private StoredFileSnapshot snapshotStoredFile(Path file) {
         if (!Files.exists(file, LinkOption.NOFOLLOW_LINKS)) {
             return StoredFileSnapshot.empty();
         }
         Path snapshotDirectory = snapshotDirectory();
         List<Path> cleanupDirectories = snapshotCleanupDirectories(snapshotDirectory);
-        Path snapshot = null;
         try {
             LocalStorageIoSupport.rejectSymbolicLinks(configuration.getPath().normalize(), snapshotDirectory.normalize());
             mkdirs(snapshotDirectory);
             LocalStorageIoSupport.rejectSymbolicLinks(configuration.getPath().normalize(), snapshotDirectory.normalize());
-            snapshot = LocalStorageIoSupport.createTempFile(
+            Path snapshot = LocalStorageIoSupport.createTempFile(
                 snapshotDirectory,
                 "micronaut-object-storage-local",
                 ".snapshot",
                 supportsPosixPermissions
             );
-            try (InputStream in = newInputStreamNoFollow(file);
-                 OutputStream out = Files.newOutputStream(snapshot)) {
-                in.transferTo(out);
-            }
-            return new StoredFileSnapshot(snapshot, cleanupDirectories);
+            return copyStoredFileToSnapshot(file, snapshot, cleanupDirectories);
         } catch (IOException e) {
-            if (snapshot != null) {
-                try {
-                    Files.deleteIfExists(snapshot);
-                } catch (IOException cleanupFailure) {
-                    e.addSuppressed(cleanupFailure);
-                }
-            }
             deleteEmptySnapshotDirectories(cleanupDirectories, e);
             throw new ObjectStorageException("Error snapshotting file before update: " + file, e);
         }
+    }
+
+    private StoredFileSnapshot copyStoredFileToSnapshot(Path file, Path snapshot, List<Path> cleanupDirectories) throws IOException {
+        try (InputStream in = newInputStreamNoFollow(file);
+             OutputStream out = Files.newOutputStream(snapshot)) {
+            in.transferTo(out);
+        } catch (IOException e) {
+            try {
+                Files.deleteIfExists(snapshot);
+            } catch (IOException cleanupFailure) {
+                e.addSuppressed(cleanupFailure);
+            }
+            throw e;
+        }
+        return new StoredFileSnapshot(snapshot, cleanupDirectories);
     }
 
     private void restoreStoredFileAfterFailure(Path file, StoredFileSnapshot snapshot, RuntimeException failure) {

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -19,40 +19,30 @@ import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
-import org.jspecify.annotations.NonNull;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.ObjectStorageOperations;
 import io.micronaut.objectstorage.configuration.ToggeableCondition;
+import io.micronaut.objectstorage.metadata.ObjectMetadataEntry;
+import io.micronaut.objectstorage.metadata.ObjectMetadataWrite;
 import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
 import io.micronaut.objectstorage.response.ListObjectsResponse;
 import io.micronaut.objectstorage.response.UploadResponse;
+import org.jspecify.annotations.NonNull;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
-import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
-import java.nio.file.OpenOption;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -77,32 +67,16 @@ public class LocalStorageOperations implements ObjectStorageOperations<
 
     public static final String METADATA_DIRECTORY = ".metadata";
     private static final int DEFAULT_LIST_PAGE_SIZE = 1_000;
-    private static final Set<PosixFilePermission> DIRECTORY_PERMISSIONS = EnumSet.of(
-        PosixFilePermission.OWNER_READ,
-        PosixFilePermission.OWNER_WRITE,
-        PosixFilePermission.OWNER_EXECUTE
-    );
-    private static final Set<PosixFilePermission> FILE_PERMISSIONS = EnumSet.of(
-        PosixFilePermission.OWNER_READ,
-        PosixFilePermission.OWNER_WRITE
-    );
-    private static final FileAttribute<Set<PosixFilePermission>> DIRECTORY_PERMISSIONS_ATTRIBUTE =
-        PosixFilePermissions.asFileAttribute(DIRECTORY_PERMISSIONS);
-    private static final FileAttribute<Set<PosixFilePermission>> FILE_PERMISSIONS_ATTRIBUTE =
-        PosixFilePermissions.asFileAttribute(FILE_PERMISSIONS);
 
     private final LocalStorageConfiguration configuration;
-    private final Path metadataPath;
+    private final LocalStorageObjectMetadataOperations objectMetadataOperations;
     private final boolean supportsPosixPermissions;
 
-    public LocalStorageOperations(@Parameter LocalStorageConfiguration configuration) {
+    public LocalStorageOperations(@Parameter LocalStorageConfiguration configuration,
+                                  LocalStorageObjectMetadataOperations objectMetadataOperations) {
         this.configuration = configuration;
+        this.objectMetadataOperations = objectMetadataOperations;
         this.supportsPosixPermissions = configuration.getPath().getFileSystem().supportedFileAttributeViews().contains("posix");
-        this.metadataPath = configuration.getPath().resolve(METADATA_DIRECTORY);
-        boolean metadataDirectoryCreated = mkdirs(metadataPath);
-        if (!metadataDirectoryCreated) {
-            throw new ObjectStorageException("Error creating metadata directory: " + metadataPath);
-        }
     }
 
     @Override
@@ -115,10 +89,18 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     @NonNull
     public UploadResponse<LocalStorageFile> upload(@NonNull UploadRequest request,
                                                    @NonNull Consumer<LocalStorageFile> requestConsumer) {
-        Path file = resolveSafe(configuration.getPath(), request.getKey());
-        Path metadataFile = resolveSafe(metadataPath, request.getKey());
+        Path file = LocalStorageIoSupport.resolveSafe(configuration.getPath(), request.getKey());
+        objectMetadataOperations.prepareMetadataTarget(request.getKey());
         storeFile(file, request.getInputStream());
-        storeMetadata(metadataFile, request.getKey(), request.getMetadata());
+        objectMetadataOperations.save(new ObjectMetadataWrite(
+            request.getKey(),
+            request.getMetadata(),
+            Map.of(),
+            request.getContentType().orElse(null),
+            request.getContentSize().orElse(null),
+            null,
+            null
+        ));
         LocalStorageFile localFile = new LocalStorageFile(file);
         requestConsumer.accept(localFile);
         return UploadResponse.of(request.getKey(), UUID.randomUUID().toString(), localFile);
@@ -129,7 +111,11 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     @SuppressWarnings("unchecked")
     public Optional<LocalStorageEntry> retrieve(@NonNull String key) {
         Optional<Path> file = retrieveFile(key);
-        return file.map(path -> new LocalStorageEntry(key, path, retrieveMetadata(key)));
+        return file.map(path -> new LocalStorageEntry(
+            key,
+            path,
+            objectMetadataOperations.retrieve(key).map(ObjectMetadataEntry::metadata).orElse(Collections.emptyMap())
+        ));
     }
 
     @Override
@@ -137,7 +123,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     public LocalStorageFile delete(@NonNull String key) {
         Optional<Path> file = retrieveFile(key);
         deleteFile(key);
-        deleteMetadata(key);
+        objectMetadataOperations.delete(key);
         return new LocalStorageFile(file.orElse(null));
     }
 
@@ -222,11 +208,22 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     @Override
     public void copy(@NonNull String sourceKey, @NonNull String destinationKey) {
         retrieveFile(sourceKey).ifPresent(source -> {
-            Path destinationFile = resolveSafe(configuration.getPath(), destinationKey);
-            Path destinationMetadata = resolveSafe(metadataPath, destinationKey);
+            Path destinationFile = LocalStorageIoSupport.resolveSafe(configuration.getPath(), destinationKey);
+            objectMetadataOperations.prepareMetadataTarget(destinationKey);
             try (InputStream in = newInputStreamNoFollow(source)) {
                 storeFile(destinationFile, in);
-                storeMetadata(destinationMetadata, destinationKey, retrieveMetadata(sourceKey));
+                objectMetadataOperations.retrieve(sourceKey).ifPresentOrElse(entry ->
+                    objectMetadataOperations.save(new ObjectMetadataWrite(
+                        destinationKey,
+                        entry.metadata(),
+                        entry.attributes(),
+                        entry.contentType(),
+                        entry.contentLength(),
+                        entry.etag(),
+                        entry.lastModified()
+                    )),
+                    () -> objectMetadataOperations.delete(destinationKey)
+                );
             } catch (IOException e) {
                 throw new ObjectStorageException("Error copying file: " + source, e);
             }
@@ -234,29 +231,12 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     }
 
     private Optional<Path> retrieveFile(String key) {
-        Path file = resolveSafe(configuration.getPath(), key);
+        Path file = LocalStorageIoSupport.resolveSafe(configuration.getPath(), key);
         if (Files.exists(file, LinkOption.NOFOLLOW_LINKS)) {
             return Optional.of(file);
         } else {
             return Optional.empty();
         }
-    }
-
-    private Map<String, String> retrieveMetadata(String key) {
-        Properties metadataProperties = new Properties();
-        Path metadata = resolveSafe(metadataPath, key).normalize();
-        if (Files.exists(metadata, LinkOption.NOFOLLOW_LINKS)) {
-            try (InputStream metadataIn = newInputStreamNoFollow(metadata)) {
-                metadataProperties.load(metadataIn);
-            } catch (IOException e) {
-                //no op
-            }
-        }
-        Map<String, String> result = new HashMap<>(metadataProperties.size());
-        for (final String name: metadataProperties.stringPropertyNames()) {
-            result.put(name, metadataProperties.getProperty(name));
-        }
-        return result;
     }
 
     private void deleteFile(String key) {
@@ -269,17 +249,6 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         });
     }
 
-    private void deleteMetadata(String key) {
-        Path metadata = resolveSafe(metadataPath, key);
-        if (Files.exists(metadata, LinkOption.NOFOLLOW_LINKS)) {
-            try {
-                Files.delete(metadata);
-            } catch (IOException e) {
-                //no op
-            }
-        }
-    }
-
     private Path storeFile(Path file, InputStream inputStream) {
         mkdirs(file.getParent());
         try (OutputStream fileOut = newOutputStreamNoFollow(file)) {
@@ -290,107 +259,16 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         }
     }
 
-    private void storeMetadata(Path metadataFilePath, String key, Map<String, String> metadata) {
-        Properties metadataProperties = new Properties();
-        metadataProperties.putAll(metadata);
-        mkdirs(metadataFilePath.getParent());
-        try (OutputStream metadataOut = newOutputStreamNoFollow(metadataFilePath)) {
-            metadataProperties.store(metadataOut, "Metadata for file: " + key);
-        } catch (IOException e) {
-            //no op
-        }
-    }
-
     private boolean mkdirs(Path path) {
-        try {
-            if (!supportsPosixPermissions) {
-                Files.createDirectories(path);
-                return true;
-            }
-            Path bucketPath = configuration.getPath();
-            Files.createDirectories(bucketPath, DIRECTORY_PERMISSIONS_ATTRIBUTE);
-            Files.setPosixFilePermissions(bucketPath, DIRECTORY_PERMISSIONS);
-            Path current = bucketPath;
-            for (Path part : bucketPath.relativize(path.normalize())) {
-                current = current.resolve(part);
-                createOwnerOnlyDirectory(current);
-            }
-            return true;
-        } catch (IOException e) {
-            return false;
-        }
+        return LocalStorageIoSupport.mkdirs(configuration.getPath(), path, supportsPosixPermissions);
     }
 
     private OutputStream newOutputStreamNoFollow(Path file) throws IOException {
-        if (supportsPosixPermissions) {
-            try {
-                Set<OpenOption> createOptions = new HashSet<>();
-                createOptions.add(StandardOpenOption.WRITE);
-                createOptions.add(StandardOpenOption.CREATE_NEW);
-                createOptions.add(LinkOption.NOFOLLOW_LINKS);
-                return Channels.newOutputStream(FileChannel.open(file, createOptions, FILE_PERMISSIONS_ATTRIBUTE));
-            } catch (FileAlreadyExistsException ignored) {
-                Files.setPosixFilePermissions(file, FILE_PERMISSIONS);
-                return Channels.newOutputStream(FileChannel.open(
-                    file,
-                    Set.of(StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE, LinkOption.NOFOLLOW_LINKS)
-                ));
-            }
-        }
-        return Channels.newOutputStream(Files.newByteChannel(file, Set.of(
-            StandardOpenOption.CREATE,
-            StandardOpenOption.TRUNCATE_EXISTING,
-            StandardOpenOption.WRITE,
-            LinkOption.NOFOLLOW_LINKS
-        )));
-    }
-
-    private static void createOwnerOnlyDirectory(Path directory) throws IOException {
-        try {
-            Files.createDirectory(directory, DIRECTORY_PERMISSIONS_ATTRIBUTE);
-        } catch (FileAlreadyExistsException ignored) {
-            if (!Files.isDirectory(directory)) {
-                throw ignored;
-            }
-        }
-        Files.setPosixFilePermissions(directory, DIRECTORY_PERMISSIONS);
-    }
-
-    private static Path resolveSafe(Path parent, String key) {
-        Path normalizedParent = parent.normalize();
-        rejectSymbolicLink(normalizedParent);
-        Path file = normalizedParent.resolve(key).normalize();
-        if (!file.startsWith(normalizedParent)) {
-            throw new IllegalArgumentException("Path lies outside the configured bucket");
-        }
-        validateKey(normalizedParent.relativize(file), key);
-        rejectSymbolicLinks(normalizedParent, file);
-        return file;
-    }
-
-    private static void validateKey(Path normalizedRelativePath, String key) {
-        if (normalizedRelativePath.getNameCount() > 0
-            && METADATA_DIRECTORY.equalsIgnoreCase(normalizedRelativePath.getName(0).toString())) {
-            throw new IllegalArgumentException("Key uses the reserved " + METADATA_DIRECTORY + " namespace: " + key);
-        }
-    }
-
-    private static void rejectSymbolicLink(Path path) {
-        if (Files.isSymbolicLink(path)) {
-            throw new IllegalArgumentException("Path contains symbolic links");
-        }
-    }
-
-    private static void rejectSymbolicLinks(Path parent, Path file) {
-        Path current = parent;
-        for (Path segment : parent.relativize(file)) {
-            current = current.resolve(segment);
-            rejectSymbolicLink(current);
-        }
+        return LocalStorageIoSupport.newOutputStreamNoFollow(file, supportsPosixPermissions);
     }
 
     private static InputStream newInputStreamNoFollow(Path path) throws IOException {
-        return Channels.newInputStream(Files.newByteChannel(path, Set.of(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)));
+        return LocalStorageIoSupport.newInputStreamNoFollow(path);
     }
 
     /**

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageReactiveBucketMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageReactiveBucketMetadataOperations.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.local;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.objectstorage.internal.DefaultReactiveBucketMetadataOperations;
+import io.micronaut.scheduling.TaskExecutors;
+import jakarta.inject.Named;
+
+import java.nio.file.Path;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Reactive local bucket metadata operations.
+ *
+ * @since 3.0.0
+ * @author Álvaro Sánchez-Mariscal
+ */
+@EachBean(LocalStorageConfiguration.class)
+@Requires(beans = LocalStorageConfiguration.class)
+@Requires(beans = LocalStorageBucketMetadataOperations.class)
+public class LocalStorageReactiveBucketMetadataOperations extends DefaultReactiveBucketMetadataOperations<Path> {
+
+    public LocalStorageReactiveBucketMetadataOperations(LocalStorageBucketMetadataOperations operations,
+                                                        @Named(TaskExecutors.BLOCKING) ExecutorService blockingExecutor) {
+        super(operations, blockingExecutor);
+    }
+}

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageReactiveBucketMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageReactiveBucketMetadataOperations.java
@@ -20,6 +20,7 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.objectstorage.internal.DefaultReactiveBucketMetadataOperations;
 import io.micronaut.objectstorage.metadata.BucketMetadataOperations;
 import io.micronaut.scheduling.TaskExecutors;
+import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
 import java.nio.file.Path;
@@ -36,6 +37,20 @@ import java.util.concurrent.ExecutorService;
 @Requires(beans = BucketMetadataOperations.class)
 public class LocalStorageReactiveBucketMetadataOperations extends DefaultReactiveBucketMetadataOperations<Path> {
 
+    /**
+     * Create reactive local bucket metadata operations.
+     *
+     * @param operations The local bucket metadata operations.
+     * @param blockingExecutor The blocking executor.
+     * @deprecated Use {@link #LocalStorageReactiveBucketMetadataOperations(BucketMetadataOperations, ExecutorService)} instead.
+     */
+    @Deprecated(since = "3.0.0")
+    public LocalStorageReactiveBucketMetadataOperations(LocalStorageBucketMetadataOperations operations,
+                                                        @Named(TaskExecutors.BLOCKING) ExecutorService blockingExecutor) {
+        this((BucketMetadataOperations<Path>) operations, blockingExecutor);
+    }
+
+    @Inject
     public LocalStorageReactiveBucketMetadataOperations(BucketMetadataOperations<Path> operations,
                                                         @Named(TaskExecutors.BLOCKING) ExecutorService blockingExecutor) {
         super(operations, blockingExecutor);

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageReactiveBucketMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageReactiveBucketMetadataOperations.java
@@ -18,6 +18,7 @@ package io.micronaut.objectstorage.local;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.objectstorage.internal.DefaultReactiveBucketMetadataOperations;
+import io.micronaut.objectstorage.metadata.BucketMetadataOperations;
 import io.micronaut.scheduling.TaskExecutors;
 import jakarta.inject.Named;
 
@@ -32,10 +33,10 @@ import java.util.concurrent.ExecutorService;
  */
 @EachBean(LocalStorageConfiguration.class)
 @Requires(beans = LocalStorageConfiguration.class)
-@Requires(beans = LocalStorageBucketMetadataOperations.class)
+@Requires(beans = BucketMetadataOperations.class)
 public class LocalStorageReactiveBucketMetadataOperations extends DefaultReactiveBucketMetadataOperations<Path> {
 
-    public LocalStorageReactiveBucketMetadataOperations(LocalStorageBucketMetadataOperations operations,
+    public LocalStorageReactiveBucketMetadataOperations(BucketMetadataOperations<Path> operations,
                                                         @Named(TaskExecutors.BLOCKING) ExecutorService blockingExecutor) {
         super(operations, blockingExecutor);
     }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageReactiveObjectMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageReactiveObjectMetadataOperations.java
@@ -18,6 +18,7 @@ package io.micronaut.objectstorage.local;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.objectstorage.internal.DefaultReactiveObjectMetadataOperations;
+import io.micronaut.objectstorage.metadata.ObjectMetadataOperations;
 import io.micronaut.scheduling.TaskExecutors;
 import jakarta.inject.Named;
 
@@ -32,10 +33,10 @@ import java.util.concurrent.ExecutorService;
  */
 @EachBean(LocalStorageConfiguration.class)
 @Requires(beans = LocalStorageConfiguration.class)
-@Requires(beans = LocalStorageObjectMetadataOperations.class)
+@Requires(beans = ObjectMetadataOperations.class)
 public class LocalStorageReactiveObjectMetadataOperations extends DefaultReactiveObjectMetadataOperations<Path> {
 
-    public LocalStorageReactiveObjectMetadataOperations(LocalStorageObjectMetadataOperations operations,
+    public LocalStorageReactiveObjectMetadataOperations(ObjectMetadataOperations<Path> operations,
                                                         @Named(TaskExecutors.BLOCKING) ExecutorService blockingExecutor) {
         super(operations, blockingExecutor);
     }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageReactiveObjectMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageReactiveObjectMetadataOperations.java
@@ -20,6 +20,7 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.objectstorage.internal.DefaultReactiveObjectMetadataOperations;
 import io.micronaut.objectstorage.metadata.ObjectMetadataOperations;
 import io.micronaut.scheduling.TaskExecutors;
+import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
 import java.nio.file.Path;
@@ -36,6 +37,20 @@ import java.util.concurrent.ExecutorService;
 @Requires(beans = ObjectMetadataOperations.class)
 public class LocalStorageReactiveObjectMetadataOperations extends DefaultReactiveObjectMetadataOperations<Path> {
 
+    /**
+     * Create reactive local object metadata operations.
+     *
+     * @param operations The local object metadata operations.
+     * @param blockingExecutor The blocking executor.
+     * @deprecated Use {@link #LocalStorageReactiveObjectMetadataOperations(ObjectMetadataOperations, ExecutorService)} instead.
+     */
+    @Deprecated(since = "3.0.0")
+    public LocalStorageReactiveObjectMetadataOperations(LocalStorageObjectMetadataOperations operations,
+                                                        @Named(TaskExecutors.BLOCKING) ExecutorService blockingExecutor) {
+        this((ObjectMetadataOperations<Path>) operations, blockingExecutor);
+    }
+
+    @Inject
     public LocalStorageReactiveObjectMetadataOperations(ObjectMetadataOperations<Path> operations,
                                                         @Named(TaskExecutors.BLOCKING) ExecutorService blockingExecutor) {
         super(operations, blockingExecutor);

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageReactiveObjectMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageReactiveObjectMetadataOperations.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.local;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.objectstorage.internal.DefaultReactiveObjectMetadataOperations;
+import io.micronaut.scheduling.TaskExecutors;
+import jakarta.inject.Named;
+
+import java.nio.file.Path;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Reactive local object metadata operations.
+ *
+ * @since 3.0.0
+ * @author Álvaro Sánchez-Mariscal
+ */
+@EachBean(LocalStorageConfiguration.class)
+@Requires(beans = LocalStorageConfiguration.class)
+@Requires(beans = LocalStorageObjectMetadataOperations.class)
+public class LocalStorageReactiveObjectMetadataOperations extends DefaultReactiveObjectMetadataOperations<Path> {
+
+    public LocalStorageReactiveObjectMetadataOperations(LocalStorageObjectMetadataOperations operations,
+                                                        @Named(TaskExecutors.BLOCKING) ExecutorService blockingExecutor) {
+        super(operations, blockingExecutor);
+    }
+}

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperationsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperationsSpec.groovy
@@ -59,6 +59,6 @@ class LocalStorageBucketMetadataOperationsSpec extends BucketMetadataOperationsS
         thrown IllegalArgumentException
 
         where:
-        name << ['..', 'foo/bar', '.metadata']
+        name << ['..', 'foo/bar', '.mn-storage']
     }
 }

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperationsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperationsSpec.groovy
@@ -1,0 +1,47 @@
+package io.micronaut.objectstorage.local
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.objectstorage.BucketMetadataOperationsSpecification
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.bucket.BucketOperations
+import io.micronaut.objectstorage.metadata.BucketMetadataOperations
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class LocalStorageBucketMetadataOperationsSpec extends BucketMetadataOperationsSpecification {
+
+    private Path rootDirectory
+    private Path defaultBucketPath
+    private ApplicationContext ctx
+
+    void setup() {
+        rootDirectory = Files.createTempDirectory('LocalStorageBucketMetadataOperationsSpec')
+        defaultBucketPath = rootDirectory.resolve('default')
+        ctx = ApplicationContext.run([
+            'micronaut.object-storage.local.default.path': defaultBucketPath.toString()
+        ])
+    }
+
+    void cleanup() {
+        ctx?.close()
+        if (rootDirectory != null && Files.exists(rootDirectory)) {
+            LocalStorageBucketOperations.deleteRecursively(rootDirectory)
+        }
+    }
+
+    @Override
+    BucketOperations<?> getBucketOperations() {
+        ctx.getBean(LocalStorageBucketOperations)
+    }
+
+    @Override
+    BucketMetadataOperations<?> getBucketMetadataOperations() {
+        ctx.getBean(LocalStorageBucketMetadataOperations)
+    }
+
+    @Override
+    ObjectStorageOperations<?, ?, ?> getObjectStorage() {
+        ctx.getBean(LocalStorageOperations)
+    }
+}

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperationsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperationsSpec.groovy
@@ -44,4 +44,21 @@ class LocalStorageBucketMetadataOperationsSpec extends BucketMetadataOperationsS
     ObjectStorageOperations<?, ?, ?> getObjectStorage() {
         ctx.getBean(LocalStorageOperations)
     }
+
+    void 'it rejects invalid bucket metadata names consistently'() {
+        when:
+        getBucketMetadataOperations().retrieve(name)
+
+        then:
+        thrown IllegalArgumentException
+
+        when:
+        getBucketMetadataOperations().delete(name)
+
+        then:
+        thrown IllegalArgumentException
+
+        where:
+        name << ['..', 'foo/bar', '.metadata']
+    }
 }

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageBucketOperationsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageBucketOperationsSpec.groovy
@@ -57,4 +57,29 @@ class LocalStorageBucketOperationsSpec extends BucketOperationsSpecification {
         then:
         thrown IllegalArgumentException
     }
+
+    void 'it rejects reserved bucket names'() {
+        when:
+        getBucketOperations().create('.metadata')
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == 'Bucket name uses the reserved .metadata namespace: .metadata'
+    }
+
+    void 'failed bucket delete preserves metadata sidecars'() {
+        given:
+        Path bucket = rootDirectory.resolve('stuck')
+        Files.writeString(bucket, 'not-a-directory')
+        Path metadataFile = rootDirectory.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('buckets').resolve('stuck')
+        Files.createDirectories(metadataFile.parent)
+        Files.writeString(metadataFile, 'owner=cliponaut')
+
+        when:
+        getBucketOperations().delete('stuck')
+
+        then:
+        thrown IllegalStateException
+        Files.exists(metadataFile)
+    }
 }

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageBucketOperationsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageBucketOperationsSpec.groovy
@@ -60,18 +60,26 @@ class LocalStorageBucketOperationsSpec extends BucketOperationsSpecification {
 
     void 'it rejects reserved bucket names'() {
         when:
-        getBucketOperations().create('.metadata')
+        getBucketOperations().create(name)
 
         then:
         def e = thrown(IllegalArgumentException)
-        e.message == 'Bucket name uses the reserved .metadata namespace: .metadata'
+        e.message == "Bucket name uses the reserved ${reservedNamespace} namespace: ${name}"
+
+        where:
+        name          | reservedNamespace
+        '.mn-storage' | '.mn-storage'
+        '.Mn-Storage' | '.mn-storage'
     }
 
     void 'failed bucket delete preserves metadata sidecars'() {
         given:
         Path bucket = rootDirectory.resolve('stuck')
         Files.writeString(bucket, 'not-a-directory')
-        Path metadataFile = rootDirectory.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('buckets').resolve('stuck')
+        Path metadataFile = rootDirectory.resolve(LocalStorageOperations.INTERNAL_DIRECTORY)
+            .resolve(LocalStorageOperations.METADATA_DIRECTORY)
+            .resolve('buckets')
+            .resolve('stuck')
         Files.createDirectories(metadataFile.parent)
         Files.writeString(metadataFile, 'owner=cliponaut')
 

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageCustomMetadataOperationsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageCustomMetadataOperationsSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.objectstorage.local
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Primary
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
 import io.micronaut.objectstorage.metadata.BucketMetadataEntry
@@ -229,12 +230,14 @@ class LocalStorageCustomMetadataOperationsSpec extends Specification {
 
         @Singleton
         @Named("default")
+        @Primary
         CustomObjectMetadataOperations objectMetadataOperations() {
             new CustomObjectMetadataOperations()
         }
 
         @Singleton
         @Named("default")
+        @Primary
         CustomBucketMetadataOperations bucketMetadataOperations() {
             new CustomBucketMetadataOperations()
         }

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageCustomMetadataOperationsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageCustomMetadataOperationsSpec.groovy
@@ -1,0 +1,332 @@
+package io.micronaut.objectstorage.local
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.objectstorage.metadata.BucketMetadataEntry
+import io.micronaut.objectstorage.metadata.BucketMetadataOperations
+import io.micronaut.objectstorage.metadata.BucketMetadataWrite
+import io.micronaut.objectstorage.metadata.ObjectMetadataEntry
+import io.micronaut.objectstorage.metadata.ObjectMetadataOperations
+import io.micronaut.objectstorage.metadata.ObjectMetadataWrite
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+
+@Property(name = "spec.name", value = LocalStorageCustomMetadataOperationsSpec.SPEC_NAME)
+@Property(name = "micronaut.object-storage.local.default.enabled", value = "true")
+@MicronautTest
+class LocalStorageCustomMetadataOperationsSpec extends Specification {
+
+    static final String SPEC_NAME = 'LocalStorageCustomMetadataOperationsSpec'
+
+    @Inject
+    LocalStorageOperations operations
+
+    @Inject
+    LocalStorageBucketOperations bucketOperations
+
+    @Inject
+    @Named("default")
+    CustomObjectMetadataOperations objectMetadataOperations
+
+    @Inject
+    @Named("default")
+    CustomBucketMetadataOperations bucketMetadataOperations
+
+    void cleanup() {
+        objectMetadataOperations.clearFailures()
+        operations.listObjects().each { operations.delete(it) }
+        objectMetadataOperations.reset()
+        bucketMetadataOperations.reset()
+    }
+
+    void 'local object storage delegates object metadata to configured metadata operations'() {
+        given:
+        UploadRequest request = UploadRequest.fromBytes('hello'.bytes, 'nested/object.txt', 'text/plain')
+        request.metadata = [source: 'custom']
+
+        when:
+        operations.upload(request)
+
+        then:
+        objectMetadataOperations.retrieve('nested/object.txt').get().metadata == [source: 'custom']
+        operations.retrieve('nested/object.txt').get().metadata == [source: 'custom']
+
+        when:
+        operations.delete('nested/object.txt')
+
+        then:
+        objectMetadataOperations.deletedKeys == ['nested/object.txt']
+    }
+
+    void 'local copy delegates object metadata to configured metadata operations'() {
+        given:
+        UploadRequest request = UploadRequest.fromBytes('hello'.bytes, 'source.txt', 'text/plain')
+        request.metadata = [source: 'custom']
+        operations.upload(request)
+
+        when:
+        operations.copy('source.txt', 'copy.txt')
+
+        then:
+        objectMetadataOperations.retrieve('copy.txt').get().metadata == [source: 'custom']
+        operations.retrieve('copy.txt').get().metadata == [source: 'custom']
+        operations.retrieve('copy.txt').get().inputStream.text == 'hello'
+    }
+
+    void 'local copy deletes destination metadata when source metadata is missing'() {
+        given:
+        operations.upload(UploadRequest.fromBytes('source'.bytes, 'source-without-metadata.txt', 'text/plain'))
+        UploadRequest destination = UploadRequest.fromBytes('destination'.bytes, 'destination.txt', 'text/plain')
+        destination.metadata = [source: 'stale']
+        operations.upload(destination)
+        objectMetadataOperations.delete('source-without-metadata.txt')
+        objectMetadataOperations.deletedKeys.clear()
+
+        when:
+        operations.copy('source-without-metadata.txt', 'destination.txt')
+
+        then:
+        objectMetadataOperations.deletedKeys == ['destination.txt']
+        !objectMetadataOperations.retrieve('destination.txt').present
+        operations.retrieve('destination.txt').get().metadata == [:]
+        operations.retrieve('destination.txt').get().inputStream.text == 'source'
+    }
+
+    void 'failed object metadata save removes a newly created object'() {
+        given:
+        objectMetadataOperations.failSaves = true
+
+        when:
+        operations.upload(UploadRequest.fromBytes('new'.bytes, 'new.txt', 'text/plain'))
+
+        then:
+        IllegalStateException e = thrown()
+        e.message == 'metadata unavailable'
+        !operations.exists('new.txt')
+    }
+
+    void 'failed object metadata save does not delete an existing object'() {
+        given:
+        operations.upload(UploadRequest.fromBytes('original'.bytes, 'existing.txt', 'text/plain'))
+        objectMetadataOperations.failSaves = true
+
+        when:
+        operations.upload(UploadRequest.fromBytes('replacement'.bytes, 'existing.txt', 'text/plain'))
+
+        then:
+        IllegalStateException e = thrown()
+        e.message == 'metadata unavailable'
+        operations.exists('existing.txt')
+        new String(operations.retrieve('existing.txt').get().inputStream.readAllBytes(), StandardCharsets.UTF_8) == 'original'
+    }
+
+    void 'failed copy metadata save removes a newly created destination object'() {
+        given:
+        operations.upload(UploadRequest.fromBytes('source'.bytes, 'source.txt', 'text/plain'))
+        objectMetadataOperations.failSaves = true
+
+        when:
+        operations.copy('source.txt', 'failed-copy.txt')
+
+        then:
+        IllegalStateException e = thrown()
+        e.message == 'metadata unavailable'
+        !operations.exists('failed-copy.txt')
+    }
+
+    void 'failed copy metadata save preserves an existing destination object'() {
+        given:
+        operations.upload(UploadRequest.fromBytes('source'.bytes, 'source.txt', 'text/plain'))
+        operations.upload(UploadRequest.fromBytes('destination'.bytes, 'destination.txt', 'text/plain'))
+        objectMetadataOperations.failSaves = true
+
+        when:
+        operations.copy('source.txt', 'destination.txt')
+
+        then:
+        IllegalStateException e = thrown()
+        e.message == 'metadata unavailable'
+        operations.exists('destination.txt')
+        def entry = operations.retrieve('destination.txt').get()
+        new String(entry.inputStream.readAllBytes(), StandardCharsets.UTF_8) == 'destination'
+        !Files.exists(entry.nativeEntry.parent.resolve(LocalStorageOperations.INTERNAL_DIRECTORY))
+    }
+
+    void 'failed object metadata delete preserves the stored object'() {
+        given:
+        operations.upload(UploadRequest.fromBytes('content'.bytes, 'delete-failure.txt', 'text/plain'))
+        objectMetadataOperations.failDeletes = true
+
+        when:
+        operations.delete('delete-failure.txt')
+
+        then:
+        IllegalStateException e = thrown()
+        e.message == 'metadata unavailable'
+        operations.exists('delete-failure.txt')
+        def entry = operations.retrieve('delete-failure.txt').get()
+        new String(entry.inputStream.readAllBytes(), StandardCharsets.UTF_8) == 'content'
+        !Files.exists(entry.nativeEntry.parent.resolve(LocalStorageOperations.INTERNAL_DIRECTORY)
+            .resolve(LocalStorageOperations.SNAPSHOT_DIRECTORY))
+    }
+
+    void 'local bucket storage delegates bucket metadata to configured metadata operations'() {
+        given:
+        String bucketName = 'custom-bucket'
+        bucketOperations.create(bucketName)
+        bucketMetadataOperations.save(new BucketMetadataWrite(bucketName, [source: 'custom']))
+
+        expect:
+        bucketMetadataOperations.retrieve(bucketName).get().metadata == [source: 'custom']
+
+        when:
+        bucketOperations.delete(bucketName)
+
+        then:
+        bucketMetadataOperations.deletedNames == [bucketName]
+        !bucketMetadataOperations.retrieve(bucketName).present
+    }
+
+    void 'custom metadata operations do not create sidecar metadata directories on context startup'() {
+        given:
+        Path rootDirectory = Files.createTempDirectory('LocalStorageCustomMetadataOperationsSpec')
+        Path bucketPath = rootDirectory.resolve('default')
+        ApplicationContext context = null
+
+        when:
+        context = ApplicationContext.run([
+            'spec.name': SPEC_NAME,
+            'micronaut.object-storage.local.default.path': bucketPath.toString()
+        ])
+        context.getBean(LocalStorageOperations)
+        context.getBean(LocalStorageBucketOperations)
+        context.getBean(LocalStorageObjectMetadataOperations)
+        context.getBean(LocalStorageBucketMetadataOperations)
+
+        then:
+        !Files.exists(bucketPath.resolve(LocalStorageOperations.INTERNAL_DIRECTORY))
+        !Files.exists(rootDirectory.resolve(LocalStorageOperations.INTERNAL_DIRECTORY))
+
+        cleanup:
+        context?.close()
+        if (Files.exists(rootDirectory)) {
+            LocalStorageBucketOperations.deleteRecursively(rootDirectory)
+        }
+    }
+
+    @Factory
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    static class MetadataOperationsFactory {
+
+        @Singleton
+        @Named("default")
+        CustomObjectMetadataOperations objectMetadataOperations() {
+            new CustomObjectMetadataOperations()
+        }
+
+        @Singleton
+        @Named("default")
+        CustomBucketMetadataOperations bucketMetadataOperations() {
+            new CustomBucketMetadataOperations()
+        }
+    }
+
+    static class CustomObjectMetadataOperations implements ObjectMetadataOperations<Path> {
+        final Map<String, ObjectMetadataWrite> writes = new ConcurrentHashMap<>()
+        final List<String> deletedKeys = Collections.synchronizedList([])
+        boolean failSaves
+        boolean failDeletes
+
+        @Override
+        Optional<ObjectMetadataEntry<Path>> retrieve(String key) {
+            ObjectMetadataWrite write = writes.get(key)
+            if (write == null) {
+                return Optional.empty()
+            }
+            return Optional.of(new ObjectMetadataEntry<>(
+                key,
+                write.metadata(),
+                write.attributes(),
+                write.contentType(),
+                write.contentLength(),
+                write.etag(),
+                write.lastModified(),
+                Path.of('metadata', key)
+            ))
+        }
+
+        @Override
+        void save(ObjectMetadataWrite write) {
+            if (failSaves) {
+                throw new IllegalStateException('metadata unavailable')
+            }
+            writes.put(write.key(), write)
+        }
+
+        @Override
+        void delete(String key) {
+            if (failDeletes) {
+                throw new IllegalStateException('metadata unavailable')
+            }
+            deletedKeys.add(key)
+            writes.remove(key)
+        }
+
+        void reset() {
+            clearFailures()
+            writes.clear()
+            deletedKeys.clear()
+        }
+
+        void clearFailures() {
+            failSaves = false
+            failDeletes = false
+        }
+    }
+
+    static class CustomBucketMetadataOperations implements BucketMetadataOperations<Path> {
+        final Map<String, BucketMetadataWrite> writes = new ConcurrentHashMap<>()
+        final List<String> deletedNames = Collections.synchronizedList([])
+
+        @Override
+        Optional<BucketMetadataEntry<Path>> retrieve(String name) {
+            BucketMetadataWrite write = writes.get(name)
+            if (write == null) {
+                return Optional.empty()
+            }
+            return Optional.of(new BucketMetadataEntry<>(
+                name,
+                write.metadata(),
+                write.attributes(),
+                Path.of('metadata', name)
+            ))
+        }
+
+        @Override
+        void save(BucketMetadataWrite write) {
+            writes.put(write.name(), write)
+        }
+
+        @Override
+        void delete(String name) {
+            deletedNames.add(name)
+            writes.remove(name)
+        }
+
+        void reset() {
+            writes.clear()
+            deletedNames.clear()
+        }
+    }
+}

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageCustomMetadataOperationsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageCustomMetadataOperationsSpec.groovy
@@ -211,8 +211,6 @@ class LocalStorageCustomMetadataOperationsSpec extends Specification {
         ])
         context.getBean(LocalStorageOperations)
         context.getBean(LocalStorageBucketOperations)
-        context.getBean(LocalStorageObjectMetadataOperations)
-        context.getBean(LocalStorageBucketMetadataOperations)
 
         then:
         !Files.exists(bucketPath.resolve(LocalStorageOperations.INTERNAL_DIRECTORY))

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageFilePermissionsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageFilePermissionsSpec.groovy
@@ -37,16 +37,18 @@ class LocalStorageFilePermissionsSpec extends Specification {
 
         then:
         Files.getPosixFilePermissions(bucket) == ownerOnlyDirectoryPermissions()
-        Files.getPosixFilePermissions(root.resolve(LocalStorageOperations.METADATA_DIRECTORY)) == ownerOnlyDirectoryPermissions()
-        Files.getPosixFilePermissions(root.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('buckets')) == ownerOnlyDirectoryPermissions()
-        Files.getPosixFilePermissions(root.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('buckets/reports')) == ownerOnlyFilePermissions()
-        Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.METADATA_DIRECTORY)) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(root.resolve(LocalStorageOperations.INTERNAL_DIRECTORY)) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(root.resolve(LocalStorageOperations.INTERNAL_DIRECTORY).resolve(LocalStorageOperations.METADATA_DIRECTORY)) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(root.resolve(LocalStorageOperations.INTERNAL_DIRECTORY).resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('buckets')) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(root.resolve(LocalStorageOperations.INTERNAL_DIRECTORY).resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('buckets/reports')) == ownerOnlyFilePermissions()
+        Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.INTERNAL_DIRECTORY)) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.INTERNAL_DIRECTORY).resolve(LocalStorageOperations.METADATA_DIRECTORY)) == ownerOnlyDirectoryPermissions()
         Files.getPosixFilePermissions(bucket.resolve('nested')) == ownerOnlyDirectoryPermissions()
         Files.getPosixFilePermissions(bucket.resolve('nested/deeper')) == ownerOnlyDirectoryPermissions()
-        Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('nested')) == ownerOnlyDirectoryPermissions()
-        Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('nested/deeper')) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.INTERNAL_DIRECTORY).resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('nested')) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.INTERNAL_DIRECTORY).resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('nested/deeper')) == ownerOnlyDirectoryPermissions()
         Files.getPosixFilePermissions(bucket.resolve('nested/deeper/object.txt')) == ownerOnlyFilePermissions()
-        Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('nested/deeper/object.txt')) == ownerOnlyFilePermissions()
+        Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.INTERNAL_DIRECTORY).resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('nested/deeper/object.txt')) == ownerOnlyFilePermissions()
 
         cleanup:
         ctx?.close()

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageFilePermissionsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageFilePermissionsSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.objectstorage.local
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.objectstorage.metadata.BucketMetadataWrite
 import io.micronaut.objectstorage.request.UploadRequest
 import spock.lang.Requires
 import spock.lang.Specification
@@ -24,14 +25,21 @@ class LocalStorageFilePermissionsSpec extends Specification {
         Path bucket = root.resolve("bucket")
         ApplicationContext ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
         LocalStorageOperations operations = ctx.getBean(LocalStorageOperations)
+        LocalStorageBucketOperations bucketOperations = ctx.getBean(LocalStorageBucketOperations)
+        LocalStorageBucketMetadataOperations bucketMetadataOperations = ctx.getBean(LocalStorageBucketMetadataOperations)
         UploadRequest request = UploadRequest.fromBytes('secret'.getBytes(StandardCharsets.UTF_8), 'nested/deeper/object.txt', 'text/plain')
         request.metadata = [classification: 'internal']
 
         when:
+        bucketOperations.create('reports')
+        bucketMetadataOperations.save(new BucketMetadataWrite('reports', [region: 'internal'], [:]))
         operations.upload(request)
 
         then:
         Files.getPosixFilePermissions(bucket) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(root.resolve(LocalStorageOperations.METADATA_DIRECTORY)) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(root.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('buckets')) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(root.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('buckets/reports')) == ownerOnlyFilePermissions()
         Files.getPosixFilePermissions(bucket.resolve(LocalStorageOperations.METADATA_DIRECTORY)) == ownerOnlyDirectoryPermissions()
         Files.getPosixFilePermissions(bucket.resolve('nested')) == ownerOnlyDirectoryPermissions()
         Files.getPosixFilePermissions(bucket.resolve('nested/deeper')) == ownerOnlyDirectoryPermissions()

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMetadataCompatibilitySpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMetadataCompatibilitySpec.groovy
@@ -1,0 +1,90 @@
+package io.micronaut.objectstorage.local
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.objectstorage.metadata.ObjectMetadataWrite
+import io.micronaut.objectstorage.request.UploadRequest
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Properties
+
+class LocalStorageMetadataCompatibilitySpec extends Specification {
+
+    private Path rootDirectory
+    private Path bucketPath
+    private ApplicationContext ctx
+
+    void setup() {
+        rootDirectory = Files.createTempDirectory('LocalStorageMetadataCompatibilitySpec')
+        bucketPath = rootDirectory.resolve('default')
+        ctx = ApplicationContext.run([
+            'micronaut.object-storage.local.default.path': bucketPath.toString()
+        ])
+    }
+
+    void cleanup() {
+        ctx?.close()
+        if (rootDirectory != null && Files.exists(rootDirectory)) {
+            LocalStorageBucketOperations.deleteRecursively(rootDirectory)
+        }
+    }
+
+    void 'legacy sidecars without a marker stay in legacy mode even for structured-looking keys'() {
+        given:
+        ctx.getBean(LocalStorageOperations).upload(UploadRequest.fromBytes('hello'.bytes, 'legacy.txt', 'text/plain'))
+        Path legacyFile = bucketPath.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('legacy.txt')
+        Files.createDirectories(legacyFile.parent)
+        Properties legacy = new Properties()
+        legacy.setProperty('metadata.owner', 'ops')
+        legacy.setProperty('attribute.region', 'eu-west-1')
+        legacy.setProperty('system.contentType', 'text/plain')
+        Files.newOutputStream(legacyFile).withCloseable {
+            legacy.store(it, 'legacy metadata')
+        }
+
+        when:
+        def entry = ctx.getBean(LocalStorageObjectMetadataOperations).retrieve('legacy.txt').get()
+
+        then:
+        entry.metadata == [
+            'metadata.owner': 'ops',
+            'attribute.region': 'eu-west-1',
+            'system.contentType': 'text/plain',
+        ]
+        entry.attributes == [:]
+        entry.contentType == null
+        entry.contentLength == null
+        entry.etag == null
+        entry.lastModified == null
+    }
+
+    void 'structured sidecars write an explicit marker and preserve prefixed metadata keys'() {
+        given:
+        ctx.getBean(LocalStorageOperations).upload(UploadRequest.fromBytes('hello'.bytes, 'structured.txt', 'text/plain'))
+        def metadataOperations = ctx.getBean(LocalStorageObjectMetadataOperations)
+
+        when:
+        metadataOperations.save(new ObjectMetadataWrite(
+            'structured.txt',
+            ['metadata.owner': 'ops'],
+            ['attribute.region': 'eu-west-1'],
+            'text/plain',
+            null,
+            'etag-1',
+            null
+        ))
+        Properties stored = new Properties()
+        Files.newInputStream(bucketPath.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('structured.txt')).withCloseable {
+            stored.load(it)
+        }
+        def entry = metadataOperations.retrieve('structured.txt').get()
+
+        then:
+        stored.getProperty('micronaut.local.metadata.format') == 'structured-v1'
+        entry.metadata == ['metadata.owner': 'ops']
+        entry.attributes == ['attribute.region': 'eu-west-1']
+        entry.contentType == 'text/plain'
+        entry.etag == 'etag-1'
+    }
+}

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMetadataCompatibilitySpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMetadataCompatibilitySpec.groovy
@@ -33,7 +33,9 @@ class LocalStorageMetadataCompatibilitySpec extends Specification {
     void 'legacy sidecars without a marker stay in legacy mode even for structured-looking keys'() {
         given:
         ctx.getBean(LocalStorageOperations).upload(UploadRequest.fromBytes('hello'.bytes, 'legacy.txt', 'text/plain'))
-        Path legacyFile = bucketPath.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('legacy.txt')
+        Path legacyFile = bucketPath.resolve(LocalStorageOperations.INTERNAL_DIRECTORY)
+            .resolve(LocalStorageOperations.METADATA_DIRECTORY)
+            .resolve('legacy.txt')
         Files.createDirectories(legacyFile.parent)
         Properties legacy = new Properties()
         legacy.setProperty('metadata.owner', 'ops')
@@ -75,7 +77,9 @@ class LocalStorageMetadataCompatibilitySpec extends Specification {
             null
         ))
         Properties stored = new Properties()
-        Files.newInputStream(bucketPath.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve('structured.txt')).withCloseable {
+        Files.newInputStream(bucketPath.resolve(LocalStorageOperations.INTERNAL_DIRECTORY)
+            .resolve(LocalStorageOperations.METADATA_DIRECTORY)
+            .resolve('structured.txt')).withCloseable {
             stored.load(it)
         }
         def entry = metadataOperations.retrieve('structured.txt').get()

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageObjectMetadataOperationsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageObjectMetadataOperationsSpec.groovy
@@ -1,0 +1,33 @@
+package io.micronaut.objectstorage.local
+
+import io.micronaut.objectstorage.ObjectMetadataOperationsSpecification
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.metadata.ObjectMetadataOperations
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+
+@MicronautTest
+class LocalStorageObjectMetadataOperationsSpec extends ObjectMetadataOperationsSpecification implements TestPropertyProvider {
+
+    @Inject
+    LocalStorageOperations operations
+
+    @Inject
+    ObjectMetadataOperations<?> metadataOperations
+
+    @Override
+    ObjectStorageOperations<?, ?, ?> getObjectStorage() {
+        operations
+    }
+
+    @Override
+    ObjectMetadataOperations<?> getObjectMetadataOperations() {
+        metadataOperations
+    }
+
+    @Override
+    Map<String, String> getProperties() {
+        [(LocalStorageConfiguration.PREFIX + '.default.enabled'): "true"]
+    }
+}

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePaginationSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePaginationSpec.groovy
@@ -50,9 +50,9 @@ class LocalStoragePaginationSpec extends spock.lang.Specification implements Tes
         secondPage.continuationToken.empty
         replayedTerminalPage.keys.empty
         replayedTerminalPage.continuationToken.empty
-        !firstPage.keys.any { it.startsWith('.metadata') }
-        !secondPage.keys.any { it.startsWith('.metadata') }
-        !replayedTerminalPage.keys.any { it.startsWith('.metadata') }
+        !firstPage.keys.any { it.startsWith('.mn-storage') }
+        !secondPage.keys.any { it.startsWith('.mn-storage') }
+        !replayedTerminalPage.keys.any { it.startsWith('.mn-storage') }
     }
 
     void 'continuation token is a strict lower bound and malicious prefixes stay inside the bucket'() {
@@ -60,7 +60,7 @@ class LocalStoragePaginationSpec extends spock.lang.Specification implements Tes
         def page = operations.listObjects(new ListObjectsRequest(2, null, 'animals/dog.txt'))
         def allKeys = operations.listObjects() as List
         def maliciousPrefixPage = operations.listObjects(new ListObjectsRequest(5, '../'))
-        def metadataPrefixPage = operations.listObjects(new ListObjectsRequest(5, '.metadata'))
+        def metadataPrefixPage = operations.listObjects(new ListObjectsRequest(5, '.mn-storage'))
 
         then:
         page.keys == ['animals/mammals/fox.txt', 'animals/zebra.txt']

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePathTraversalSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePathTraversalSpec.groovy
@@ -117,7 +117,7 @@ class LocalStoragePathTraversalSpec extends Specification {
         Path metadataTarget = outside.resolve("metadata-target")
         Files.createDirectory(metadataTarget)
         assumeSymbolicLinksSupported(tmp)
-        Files.createSymbolicLink(bucket.resolve(LocalStorageOperations.METADATA_DIRECTORY), metadataTarget)
+        Files.createSymbolicLink(bucket.resolve(LocalStorageOperations.INTERNAL_DIRECTORY), metadataTarget)
 
         ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
         UploadRequest request = UploadRequest.fromBytes("evil".bytes, "public", "text/plain")
@@ -129,7 +129,7 @@ class LocalStoragePathTraversalSpec extends Specification {
         then:
         thrown IllegalArgumentException
         !Files.exists(bucket.resolve("public"))
-        !Files.exists(metadataTarget.resolve("public"))
+        !Files.exists(metadataTarget.resolve(LocalStorageOperations.METADATA_DIRECTORY).resolve("public"))
 
         cleanup:
         ctx?.close()

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageReservedMetadataSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageReservedMetadataSpec.groovy
@@ -8,6 +8,8 @@ import jakarta.inject.Inject
 import spock.lang.Specification
 
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
 
 @MicronautTest
 class LocalStorageReservedMetadataSpec extends Specification implements TestPropertyProvider {
@@ -24,7 +26,7 @@ class LocalStorageReservedMetadataSpec extends Specification implements TestProp
         operations.listObjects().each { operations.delete(it) }
     }
 
-    void 'reserved metadata keys are rejected for upload without corrupting stored metadata'() {
+    void 'reserved local storage keys are rejected for upload without corrupting stored metadata'() {
         given:
         def request = UploadRequest.fromBytes('safe'.bytes, 'foo.txt', 'text/plain')
         request.metadata = [owner: 'safe']
@@ -35,7 +37,7 @@ class LocalStorageReservedMetadataSpec extends Specification implements TestProp
 
         then:
         def ex = thrown(IllegalArgumentException)
-        ex.message == "Key uses the reserved .metadata namespace: ${key}"
+        ex.message == "Key uses the reserved ${reservedNamespace(key)} namespace: ${key}"
         operations.listObjects() == ['foo.txt'] as Set
         operations.retrieve('foo.txt').get().metadata == [owner: 'safe']
 
@@ -43,66 +45,85 @@ class LocalStorageReservedMetadataSpec extends Specification implements TestProp
         key << blockedKeys()
     }
 
-    void 'reserved metadata keys are rejected for direct object operations'() {
+    void 'reserved local storage keys are rejected for direct object operations'() {
         when:
         operations.retrieve(key)
 
         then:
         def retrieveException = thrown(IllegalArgumentException)
-        retrieveException.message == "Key uses the reserved .metadata namespace: ${key}"
+        retrieveException.message == "Key uses the reserved ${reservedNamespace(key)} namespace: ${key}"
 
         when:
         operations.delete(key)
 
         then:
         def deleteException = thrown(IllegalArgumentException)
-        deleteException.message == "Key uses the reserved .metadata namespace: ${key}"
+        deleteException.message == "Key uses the reserved ${reservedNamespace(key)} namespace: ${key}"
 
         when:
         operations.exists(key)
 
         then:
         def existsException = thrown(IllegalArgumentException)
-        existsException.message == "Key uses the reserved .metadata namespace: ${key}"
+        existsException.message == "Key uses the reserved ${reservedNamespace(key)} namespace: ${key}"
 
         when:
         operations.upload(UploadRequest.fromBytes('blocked'.bytes, key, 'text/plain'))
 
         then:
         def uploadException = thrown(IllegalArgumentException)
-        uploadException.message == "Key uses the reserved .metadata namespace: ${key}"
+        uploadException.message == "Key uses the reserved ${reservedNamespace(key)} namespace: ${key}"
 
         where:
         key << blockedKeys()
     }
 
-    void 'listing never exposes the reserved metadata namespace'() {
+    void 'listing never exposes reserved local storage namespaces'() {
         given:
         operations.upload(UploadRequest.fromBytes('visible'.bytes, 'visible.txt', 'text/plain'))
+        def bucketPath = operations.retrieve('visible.txt').get().nativeEntry.parent
+        Path internalDirectory = bucketPath.resolve(LocalStorageOperations.INTERNAL_DIRECTORY)
+        Path snapshotDirectory = internalDirectory.resolve(LocalStorageOperations.SNAPSHOT_DIRECTORY)
+        Files.createDirectories(snapshotDirectory)
+        Files.writeString(snapshotDirectory.resolve('temporary'), 'hidden')
 
         expect:
-        operations.listObjects(new ListObjectsRequest(5, '.metadata')).keys.empty
-        operations.listObjects(new ListObjectsRequest(5, '.metadata/')).keys.empty
+        operations.listObjects(new ListObjectsRequest(5, '.mn-storage')).keys.empty
+        operations.listObjects(new ListObjectsRequest(5, '.mn-storage/')).keys.empty
+        operations.listObjects(new ListObjectsRequest(5, '.mn-storage/metadata')).keys.empty
+        operations.listObjects(new ListObjectsRequest(5, '.mn-storage/snapshots')).keys.empty
         operations.listObjects() == ['visible.txt'] as Set
+
+        cleanup:
+        Files.deleteIfExists(snapshotDirectory.resolve('temporary'))
+        Files.deleteIfExists(snapshotDirectory)
     }
 
     private static List<String> blockedKeys() {
-        def keys = ['.metadata', '.Metadata', '.METADATA']
-                .collectMany { metadataDirectory ->
+        def keys = reservedNamespaces()
+                .collectMany { reservedNamespace ->
                     [
-                            metadataDirectory,
-                            "${metadataDirectory}/nested.txt",
-                            "foo/../${metadataDirectory}/nested.txt",
-                            "./${metadataDirectory}/nested.txt"
+                            reservedNamespace,
+                            "${reservedNamespace}/nested.txt",
+                            "foo/../${reservedNamespace}/nested.txt",
+                            "./${reservedNamespace}/nested.txt"
                     ]
                 }
         if (File.separatorChar != '/') {
-            ['.metadata', '.Metadata', '.METADATA'].each { metadataDirectory ->
-                keys << "${metadataDirectory}${File.separator}nested.txt"
-                keys << "foo${File.separator}..${File.separator}${metadataDirectory}${File.separator}nested.txt"
-                keys << ".${File.separator}${metadataDirectory}${File.separator}nested.txt"
+            reservedNamespaces().each { reservedNamespace ->
+                keys << "${reservedNamespace}${File.separator}nested.txt"
+                keys << "foo${File.separator}..${File.separator}${reservedNamespace}${File.separator}nested.txt"
+                keys << ".${File.separator}${reservedNamespace}${File.separator}nested.txt"
             }
         }
         keys
+    }
+
+    private static List<String> reservedNamespaces() {
+        ['.mn-storage', '.Mn-Storage', '.MN-STORAGE']
+    }
+
+    private static String reservedNamespace(String key) {
+        '.mn-storage'
     }
 }

--- a/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/BucketMetadataOperationsSpecification.groovy
+++ b/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/BucketMetadataOperationsSpecification.groovy
@@ -27,6 +27,8 @@ import java.util.UUID
 
 abstract class BucketMetadataOperationsSpecification extends Specification {
 
+    private static final String OWNER = "cliponaut"
+
     void 'it can save retrieve update and delete bucket metadata'() {
         given:
         BucketOperations<?> bucketOperations = getBucketOperations()
@@ -42,12 +44,12 @@ abstract class BucketMetadataOperationsSpecification extends Specification {
         }
 
         when:
-        metadataOperations.save(new BucketMetadataWrite(bucketName, [region: "test"], [owner: "cliponaut"]))
+        metadataOperations.save(new BucketMetadataWrite(bucketName, [region: "test"], [owner: OWNER]))
 
         then:
         metadataOperations.retrieve(bucketName).present
         metadataOperations.retrieve(bucketName).get().metadata == [region: "test"]
-        metadataOperations.retrieve(bucketName).get().attributes == [owner: "cliponaut"]
+        metadataOperations.retrieve(bucketName).get().attributes == [owner: OWNER]
 
         when:
         metadataOperations.save(new BucketMetadataWrite(bucketName, [region: "prod"], [owner: "core"]))
@@ -81,7 +83,7 @@ abstract class BucketMetadataOperationsSpecification extends Specification {
         when:
         storage.upload(UploadRequest.fromBytes("foo".bytes, key))
         bucketOperations.create(bucketName)
-        metadataOperations.save(new BucketMetadataWrite(bucketName, [region: "test"], [owner: "cliponaut"]))
+        metadataOperations.save(new BucketMetadataWrite(bucketName, [region: "test"], [owner: OWNER]))
 
         then:
         conditions.eventually {

--- a/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/BucketMetadataOperationsSpecification.groovy
+++ b/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/BucketMetadataOperationsSpecification.groovy
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage
+
+import io.micronaut.objectstorage.bucket.BucketOperations
+import io.micronaut.objectstorage.metadata.BucketMetadataOperations
+import io.micronaut.objectstorage.metadata.BucketMetadataWrite
+import io.micronaut.objectstorage.request.UploadRequest
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+
+abstract class BucketMetadataOperationsSpecification extends Specification {
+
+    void 'it can save retrieve update and delete bucket metadata'() {
+        given:
+        BucketOperations<?> bucketOperations = getBucketOperations()
+        BucketMetadataOperations<?> metadataOperations = getBucketMetadataOperations()
+        String bucketName = newBucketName()
+
+        when:
+        bucketOperations.create(bucketName)
+
+        then:
+        new PollingConditions(timeout: 30).eventually {
+            assert bucketOperations.exists(bucketName)
+        }
+
+        when:
+        metadataOperations.save(new BucketMetadataWrite(bucketName, [region: "test"], [owner: "cliponaut"]))
+
+        then:
+        metadataOperations.retrieve(bucketName).present
+        metadataOperations.retrieve(bucketName).get().metadata == [region: "test"]
+        metadataOperations.retrieve(bucketName).get().attributes == [owner: "cliponaut"]
+
+        when:
+        metadataOperations.save(new BucketMetadataWrite(bucketName, [region: "prod"], [owner: "core"]))
+
+        then:
+        metadataOperations.retrieve(bucketName).get().metadata == [region: "prod"]
+        metadataOperations.retrieve(bucketName).get().attributes == [owner: "core"]
+
+        when:
+        metadataOperations.delete(bucketName)
+
+        then:
+        !metadataOperations.retrieve(bucketName).present
+
+        cleanup:
+        metadataOperations.delete(bucketName)
+        if (bucketOperations.exists(bucketName)) {
+            bucketOperations.delete(bucketName)
+        }
+    }
+
+    void 'bucket metadata operations do not retarget the configured object storage bean'() {
+        given:
+        BucketOperations<?> bucketOperations = getBucketOperations()
+        BucketMetadataOperations<?> metadataOperations = getBucketMetadataOperations()
+        ObjectStorageOperations<?, ?, ?> storage = getObjectStorage()
+        String bucketName = newBucketName()
+        String key = "bucket-metadata-${UUID.randomUUID()}.txt"
+        PollingConditions conditions = new PollingConditions(timeout: 30)
+
+        when:
+        storage.upload(UploadRequest.fromBytes("foo".bytes, key))
+        bucketOperations.create(bucketName)
+        metadataOperations.save(new BucketMetadataWrite(bucketName, [region: "test"], [owner: "cliponaut"]))
+
+        then:
+        conditions.eventually {
+            assert bucketOperations.exists(bucketName)
+            assert metadataOperations.retrieve(bucketName).present
+        }
+        storage.exists(key)
+        new String(storage.retrieve(key).orElseThrow().inputStream.readAllBytes(), StandardCharsets.UTF_8) == "foo"
+
+        cleanup:
+        metadataOperations.delete(bucketName)
+        if (bucketOperations.exists(bucketName)) {
+            bucketOperations.delete(bucketName)
+        }
+        if (storage.exists(key)) {
+            storage.delete(key)
+        }
+    }
+
+    abstract BucketOperations<?> getBucketOperations()
+
+    abstract BucketMetadataOperations<?> getBucketMetadataOperations()
+
+    abstract ObjectStorageOperations<?, ?, ?> getObjectStorage()
+
+    String newBucketName() {
+        "micronaut-object-storage-${UUID.randomUUID().toString().replace('-', '').substring(0, 20)}"
+    }
+}

--- a/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/ObjectMetadataOperationsSpecification.groovy
+++ b/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/ObjectMetadataOperationsSpecification.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage
+
+import io.micronaut.objectstorage.metadata.ObjectMetadataOperations
+import io.micronaut.objectstorage.metadata.ObjectMetadataWrite
+import io.micronaut.objectstorage.request.UploadRequest
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+
+abstract class ObjectMetadataOperationsSpecification extends Specification {
+
+    void 'it can save retrieve update and delete object metadata without rewriting object bytes'() {
+        given:
+        ObjectStorageOperations<?, ?, ?> storage = getObjectStorage()
+        ObjectMetadataOperations<?> metadataOperations = getObjectMetadataOperations()
+        String key = "metadata-${UUID.randomUUID()}.txt"
+        UploadRequest request = UploadRequest.fromBytes("micronaut".bytes, key, "text/plain")
+        request.metadata = [project: "initial"]
+        storage.upload(request)
+
+        when:
+        def initial = metadataOperations.retrieve(key)
+
+        then:
+        initial.present
+        initial.get().metadata == [project: "initial"]
+        initial.get().attributes == [:]
+
+        when:
+        metadataOperations.save(new ObjectMetadataWrite(
+            key,
+            [project: "updated"],
+            [owner: "cliponaut"],
+            initial.get().contentType(),
+            initial.get().contentLength(),
+            initial.get().etag(),
+            initial.get().lastModified()
+        ))
+
+        then:
+        metadataOperations.retrieve(key).get().metadata == [project: "updated"]
+        metadataOperations.retrieve(key).get().attributes == [owner: "cliponaut"]
+        storage.retrieve(key).get().metadata == [project: "updated"]
+        new String(storage.retrieve(key).get().inputStream.readAllBytes(), StandardCharsets.UTF_8) == "micronaut"
+
+        when:
+        metadataOperations.delete(key)
+
+        then:
+        !metadataOperations.retrieve(key).present
+        storage.retrieve(key).present
+        storage.retrieve(key).get().metadata == [:]
+        new String(storage.retrieve(key).get().inputStream.readAllBytes(), StandardCharsets.UTF_8) == "micronaut"
+
+        cleanup:
+        if (storage.exists(key)) {
+            storage.delete(key)
+        }
+    }
+
+    void 'missing object metadata returns empty'() {
+        expect:
+        !getObjectMetadataOperations().retrieve("missing-${UUID.randomUUID()}.txt").present
+    }
+
+    abstract ObjectStorageOperations<?, ?, ?> getObjectStorage()
+
+    abstract ObjectMetadataOperations<?> getObjectMetadataOperations()
+}

--- a/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/ObjectMetadataOperationsSpecification.groovy
+++ b/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/ObjectMetadataOperationsSpecification.groovy
@@ -25,12 +25,16 @@ import java.util.UUID
 
 abstract class ObjectMetadataOperationsSpecification extends Specification {
 
+    private static final String INITIAL_CONTENT = "micronaut"
+    private static final String UPDATED_PROJECT = "updated"
+    private static final String OWNER = "cliponaut"
+
     void 'it can save retrieve update and delete object metadata without rewriting object bytes'() {
         given:
         ObjectStorageOperations<?, ?, ?> storage = getObjectStorage()
         ObjectMetadataOperations<?> metadataOperations = getObjectMetadataOperations()
         String key = "metadata-${UUID.randomUUID()}.txt"
-        UploadRequest request = UploadRequest.fromBytes("micronaut".bytes, key, "text/plain")
+        UploadRequest request = UploadRequest.fromBytes(INITIAL_CONTENT.bytes, key, "text/plain")
         request.metadata = [project: "initial"]
         storage.upload(request)
 
@@ -45,8 +49,8 @@ abstract class ObjectMetadataOperationsSpecification extends Specification {
         when:
         metadataOperations.save(new ObjectMetadataWrite(
             key,
-            [project: "updated"],
-            [owner: "cliponaut"],
+            [project: UPDATED_PROJECT],
+            [owner: OWNER],
             initial.get().contentType(),
             initial.get().contentLength(),
             initial.get().etag(),
@@ -54,10 +58,10 @@ abstract class ObjectMetadataOperationsSpecification extends Specification {
         ))
 
         then:
-        metadataOperations.retrieve(key).get().metadata == [project: "updated"]
-        metadataOperations.retrieve(key).get().attributes == [owner: "cliponaut"]
-        storage.retrieve(key).get().metadata == [project: "updated"]
-        new String(storage.retrieve(key).get().inputStream.readAllBytes(), StandardCharsets.UTF_8) == "micronaut"
+        metadataOperations.retrieve(key).get().metadata == [project: UPDATED_PROJECT]
+        metadataOperations.retrieve(key).get().attributes == [owner: OWNER]
+        storage.retrieve(key).get().metadata == [project: UPDATED_PROJECT]
+        new String(storage.retrieve(key).get().inputStream.readAllBytes(), StandardCharsets.UTF_8) == INITIAL_CONTENT
 
         when:
         metadataOperations.delete(key)
@@ -66,7 +70,7 @@ abstract class ObjectMetadataOperationsSpecification extends Specification {
         !metadataOperations.retrieve(key).present
         storage.retrieve(key).present
         storage.retrieve(key).get().metadata == [:]
-        new String(storage.retrieve(key).get().inputStream.readAllBytes(), StandardCharsets.UTF_8) == "micronaut"
+        new String(storage.retrieve(key).get().inputStream.readAllBytes(), StandardCharsets.UTF_8) == INITIAL_CONTENT
 
         cleanup:
         if (storage.exists(key)) {

--- a/src/main/docs/guide/local.adoc
+++ b/src/main/docs/guide/local.adoc
@@ -19,6 +19,11 @@ api:objectstorage.ObjectStorageOperations[].
 NOTE: The local storage implementation reserves the `.metadata` key namespace for per-object metadata files. User object
 keys cannot be `.metadata` or start with `.metadata/` (or `.metadata\` on platforms where the file separator is `\`).
 
+The local implementation is also the reference provider for
+api:objectstorage.metadata.ObjectMetadataOperations[] and api:objectstorage.metadata.BucketMetadataOperations[].
+Object metadata sidecars live under the configured bucket's `.metadata` tree, while bucket metadata sidecars live under
+the sibling `.metadata/buckets` tree managed by the local bucket lifecycle API.
+
 By default, it will create a temporary folder to store the files, but you can configure it to use a specific folder:
 
 On POSIX-capable file systems, configured bucket paths created by the local implementation use owner-only permissions for

--- a/src/main/docs/guide/local.adoc
+++ b/src/main/docs/guide/local.adoc
@@ -16,19 +16,22 @@ micronaut:
 NOTE: When added to the classpath, api:objectstorage.local.LocalStorageOperations[] becomes the primary implementation of
 api:objectstorage.ObjectStorageOperations[].
 
-NOTE: The local storage implementation reserves the `.metadata` key namespace for per-object metadata files. User object
-keys cannot be `.metadata` or start with `.metadata/` (or `.metadata\` on platforms where the file separator is `\`).
+NOTE: The local storage implementation reserves the `.mn-storage` key namespace for provider-managed metadata and
+temporary rollback files. User object keys cannot be `.mn-storage` or start with `.mn-storage/` (or the equivalent
+platform file separator).
 
 The local implementation is also the reference provider for
 api:objectstorage.metadata.ObjectMetadataOperations[] and api:objectstorage.metadata.BucketMetadataOperations[].
-Object metadata sidecars live under the configured bucket's `.metadata` tree, while bucket metadata sidecars live under
-the sibling `.metadata/buckets` tree managed by the local bucket lifecycle API.
+Object metadata sidecars live under the configured bucket's `.mn-storage/metadata` tree, while bucket metadata sidecars
+live under the sibling `.mn-storage/metadata/buckets` tree managed by the local bucket lifecycle API. Temporary local
+file rollback snapshots live under `.mn-storage/snapshots`.
 
 By default, it will create a temporary folder to store the files, but you can configure it to use a specific folder:
 
 On POSIX-capable file systems, configured bucket paths created by the local implementation use owner-only permissions for
-bucket subdirectories, stored objects, and `.metadata` files. On non-POSIX file systems, Micronaut cannot apply those
-permissions directly, so custom storage paths on shared hosts should be provisioned with restrictive ACLs by the caller.
+bucket subdirectories, stored objects, and provider-managed `.mn-storage` files. On non-POSIX file systems,
+Micronaut cannot apply those permissions directly, so custom storage paths on shared hosts should be provisioned with
+restrictive ACLs by the caller.
 
 include::{includedir}configurationProperties/io.micronaut.objectstorage.local.LocalStorageConfiguration.adoc[]
 

--- a/src/main/docs/guide/metadataPersistence.adoc
+++ b/src/main/docs/guide/metadataPersistence.adoc
@@ -1,0 +1,41 @@
+= Metadata Persistence SPI
+
+Micronaut Object Storage now exposes additive metadata contracts for implementations that need to persist
+bucket/container metadata or object metadata separately from raw object bytes:
+
+- api:objectstorage.metadata.ObjectMetadataOperations[]
+- api:objectstorage.metadata.ReactiveObjectMetadataOperations[]
+- api:objectstorage.metadata.BucketMetadataOperations[]
+- api:objectstorage.metadata.ReactiveBucketMetadataOperations[]
+
+The portable write models use replace/upsert semantics:
+
+- api:objectstorage.metadata.ObjectMetadataWrite[]
+- api:objectstorage.metadata.BucketMetadataWrite[]
+
+The corresponding read models expose the stored metadata snapshot plus any provider-native metadata handle:
+
+- api:objectstorage.metadata.ObjectMetadataEntry[]
+- api:objectstorage.metadata.BucketMetadataEntry[]
+
+This SPI is intentionally separate from api:objectstorage.ObjectStorageOperations[] and
+api:objectstorage.bucket.BucketOperations[].
+
+That keeps the existing upload, retrieve, and bucket lifecycle contracts source- and binary-compatible while still
+allowing new implementations to compose metadata and content storage differently.
+
+Version `3.0.x` keeps the first release deliberately narrow:
+
+- CRUD-style metadata persistence is supported.
+- Updating metadata without rewriting object bytes is supported.
+- Portable metadata and attributes are string maps.
+- Querying, indexing, and attribute-based search are out of scope.
+
+Current provider support:
+
+- Local storage implements both object and bucket metadata contracts as the first reference implementation.
+
+Consistency note:
+
+- When an implementation stores metadata separately from content, Micronaut does not guarantee distributed transaction
+  semantics between those stores. Providers should document their own consistency model.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -5,6 +5,7 @@ reactiveOperations: Reactive Operations
 preSignedUploads: Pre-Signed Uploads
 paginatedListing: Paginated Listing
 bucketManagement: Bucket and Container Management
+metadataPersistence: Metadata Persistence SPI
 aws: Amazon S3
 azure: Azure Blob Storage
 gcp: Google Cloud Storage


### PR DESCRIPTION
## Summary
- add additive bucket and object metadata persistence contracts in `object-storage-core`
- implement Local storage sidecar metadata persistence as the first provider-backed implementation
- add TCK/spec coverage and guide documentation for metadata persistence

Closes #759