### PR TITLE
Add relational object storage module

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ micronaut-logging = "2.0.0-M2"
 
 gcp-libraries = '26.79.0'
 bytebuddy = '1.18.8'
+h2 = "2.3.232"
 
 # Gradle plugins
 micronaut-gradle-plugin = "4.6.2"
@@ -47,6 +48,7 @@ micronaut-logging = { module = "io.micronaut.logging:micronaut-logging-bom", ver
 micronaut-core-reactive = { module = "io.micronaut:micronaut-core-reactive" }
 
 bytebuddy = { module = 'net.bytebuddy:byte-buddy', version.ref = 'bytebuddy' }
+h2 = { module = "com.h2database:h2", version.ref = "h2" }
 
 # Plugins
 gradle-micronaut = { module = 'io.micronaut.gradle:micronaut-gradle-plugin', version.ref = 'micronaut-gradle-plugin' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ micronaut-logging = "2.0.0-M2"
 gcp-libraries = '26.79.0'
 bytebuddy = '1.18.8'
 h2 = "2.3.232"
+postgresql = "42.7.8"
 
 # Gradle plugins
 micronaut-gradle-plugin = "4.6.2"
@@ -49,6 +50,7 @@ micronaut-core-reactive = { module = "io.micronaut:micronaut-core-reactive" }
 
 bytebuddy = { module = 'net.bytebuddy:byte-buddy', version.ref = 'bytebuddy' }
 h2 = { module = "com.h2database:h2", version.ref = "h2" }
+postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 
 # Plugins
 gradle-micronaut = { module = 'io.micronaut.gradle:micronaut-gradle-plugin', version.ref = 'micronaut-gradle-plugin' }

--- a/object-storage-relational/build.gradle.kts
+++ b/object-storage-relational/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    io.micronaut.build.internal.`objectstorage-module`
+}
+
+dependencies {
+    api(projects.micronautObjectStorageCore)
+
+    testImplementation(libs.h2)
+    testImplementation(mnTest.micronaut.test.spock)
+    testImplementation(projects.micronautObjectStorageTck)
+}
+
+micronautBuild {
+    binaryCompatibility {
+        enabledAfter("3.0.0")
+    }
+}

--- a/object-storage-relational/build.gradle.kts
+++ b/object-storage-relational/build.gradle.kts
@@ -6,7 +6,11 @@ dependencies {
     api(projects.micronautObjectStorageCore)
 
     testImplementation(libs.h2)
+    testImplementation(libs.postgresql)
     testImplementation(mnTest.micronaut.test.spock)
+    testRuntimeOnly(mnTestResources.micronaut.test.resources.jdbc.postgresql)
+    testImplementation(mnTestResources.testcontainers.jdbc)
+    testImplementation(mnTestResources.testcontainers.postgres)
     testImplementation(projects.micronautObjectStorageTck)
 }
 

--- a/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/JdbcRelationalObjectStore.java
+++ b/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/JdbcRelationalObjectStore.java
@@ -292,6 +292,8 @@ final class JdbcRelationalObjectStore {
     private void initializeSchema() {
         try (Connection connection = dataSource.getConnection();
              Statement statement = connection.createStatement()) {
+            String metadataColumnType = metadataColumnType(connection);
+            String payloadColumnType = payloadColumnType(connection);
             if (configuration.getSchema().isPresent()) {
                 statement.execute("CREATE SCHEMA IF NOT EXISTS " + configuration.getSchema().orElseThrow());
             }
@@ -301,13 +303,28 @@ final class JdbcRelationalObjectStore {
                     + "etag VARCHAR(128) NOT NULL, "
                     + "content_length BIGINT NOT NULL, "
                     + "content_type VARCHAR(255), "
-                    + "metadata CHARACTER LARGE OBJECT, "
-                    + "object_content BINARY LARGE OBJECT NOT NULL, "
+                    + "metadata " + metadataColumnType + ", "
+                    + "object_content " + payloadColumnType + " NOT NULL, "
                     + "updated_at TIMESTAMP NOT NULL)"
             );
         } catch (SQLException e) {
             throw new ObjectStorageException("Error initializing relational object storage schema", e);
         }
+    }
+
+    @NonNull
+    private static String metadataColumnType(@NonNull Connection connection) throws SQLException {
+        return usesPostgreSqlLargeObjectTypes(connection) ? "TEXT" : "CLOB";
+    }
+
+    @NonNull
+    private static String payloadColumnType(@NonNull Connection connection) throws SQLException {
+        return usesPostgreSqlLargeObjectTypes(connection) ? "BYTEA" : "BLOB";
+    }
+
+    private static boolean usesPostgreSqlLargeObjectTypes(@NonNull Connection connection) throws SQLException {
+        String databaseProductName = connection.getMetaData().getDatabaseProductName();
+        return "PostgreSQL".equalsIgnoreCase(databaseProductName) || "H2".equalsIgnoreCase(databaseProductName);
     }
 
     @NonNull

--- a/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/JdbcRelationalObjectStore.java
+++ b/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/JdbcRelationalObjectStore.java
@@ -143,22 +143,23 @@ final class JdbcRelationalObjectStore {
         List<Object> arguments = new ArrayList<>(3);
         String prefix = toStoredPrefix(request.getPrefix().orElse(null));
         if (prefix != null) {
-            sql.append(" AND object_key LIKE ?");
-            arguments.add(prefix + '%');
+            sql.append(" AND object_key LIKE ? ESCAPE '\\'");
+            arguments.add(toLikePattern(prefix));
         }
         String continuationToken = request.getContinuationToken().map(this::toStoredKey).orElse(null);
         if (continuationToken != null) {
             sql.append(" AND object_key > ?");
             arguments.add(continuationToken);
         }
+        int fetchLimit = fetchLimit(request.getPageSize());
         sql.append(" ORDER BY object_key ASC LIMIT ?");
-        arguments.add(request.getPageSize() + 1);
+        arguments.add(fetchLimit);
 
         try (Connection connection = dataSource.getConnection();
              PreparedStatement statement = connection.prepareStatement(sql.toString())) {
             bindArguments(statement, arguments);
             try (ResultSet resultSet = statement.executeQuery()) {
-                List<String> storedKeys = new ArrayList<>(request.getPageSize() + 1);
+                List<String> storedKeys = new ArrayList<>();
                 while (resultSet.next()) {
                     storedKeys.add(resultSet.getString(1));
                 }
@@ -192,27 +193,32 @@ final class JdbcRelationalObjectStore {
     @NonNull
     InputStream openInputStream(@NonNull String key) {
         String sql = "SELECT object_content FROM " + qualifiedTableName + " WHERE object_key = ?";
+        Connection connection = null;
+        PreparedStatement statement = null;
+        ResultSet resultSet = null;
         try {
-            Connection connection = dataSource.getConnection();
-            PreparedStatement statement = connection.prepareStatement(sql);
+            connection = dataSource.getConnection();
+            statement = connection.prepareStatement(sql);
             statement.setString(1, toStoredKey(key));
-            ResultSet resultSet = statement.executeQuery();
+            resultSet = statement.executeQuery();
             if (!resultSet.next()) {
-                closeQuietly(resultSet);
-                closeQuietly(statement);
-                closeQuietly(connection);
                 throw new ObjectStorageException("No relational object found for key [" + key + "]");
             }
             InputStream inputStream = resultSet.getBinaryStream(1);
             if (inputStream == null) {
-                closeQuietly(resultSet);
-                closeQuietly(statement);
-                closeQuietly(connection);
                 throw new ObjectStorageException("No relational payload stream available for key [" + key + "]");
             }
-            return new ManagedJdbcInputStream(inputStream, resultSet, statement, connection);
+            ManagedJdbcInputStream managedInputStream = new ManagedJdbcInputStream(inputStream, resultSet, statement, connection);
+            resultSet = null;
+            statement = null;
+            connection = null;
+            return managedInputStream;
         } catch (SQLException e) {
             throw new ObjectStorageException("Error opening relational object stream for key [" + key + "]", e);
+        } finally {
+            closeQuietly(resultSet);
+            closeQuietly(statement);
+            closeQuietly(connection);
         }
     }
 
@@ -382,6 +388,23 @@ final class JdbcRelationalObjectStore {
         for (int index = 0; index < arguments.size(); index++) {
             statement.setObject(index + 1, arguments.get(index));
         }
+    }
+
+    @NonNull
+    private static String toLikePattern(@NonNull String prefix) {
+        return escapeLikePattern(prefix) + '%';
+    }
+
+    @NonNull
+    private static String escapeLikePattern(@NonNull String value) {
+        return value
+            .replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_");
+    }
+
+    private static int fetchLimit(int pageSize) {
+        return pageSize == Integer.MAX_VALUE ? Integer.MAX_VALUE : pageSize + 1;
     }
 
     @Nullable

--- a/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/JdbcRelationalObjectStore.java
+++ b/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/JdbcRelationalObjectStore.java
@@ -1,0 +1,484 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.relational;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.ObjectStorageException;
+import io.micronaut.objectstorage.request.ListObjectsRequest;
+import io.micronaut.objectstorage.request.UploadRequest;
+import io.micronaut.objectstorage.response.ListObjectsResponse;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import javax.sql.DataSource;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+/**
+ * Internal JDBC-backed relational object store.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Internal
+final class JdbcRelationalObjectStore {
+
+    private final DataSource dataSource;
+    private final RelationalStorageConfiguration configuration;
+    private final String qualifiedTableName;
+
+    JdbcRelationalObjectStore(DataSource dataSource, RelationalStorageConfiguration configuration) {
+        this.dataSource = dataSource;
+        this.configuration = configuration;
+        this.qualifiedTableName = configuration.getSchema()
+            .map(schema -> schema + '.' + configuration.getTableName())
+            .orElse(configuration.getTableName());
+        initializeSchema();
+    }
+
+    @NonNull
+    RelationalStoredObject upload(@NonNull UploadRequest request) {
+        return store(
+            request.getKey(),
+            request.getContentType().orElse(null),
+            request.getMetadata(),
+            request::getInputStream
+        );
+    }
+
+    @NonNull
+    Optional<RelationalStoredObject> find(@NonNull String key) {
+        String sql = "SELECT etag, content_length, content_type, metadata, updated_at FROM " + qualifiedTableName + " WHERE object_key = ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, toStoredKey(key));
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) {
+                    return Optional.empty();
+                }
+                return Optional.of(
+                    new RelationalStoredObject(
+                        key,
+                        resultSet.getString("etag"),
+                        resultSet.getLong("content_length"),
+                        resultSet.getString("content_type"),
+                        deserializeMetadata(resultSet.getString("metadata")),
+                        toInstant(resultSet.getTimestamp("updated_at"))
+                    )
+                );
+            }
+        } catch (SQLException e) {
+            throw new ObjectStorageException("Error retrieving relational object metadata for key [" + key + "]", e);
+        }
+    }
+
+    boolean exists(@NonNull String key) {
+        String sql = "SELECT 1 FROM " + qualifiedTableName + " WHERE object_key = ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, toStoredKey(key));
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        } catch (SQLException e) {
+            throw new ObjectStorageException("Error checking relational object existence for key [" + key + "]", e);
+        }
+    }
+
+    @NonNull
+    RelationalStoredObject delete(@NonNull String key) {
+        Optional<RelationalStoredObject> existing = find(key);
+        String sql = "DELETE FROM " + qualifiedTableName + " WHERE object_key = ?";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, toStoredKey(key));
+            statement.executeUpdate();
+            return existing.orElseGet(() -> new RelationalStoredObject(key, null, null, null, Map.of(), null));
+        } catch (SQLException e) {
+            throw new ObjectStorageException("Error deleting relational object for key [" + key + "]", e);
+        }
+    }
+
+    @NonNull
+    ListObjectsResponse list(@NonNull ListObjectsRequest request) {
+        StringBuilder sql = new StringBuilder("SELECT object_key FROM ")
+            .append(qualifiedTableName)
+            .append(" WHERE 1 = 1");
+        List<Object> arguments = new ArrayList<>(3);
+        String prefix = toStoredPrefix(request.getPrefix().orElse(null));
+        if (prefix != null) {
+            sql.append(" AND object_key LIKE ?");
+            arguments.add(prefix + '%');
+        }
+        String continuationToken = request.getContinuationToken().map(this::toStoredKey).orElse(null);
+        if (continuationToken != null) {
+            sql.append(" AND object_key > ?");
+            arguments.add(continuationToken);
+        }
+        sql.append(" ORDER BY object_key ASC LIMIT ?");
+        arguments.add(request.getPageSize() + 1);
+
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql.toString())) {
+            bindArguments(statement, arguments);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<String> storedKeys = new ArrayList<>(request.getPageSize() + 1);
+                while (resultSet.next()) {
+                    storedKeys.add(resultSet.getString(1));
+                }
+                if (storedKeys.isEmpty()) {
+                    return new ListObjectsResponse(List.of());
+                }
+                int pageSize = request.getPageSize();
+                List<String> exposedKeys = storedKeys.stream()
+                    .limit(pageSize)
+                    .map(this::toExternalKey)
+                    .toList();
+                String nextContinuationToken = storedKeys.size() > pageSize
+                    ? exposedKeys.get(exposedKeys.size() - 1)
+                    : null;
+                return new ListObjectsResponse(exposedKeys, nextContinuationToken);
+            }
+        } catch (SQLException e) {
+            throw new ObjectStorageException("Error listing relational objects", e);
+        }
+    }
+
+    void copy(@NonNull String sourceKey, @NonNull String destinationKey) {
+        find(sourceKey).ifPresent(source -> store(
+            destinationKey,
+            source.contentType(),
+            source.metadata(),
+            () -> openInputStream(sourceKey)
+        ));
+    }
+
+    @NonNull
+    InputStream openInputStream(@NonNull String key) {
+        String sql = "SELECT object_content FROM " + qualifiedTableName + " WHERE object_key = ?";
+        try {
+            Connection connection = dataSource.getConnection();
+            PreparedStatement statement = connection.prepareStatement(sql);
+            statement.setString(1, toStoredKey(key));
+            ResultSet resultSet = statement.executeQuery();
+            if (!resultSet.next()) {
+                closeQuietly(resultSet);
+                closeQuietly(statement);
+                closeQuietly(connection);
+                throw new ObjectStorageException("No relational object found for key [" + key + "]");
+            }
+            InputStream inputStream = resultSet.getBinaryStream(1);
+            if (inputStream == null) {
+                closeQuietly(resultSet);
+                closeQuietly(statement);
+                closeQuietly(connection);
+                throw new ObjectStorageException("No relational payload stream available for key [" + key + "]");
+            }
+            return new ManagedJdbcInputStream(inputStream, resultSet, statement, connection);
+        } catch (SQLException e) {
+            throw new ObjectStorageException("Error opening relational object stream for key [" + key + "]", e);
+        }
+    }
+
+    @NonNull
+    private RelationalStoredObject store(@NonNull String key,
+                                         @Nullable String contentType,
+                                         @NonNull Map<String, String> metadata,
+                                         @NonNull InputStreamSupplier inputStreamSupplier) {
+        Path tempFile = createTempFile();
+        Instant updatedAt = Instant.now();
+        String eTag;
+        long contentLength;
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            contentLength = copyToTempFile(tempFile, inputStreamSupplier.open(), digest);
+            eTag = HexFormat.of().formatHex(digest.digest());
+            writeRow(key, contentType, metadata, tempFile, contentLength, eTag, updatedAt);
+            return new RelationalStoredObject(key, eTag, contentLength, contentType, metadata, updatedAt);
+        } catch (IOException | SQLException e) {
+            throw new ObjectStorageException("Error storing relational object for key [" + key + "]", e);
+        } catch (NoSuchAlgorithmException e) {
+            throw new ObjectStorageException("SHA-256 message digest is not available", e);
+        } finally {
+            try {
+                Files.deleteIfExists(tempFile);
+            } catch (IOException ignored) {
+                // Nothing to do.
+            }
+        }
+    }
+
+    private void writeRow(@NonNull String key,
+                          @Nullable String contentType,
+                          @NonNull Map<String, String> metadata,
+                          @NonNull Path tempFile,
+                          long contentLength,
+                          @NonNull String eTag,
+                          @NonNull Instant updatedAt) throws SQLException, IOException {
+        String deleteSql = "DELETE FROM " + qualifiedTableName + " WHERE object_key = ?";
+        String insertSql = "INSERT INTO " + qualifiedTableName
+            + " (object_key, etag, content_length, content_type, metadata, object_content, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)";
+        try (Connection connection = dataSource.getConnection()) {
+            connection.setAutoCommit(false);
+            try (PreparedStatement deleteStatement = connection.prepareStatement(deleteSql);
+                 PreparedStatement insertStatement = connection.prepareStatement(insertSql);
+                 InputStream payload = Files.newInputStream(tempFile)) {
+                deleteStatement.setString(1, toStoredKey(key));
+                deleteStatement.executeUpdate();
+
+                insertStatement.setString(1, toStoredKey(key));
+                insertStatement.setString(2, eTag);
+                insertStatement.setLong(3, contentLength);
+                if (contentType == null || contentType.isBlank()) {
+                    insertStatement.setNull(4, Types.VARCHAR);
+                } else {
+                    insertStatement.setString(4, contentType);
+                }
+                String metadataValue = serializeMetadata(metadata);
+                if (metadataValue == null) {
+                    insertStatement.setNull(5, Types.CLOB);
+                } else {
+                    insertStatement.setString(5, metadataValue);
+                }
+                insertStatement.setBinaryStream(6, payload, contentLength);
+                insertStatement.setTimestamp(7, Timestamp.from(updatedAt));
+                insertStatement.executeUpdate();
+                connection.commit();
+            } catch (SQLException | IOException e) {
+                connection.rollback();
+                throw e;
+            } finally {
+                connection.setAutoCommit(true);
+            }
+        }
+    }
+
+    private void initializeSchema() {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            if (configuration.getSchema().isPresent()) {
+                statement.execute("CREATE SCHEMA IF NOT EXISTS " + configuration.getSchema().orElseThrow());
+            }
+            statement.execute(
+                "CREATE TABLE IF NOT EXISTS " + qualifiedTableName + " ("
+                    + "object_key VARCHAR(1024) PRIMARY KEY, "
+                    + "etag VARCHAR(128) NOT NULL, "
+                    + "content_length BIGINT NOT NULL, "
+                    + "content_type VARCHAR(255), "
+                    + "metadata CHARACTER LARGE OBJECT, "
+                    + "object_content BINARY LARGE OBJECT NOT NULL, "
+                    + "updated_at TIMESTAMP NOT NULL)"
+            );
+        } catch (SQLException e) {
+            throw new ObjectStorageException("Error initializing relational object storage schema", e);
+        }
+    }
+
+    @NonNull
+    private String toStoredKey(@NonNull String key) {
+        return configuration.getKeyPrefix()
+            .map(prefix -> prefix + key)
+            .orElse(key);
+    }
+
+    @Nullable
+    private String toStoredPrefix(@Nullable String prefix) {
+        if (prefix == null || prefix.isEmpty()) {
+            return configuration.getKeyPrefix().orElse(null);
+        }
+        return configuration.getKeyPrefix()
+            .map(configuredPrefix -> configuredPrefix + prefix)
+            .orElse(prefix);
+    }
+
+    @NonNull
+    private String toExternalKey(@NonNull String storedKey) {
+        return configuration.getKeyPrefix()
+            .filter(storedKey::startsWith)
+            .map(prefix -> storedKey.substring(prefix.length()))
+            .orElse(storedKey);
+    }
+
+    @NonNull
+    private static Path createTempFile() {
+        try {
+            return Files.createTempFile("micronaut-object-storage-relational-", ".bin");
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error creating temporary file for relational object storage", e);
+        }
+    }
+
+    private static long copyToTempFile(@NonNull Path tempFile,
+                                       @NonNull InputStream inputStream,
+                                       @NonNull MessageDigest digest) throws IOException {
+        try (InputStream source = inputStream;
+             OutputStream outputStream = Files.newOutputStream(tempFile)) {
+            byte[] buffer = new byte[8_192];
+            long count = 0;
+            int read;
+            while ((read = source.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+                outputStream.write(buffer, 0, read);
+                count += read;
+            }
+            return count;
+        }
+    }
+
+    private static void bindArguments(@NonNull PreparedStatement statement, @NonNull List<Object> arguments) throws SQLException {
+        for (int index = 0; index < arguments.size(); index++) {
+            statement.setObject(index + 1, arguments.get(index));
+        }
+    }
+
+    @Nullable
+    private static String serializeMetadata(@NonNull Map<String, String> metadata) {
+        if (metadata.isEmpty()) {
+            return null;
+        }
+        Properties properties = new Properties();
+        properties.putAll(metadata);
+        try {
+            StringWriter writer = new StringWriter();
+            properties.store(writer, null);
+            return writer.toString();
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error serializing relational object metadata", e);
+        }
+    }
+
+    @NonNull
+    private static Map<String, String> deserializeMetadata(@Nullable String metadata) {
+        if (metadata == null || metadata.isBlank()) {
+            return Map.of();
+        }
+        Properties properties = new Properties();
+        try {
+            properties.load(new StringReader(metadata));
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error deserializing relational object metadata", e);
+        }
+        Map<String, String> values = new LinkedHashMap<>(properties.size());
+        for (String name : properties.stringPropertyNames()) {
+            values.put(name, properties.getProperty(name));
+        }
+        return values;
+    }
+
+    @Nullable
+    private static Instant toInstant(@Nullable Timestamp timestamp) {
+        return timestamp == null ? null : timestamp.toInstant();
+    }
+
+    private static void closeQuietly(@Nullable AutoCloseable closeable) {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        } catch (Exception ignored) {
+            // Nothing to do.
+        }
+    }
+
+    @FunctionalInterface
+    interface InputStreamSupplier {
+        @NonNull
+        InputStream open() throws IOException;
+    }
+
+    private static final class ManagedJdbcInputStream extends FilterInputStream {
+
+        private final ResultSet resultSet;
+        private final Statement statement;
+        private final Connection connection;
+        private boolean closed;
+
+        private ManagedJdbcInputStream(InputStream inputStream,
+                                       ResultSet resultSet,
+                                       Statement statement,
+                                       Connection connection) {
+            super(inputStream);
+            this.resultSet = resultSet;
+            this.statement = statement;
+            this.connection = connection;
+        }
+
+        @Override
+        public int read() throws IOException {
+            int read = super.read();
+            closeOnEndOfStream(read);
+            return read;
+        }
+
+        @Override
+        public int read(byte[] buffer, int off, int len) throws IOException {
+            int read = super.read(buffer, off, len);
+            closeOnEndOfStream(read);
+            return read;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            IOException thrown = null;
+            try {
+                super.close();
+            } catch (IOException e) {
+                thrown = e;
+            } finally {
+                closeQuietly(resultSet);
+                closeQuietly(statement);
+                closeQuietly(connection);
+            }
+            if (thrown != null) {
+                throw thrown;
+            }
+        }
+
+        private void closeOnEndOfStream(int read) throws IOException {
+            if (read == -1) {
+                close();
+            }
+        }
+    }
+}

--- a/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/RelationalStorageConfiguration.java
+++ b/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/RelationalStorageConfiguration.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.relational;
+
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.objectstorage.configuration.AbstractObjectStorageConfiguration;
+import io.micronaut.objectstorage.configuration.EachPropertyContainsEntriesCondition;
+import io.micronaut.objectstorage.configuration.ObjectStorageConfiguration;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * Relational object storage configuration.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@EachProperty(RelationalStorageConfiguration.PREFIX)
+@Requires(condition = EachPropertyContainsEntriesCondition.class)
+@Introspected
+public class RelationalStorageConfiguration extends AbstractObjectStorageConfiguration {
+
+    /**
+     * Configuration prefix ending.
+     */
+    public static final String NAME = "relational";
+
+    /**
+     * Configuration prefix.
+     */
+    public static final String PREFIX = ObjectStorageConfiguration.PREFIX + '.' + NAME;
+
+    private static final Pattern IDENTIFIER = Pattern.compile("[A-Za-z][A-Za-z0-9_]*");
+
+    @Nullable
+    private String datasource;
+
+    @Nullable
+    private String schema;
+
+    @NonNull
+    private String tableName = "micronaut_object_storage_object";
+
+    @Nullable
+    private String keyPrefix;
+
+    public RelationalStorageConfiguration(@Parameter String name) {
+        super(name);
+    }
+
+    /**
+     * @return The datasource bean name to use. Defaults to the storage bean name.
+     */
+    @NonNull
+    public String getDatasource() {
+        return datasource == null || datasource.isBlank() ? getName() : datasource;
+    }
+
+    /**
+     * @param datasource The datasource bean name to use.
+     */
+    public void setDatasource(@Nullable String datasource) {
+        this.datasource = normalizeOptionalValue(datasource);
+    }
+
+    /**
+     * @return The optional schema to create and use.
+     */
+    @NonNull
+    public Optional<String> getSchema() {
+        return Optional.ofNullable(schema);
+    }
+
+    /**
+     * @param schema The optional schema to create and use.
+     */
+    public void setSchema(@Nullable String schema) {
+        this.schema = normalizeIdentifier(schema, "schema");
+    }
+
+    /**
+     * @return The table name used for object rows.
+     */
+    @NonNull
+    public String getTableName() {
+        return tableName;
+    }
+
+    /**
+     * @param tableName The table name used for object rows.
+     */
+    public void setTableName(@NonNull String tableName) {
+        String normalized = normalizeIdentifier(tableName, "tableName");
+        if (normalized == null) {
+            throw new ConfigurationException("The relational tableName must not be blank");
+        }
+        this.tableName = normalized;
+    }
+
+    /**
+     * @return The optional internal key prefix used to namespace stored rows.
+     */
+    @NonNull
+    public Optional<String> getKeyPrefix() {
+        return Optional.ofNullable(keyPrefix);
+    }
+
+    /**
+     * @param keyPrefix The optional internal key prefix used to namespace stored rows.
+     */
+    public void setKeyPrefix(@Nullable String keyPrefix) {
+        if (keyPrefix == null || keyPrefix.isBlank()) {
+            this.keyPrefix = null;
+            return;
+        }
+        String normalized = keyPrefix;
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        this.keyPrefix = normalized.isEmpty() ? null : normalized + '/';
+    }
+
+    /**
+     * Whether to enable or disable this object storage.
+     */
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Nullable
+    private static String normalizeOptionalValue(@Nullable String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    @Nullable
+    private static String normalizeIdentifier(@Nullable String value, @NonNull String propertyName) {
+        String normalized = normalizeOptionalValue(value);
+        if (normalized == null) {
+            return null;
+        }
+        if (!IDENTIFIER.matcher(normalized).matches()) {
+            throw new ConfigurationException("The relational " + propertyName + " must match " + IDENTIFIER.pattern());
+        }
+        return normalized;
+    }
+}

--- a/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/RelationalStorageEntry.java
+++ b/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/RelationalStorageEntry.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.relational;
+
+import io.micronaut.objectstorage.ObjectStorageEntry;
+import org.jspecify.annotations.NonNull;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Relational {@link ObjectStorageEntry} implementation.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+public final class RelationalStorageEntry implements ObjectStorageEntry<RelationalStoredObject> {
+
+    private final JdbcRelationalObjectStore objectStore;
+    private final RelationalStoredObject storedObject;
+
+    RelationalStorageEntry(JdbcRelationalObjectStore objectStore, RelationalStoredObject storedObject) {
+        this.objectStore = objectStore;
+        this.storedObject = storedObject;
+    }
+
+    @Override
+    @NonNull
+    public String getKey() {
+        return storedObject.key();
+    }
+
+    @Override
+    @NonNull
+    public InputStream getInputStream() {
+        return objectStore.openInputStream(storedObject.key());
+    }
+
+    @Override
+    @NonNull
+    public RelationalStoredObject getNativeEntry() {
+        return storedObject;
+    }
+
+    @Override
+    @NonNull
+    public Map<String, String> getMetadata() {
+        return storedObject.metadata();
+    }
+
+    @Override
+    @NonNull
+    public Optional<String> getContentType() {
+        return storedObject.getContentType();
+    }
+}

--- a/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/RelationalStorageModuleConfiguration.java
+++ b/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/RelationalStorageModuleConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.relational;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.objectstorage.configuration.AbstractObjectStorageModuleConfiguration;
+
+/**
+ * Relational storage module configuration.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@ConfigurationProperties(RelationalStorageConfiguration.PREFIX)
+public class RelationalStorageModuleConfiguration extends AbstractObjectStorageModuleConfiguration {
+
+    /**
+     * Whether to enable or disable the whole relational module.
+     */
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/RelationalStorageOperations.java
+++ b/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/RelationalStorageOperations.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.relational;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.objectstorage.ObjectStorageOperations;
+import io.micronaut.objectstorage.configuration.ToggeableCondition;
+import io.micronaut.objectstorage.request.ListObjectsRequest;
+import io.micronaut.objectstorage.request.UploadRequest;
+import io.micronaut.objectstorage.response.ListObjectsResponse;
+import io.micronaut.objectstorage.response.UploadResponse;
+import org.jspecify.annotations.NonNull;
+
+import javax.sql.DataSource;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * Relational implementation of {@link ObjectStorageOperations}.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@EachBean(RelationalStorageConfiguration.class)
+@Requires(condition = ToggeableCondition.class)
+@Requires(beans = RelationalStorageConfiguration.class)
+public class RelationalStorageOperations implements ObjectStorageOperations<
+    RelationalStoredObject,
+    RelationalStoredObject,
+    RelationalStoredObject> {
+
+    private static final int DEFAULT_LIST_PAGE_SIZE = 1_000;
+
+    private final JdbcRelationalObjectStore objectStore;
+
+    public RelationalStorageOperations(@Parameter RelationalStorageConfiguration configuration,
+                                       BeanContext beanContext) {
+        DataSource dataSource = beanContext.getBean(DataSource.class, Qualifiers.byName(configuration.getDatasource()));
+        this.objectStore = new JdbcRelationalObjectStore(dataSource, configuration);
+    }
+
+    @Override
+    @NonNull
+    public UploadResponse<RelationalStoredObject> upload(@NonNull UploadRequest request) {
+        RelationalStoredObject storedObject = objectStore.upload(request);
+        return UploadResponse.of(request.getKey(), storedObject.eTag(), storedObject);
+    }
+
+    @Override
+    @NonNull
+    public UploadResponse<RelationalStoredObject> upload(@NonNull UploadRequest request,
+                                                         @NonNull Consumer<RelationalStoredObject> requestConsumer) {
+        RelationalStoredObject storedObject = objectStore.upload(request);
+        requestConsumer.accept(storedObject);
+        return UploadResponse.of(request.getKey(), storedObject.eTag(), storedObject);
+    }
+
+    @Override
+    @NonNull
+    @SuppressWarnings("unchecked")
+    public Optional<RelationalStorageEntry> retrieve(@NonNull String key) {
+        return objectStore.find(key).map(storedObject -> new RelationalStorageEntry(objectStore, storedObject));
+    }
+
+    @Override
+    @NonNull
+    public RelationalStoredObject delete(@NonNull String key) {
+        return objectStore.delete(key);
+    }
+
+    @Override
+    public boolean exists(@NonNull String key) {
+        return objectStore.exists(key);
+    }
+
+    @Override
+    @NonNull
+    public Set<String> listObjects() {
+        Set<String> keys = new LinkedHashSet<>();
+        String continuationToken = null;
+        do {
+            ListObjectsResponse response = objectStore.list(new ListObjectsRequest(DEFAULT_LIST_PAGE_SIZE, null, continuationToken));
+            keys.addAll(response.getKeys());
+            continuationToken = response.getContinuationToken().orElse(null);
+        } while (continuationToken != null);
+        return keys;
+    }
+
+    @Override
+    @NonNull
+    public ListObjectsResponse listObjects(@NonNull ListObjectsRequest request) {
+        return objectStore.list(request);
+    }
+
+    @Override
+    public void copy(@NonNull String sourceKey, @NonNull String destinationKey) {
+        objectStore.copy(sourceKey, destinationKey);
+    }
+}

--- a/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/RelationalStoredObject.java
+++ b/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/RelationalStoredObject.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.relational;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Native relational metadata for one stored object.
+ *
+ * @param key The exposed object key.
+ * @param eTag The object ETag if known.
+ * @param contentLength The object length if known.
+ * @param contentType The object content type if known.
+ * @param metadata The object metadata.
+ * @param updatedAt The last update timestamp if known.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+public record RelationalStoredObject(
+    @NonNull String key,
+    @Nullable String eTag,
+    @Nullable Long contentLength,
+    @Nullable String contentType,
+    @NonNull Map<String, String> metadata,
+    @Nullable Instant updatedAt
+) {
+
+    public RelationalStoredObject(
+        @NonNull String key,
+        @Nullable String eTag,
+        @Nullable Long contentLength,
+        @Nullable String contentType,
+        @NonNull Map<String, String> metadata,
+        @Nullable Instant updatedAt
+    ) {
+        this.key = key;
+        this.eTag = eTag;
+        this.contentLength = contentLength;
+        this.contentType = contentType;
+        this.metadata = Map.copyOf(metadata);
+        this.updatedAt = updatedAt;
+    }
+
+    /**
+     * @return The object content type if known.
+     */
+    @NonNull
+    public Optional<String> getContentType() {
+        return Optional.ofNullable(contentType);
+    }
+
+    /**
+     * @return The object content length if known.
+     */
+    @NonNull
+    public Optional<Long> getContentLength() {
+        return Optional.ofNullable(contentLength);
+    }
+
+    /**
+     * @return The object update timestamp if known.
+     */
+    @NonNull
+    public Optional<Instant> getUpdatedAt() {
+        return Optional.ofNullable(updatedAt);
+    }
+}

--- a/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/package-info.java
+++ b/object-storage-relational/src/main/java/io/micronaut/objectstorage/relational/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Object Storage classes related to relational object storage backends.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Configuration
+@Requires(property = RelationalStorageConfiguration.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
+package io.micronaut.objectstorage.relational;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;

--- a/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/AbstractRelationalStorageOperationsSpec.groovy
+++ b/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/AbstractRelationalStorageOperationsSpec.groovy
@@ -1,0 +1,22 @@
+package io.micronaut.objectstorage.relational
+
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.ObjectStorageOperationsSpecification
+import io.micronaut.objectstorage.bucket.BucketOperations
+import jakarta.inject.Inject
+
+abstract class AbstractRelationalStorageOperationsSpec extends ObjectStorageOperationsSpecification {
+
+    @Inject
+    RelationalStorageOperations operations
+
+    @Override
+    ObjectStorageOperations<?, ?, ?> getObjectStorage() {
+        return operations
+    }
+
+    @Override
+    BucketOperations<?> getBucketOperations() {
+        return null
+    }
+}

--- a/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/JdbcRelationalObjectStoreSpec.groovy
+++ b/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/JdbcRelationalObjectStoreSpec.groovy
@@ -1,0 +1,53 @@
+package io.micronaut.objectstorage.relational
+
+import io.micronaut.objectstorage.ObjectStorageException
+
+import javax.sql.DataSource
+import java.sql.Connection
+import java.sql.DatabaseMetaData
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.sql.Statement
+
+class JdbcRelationalObjectStoreSpec extends spock.lang.Specification {
+
+    void 'openInputStream closes allocated jdbc resources when stream acquisition fails'() {
+        given:
+        DataSource dataSource = Mock()
+        Connection initializationConnection = Stub()
+        Statement initializationStatement = Stub()
+        DatabaseMetaData initializationMetadata = Stub()
+        Connection queryConnection = Mock()
+        PreparedStatement queryStatement = Mock()
+        ResultSet queryResultSet = Mock()
+        RelationalStorageConfiguration configuration = new RelationalStorageConfiguration('default')
+
+        configuration.setTableName('jdbc_relational_object_store_spec')
+
+        dataSource.getConnection() >>> [initializationConnection, queryConnection]
+
+        initializationConnection.createStatement() >> initializationStatement
+        initializationConnection.getMetaData() >> initializationMetadata
+        initializationMetadata.getDatabaseProductName() >> 'H2'
+
+        queryConnection.prepareStatement(_ as String) >> queryStatement
+        queryStatement.executeQuery() >> queryResultSet
+        queryResultSet.next() >> true
+        queryResultSet.getBinaryStream(1) >> { throw new SQLException('boom') }
+
+        JdbcRelationalObjectStore store = new JdbcRelationalObjectStore(dataSource, configuration)
+
+        when:
+        store.openInputStream('docs/failure.bin')
+
+        then:
+        def e = thrown(ObjectStorageException)
+        e.message == 'Error opening relational object stream for key [docs/failure.bin]'
+
+        1 * queryStatement.setString(1, 'docs/failure.bin')
+        1 * queryResultSet.close()
+        1 * queryStatement.close()
+        1 * queryConnection.close()
+    }
+}

--- a/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStorageConfigurationSpec.groovy
+++ b/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStorageConfigurationSpec.groovy
@@ -1,0 +1,26 @@
+package io.micronaut.objectstorage.relational
+
+import io.micronaut.context.exceptions.ConfigurationException
+import io.micronaut.objectstorage.ObjectStorageConfigurationSpecification
+
+class RelationalStorageConfigurationSpec extends ObjectStorageConfigurationSpecification<RelationalStorageOperations> {
+
+    void 'it rejects enabled as a named configuration'() {
+        when:
+        new RelationalStorageConfiguration('enabled')
+
+        then:
+        def e = thrown(ConfigurationException)
+        e.message == "The object storage configuration name 'enabled' is reserved for the module-level enabled flag"
+    }
+
+    @Override
+    String getConfigPrefix() {
+        return RelationalStorageConfiguration.PREFIX
+    }
+
+    @Override
+    Class<RelationalStorageOperations> getObjectStorage() {
+        return RelationalStorageOperations.class
+    }
+}

--- a/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStorageFailureSpec.groovy
+++ b/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStorageFailureSpec.groovy
@@ -1,0 +1,91 @@
+package io.micronaut.objectstorage.relational
+
+import io.micronaut.objectstorage.ObjectStorageException
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+import jakarta.inject.Named
+
+import javax.sql.DataSource
+
+@MicronautTest
+class RelationalStorageFailureSpec extends spock.lang.Specification implements TestPropertyProvider {
+
+    private static final String TABLE_NAME = 'relational_storage_failure_spec_objects'
+
+    @Inject
+    RelationalStorageOperations operations
+
+    @Inject
+    @Named('default')
+    DataSource dataSource
+
+    @Override
+    Map<String, String> getProperties() {
+        [
+            (RelationalStorageConfiguration.PREFIX + '.default.enabled'): 'true',
+            (RelationalStorageConfiguration.PREFIX + '.default.table-name'): TABLE_NAME,
+        ]
+    }
+
+    void cleanup() {
+        operations.listObjects().each { operations.delete(it) }
+    }
+
+    void 'failed overwrite rolls back the prior row instead of orphaning the object'() {
+        given:
+        operations.upload(UploadRequest.fromBytes('v1-body'.bytes, 'docs/report.txt', 'text/plain'))
+        UploadRequest failingUpdate = UploadRequest.fromBytes('v2-body'.bytes, 'docs/report.txt', 'x' * 300)
+
+        when:
+        operations.upload(failingUpdate)
+
+        then:
+        def e = thrown(ObjectStorageException)
+        e.message == 'Error storing relational object for key [docs/report.txt]'
+        operations.retrieve('docs/report.txt').orElseThrow().with {
+            inputStream.text == 'v1-body'
+            contentType == Optional.of('text/plain')
+            metadata == [:]
+        }
+        storedKeys() == ['docs/report.txt']
+    }
+
+    void 'entry stream fails cleanly when the payload row disappears after metadata lookup'() {
+        given:
+        operations.upload(UploadRequest.fromBytes('payload'.bytes, 'docs/missing.bin', 'application/octet-stream'))
+        def entry = operations.retrieve('docs/missing.bin').orElseThrow()
+        deleteRow('docs/missing.bin')
+
+        when:
+        entry.inputStream.text
+
+        then:
+        def e = thrown(ObjectStorageException)
+        e.message == 'No relational object found for key [docs/missing.bin]'
+    }
+
+    private void deleteRow(String key) {
+        dataSource.connection.withCloseable { connection ->
+            connection.prepareStatement("DELETE FROM ${TABLE_NAME} WHERE object_key = ?").withCloseable { statement ->
+                statement.setString(1, key)
+                statement.executeUpdate()
+            }
+        }
+    }
+
+    private List<String> storedKeys() {
+        dataSource.connection.withCloseable { connection ->
+            connection.prepareStatement("SELECT object_key FROM ${TABLE_NAME} ORDER BY object_key ASC").withCloseable { statement ->
+                def resultSet = statement.executeQuery()
+                List<String> keys = []
+                while (resultSet.next()) {
+                    keys << resultSet.getString(1)
+                }
+                resultSet.close()
+                return keys
+            }
+        }
+    }
+}

--- a/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStorageH2TckSpec.groovy
+++ b/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStorageH2TckSpec.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.objectstorage.relational
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+
+@MicronautTest
+class RelationalStorageH2TckSpec extends AbstractRelationalStorageOperationsSpec implements TestPropertyProvider {
+
+    @Override
+    Map<String, String> getProperties() {
+        [
+            (RelationalStorageConfiguration.PREFIX + '.default.enabled'): 'true',
+            (RelationalStorageConfiguration.PREFIX + '.default.table-name'): 'relational_storage_h2_tck_objects',
+        ]
+    }
+}

--- a/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStorageNamedSpec.groovy
+++ b/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStorageNamedSpec.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.objectstorage.relational
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Named
+import spock.lang.Specification
+
+@Property(name = "micronaut.object-storage.relational.analytics.enabled", value = "true")
+@Property(name = "micronaut.object-storage.relational.analytics.datasource", value = "analytics")
+@Property(name = "micronaut.object-storage.relational.analytics.table-name", value = "named_relational_objects")
+@MicronautTest
+class RelationalStorageNamedSpec extends Specification {
+
+    @Inject
+    @Named("analytics")
+    ObjectStorageOperations<?, ?, ?> storageOperations
+
+    void 'it can inject named relational storage operations'() {
+        expect:
+        storageOperations instanceof RelationalStorageOperations
+    }
+}

--- a/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStoragePaginationSpec.groovy
+++ b/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStoragePaginationSpec.groovy
@@ -1,0 +1,76 @@
+package io.micronaut.objectstorage.relational
+
+import io.micronaut.objectstorage.request.ListObjectsRequest
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+
+@MicronautTest
+class RelationalStoragePaginationSpec extends spock.lang.Specification implements TestPropertyProvider {
+
+    private static final List<String> SEEDED_KEYS = [
+        'animals/cat.txt',
+        'animals/dog.txt',
+        'animals/mammals/fox.txt',
+        'animals/zebra.txt',
+        'plants/oak.txt',
+        'plants/pine.txt',
+        'tools/axe.txt',
+    ]
+
+    @Inject
+    RelationalStorageOperations operations
+
+    @Override
+    Map<String, String> getProperties() {
+        [
+            (RelationalStorageConfiguration.PREFIX + '.default.enabled'): 'true',
+            (RelationalStorageConfiguration.PREFIX + '.default.table-name'): 'pagination_relational_objects',
+        ]
+    }
+
+    void setup() {
+        SEEDED_KEYS.each { key ->
+            operations.upload(UploadRequest.fromBytes('seed'.bytes, key, 'text/plain'))
+        }
+    }
+
+    void cleanup() {
+        operations.listObjects().each { operations.delete(it) }
+    }
+
+    void 'paginated listing is bounded prefix filtered and keeps continuation tokens external'() {
+        when:
+        def firstPage = operations.listObjects(new ListObjectsRequest(2, 'animals/'))
+        def secondPage = operations.listObjects(new ListObjectsRequest(2, 'animals/', firstPage.continuationToken.orElse(null)))
+        def replayedTerminalPage = operations.listObjects(new ListObjectsRequest(2, 'animals/', secondPage.keys.last()))
+
+        then:
+        firstPage.keys == ['animals/cat.txt', 'animals/dog.txt']
+        firstPage.continuationToken.orElse(null) == 'animals/dog.txt'
+        secondPage.keys == ['animals/mammals/fox.txt', 'animals/zebra.txt']
+        secondPage.continuationToken.empty
+        replayedTerminalPage.keys.empty
+        replayedTerminalPage.continuationToken.empty
+    }
+
+    void 'continuation token is a strict lower bound and listObjects returns all visible keys in order'() {
+        when:
+        def page = operations.listObjects(new ListObjectsRequest(2, null, 'animals/dog.txt'))
+        def allKeys = operations.listObjects() as List
+
+        then:
+        page.keys == ['animals/mammals/fox.txt', 'animals/zebra.txt']
+        page.continuationToken.orElse(null) == 'animals/zebra.txt'
+        allKeys == [
+            'animals/cat.txt',
+            'animals/dog.txt',
+            'animals/mammals/fox.txt',
+            'animals/zebra.txt',
+            'plants/oak.txt',
+            'plants/pine.txt',
+            'tools/axe.txt',
+        ]
+    }
+}

--- a/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStoragePaginationSpec.groovy
+++ b/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStoragePaginationSpec.groovy
@@ -73,4 +73,32 @@ class RelationalStoragePaginationSpec extends spock.lang.Specification implement
             'tools/axe.txt',
         ]
     }
+
+    void 'prefix filtering treats SQL wildcard characters literally'() {
+        given:
+        operations.upload(UploadRequest.fromBytes('wild'.bytes, 'animals/%-literal.txt', 'text/plain'))
+        operations.upload(UploadRequest.fromBytes('wild'.bytes, 'animals/_-literal.txt', 'text/plain'))
+
+        when:
+        def percentPage = operations.listObjects(new ListObjectsRequest(10, 'animals/%'))
+        def underscorePage = operations.listObjects(new ListObjectsRequest(10, 'animals/_'))
+
+        then:
+        percentPage.keys == ['animals/%-literal.txt']
+        underscorePage.keys == ['animals/_-literal.txt']
+    }
+
+    void 'page size at integer max returns visible keys without overflowing internal limits'() {
+        when:
+        def page = operations.listObjects(new ListObjectsRequest(Integer.MAX_VALUE, 'animals/'))
+
+        then:
+        page.keys == [
+            'animals/cat.txt',
+            'animals/dog.txt',
+            'animals/mammals/fox.txt',
+            'animals/zebra.txt',
+        ]
+        page.continuationToken.empty
+    }
 }

--- a/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStoragePostgresDataSourceFactory.groovy
+++ b/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStoragePostgresDataSourceFactory.groovy
@@ -1,0 +1,91 @@
+package io.micronaut.objectstorage.relational
+
+import io.micronaut.context.annotation.Factory
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import org.postgresql.ds.PGSimpleDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+
+import javax.sql.DataSource
+import java.io.PrintWriter
+import java.sql.Connection
+import java.sql.SQLException
+import java.util.UUID
+import java.util.logging.Logger
+
+@Factory
+class RelationalStoragePostgresDataSourceFactory {
+
+    @Singleton
+    @Named("postgres")
+    DataSource postgresDataSource() {
+        return new ContainerBackedDataSource("relational_storage_${UUID.randomUUID()}")
+    }
+
+    private static final class ContainerBackedDataSource implements DataSource, AutoCloseable {
+        private final PostgreSQLContainer<?> container
+        private final PGSimpleDataSource dataSource
+
+        private ContainerBackedDataSource(String databaseName) {
+            this.container = new PostgreSQLContainer<>("postgres:16-alpine")
+                .withDatabaseName(databaseName)
+                .withUsername("test")
+                .withPassword("test")
+            container.start()
+            this.dataSource = new PGSimpleDataSource()
+            dataSource.setURL(container.getJdbcUrl())
+            dataSource.setUser(container.getUsername())
+            dataSource.setPassword(container.getPassword())
+        }
+
+        @Override
+        Connection getConnection() throws SQLException {
+            return dataSource.getConnection()
+        }
+
+        @Override
+        Connection getConnection(String username, String password) throws SQLException {
+            return dataSource.getConnection(username, password)
+        }
+
+        @Override
+        PrintWriter getLogWriter() throws SQLException {
+            return dataSource.getLogWriter()
+        }
+
+        @Override
+        void setLogWriter(PrintWriter out) throws SQLException {
+            dataSource.setLogWriter(out)
+        }
+
+        @Override
+        void setLoginTimeout(int seconds) throws SQLException {
+            dataSource.setLoginTimeout(seconds)
+        }
+
+        @Override
+        int getLoginTimeout() throws SQLException {
+            return dataSource.getLoginTimeout()
+        }
+
+        @Override
+        Logger getParentLogger() {
+            return dataSource.getParentLogger()
+        }
+
+        @Override
+        <T> T unwrap(Class<T> iface) throws SQLException {
+            return dataSource.unwrap(iface)
+        }
+
+        @Override
+        boolean isWrapperFor(Class<?> iface) {
+            return dataSource.isWrapperFor(iface)
+        }
+
+        @Override
+        void close() {
+            container.stop()
+        }
+    }
+}

--- a/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStoragePostgresTckSpec.groovy
+++ b/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStoragePostgresTckSpec.groovy
@@ -1,0 +1,76 @@
+package io.micronaut.objectstorage.relational
+
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import org.testcontainers.DockerClientFactory
+import spock.lang.Requires
+
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+
+@MicronautTest
+@Requires({ DockerClientFactory.instance().isDockerAvailable() })
+class RelationalStoragePostgresTckSpec extends AbstractRelationalStorageOperationsSpec implements TestPropertyProvider {
+
+    private static final int LARGE_PAYLOAD_SIZE = 5 * 1024 * 1024
+
+    @Override
+    Map<String, String> getProperties() {
+        [
+            (RelationalStorageConfiguration.PREFIX + '.default.enabled'): 'true',
+            (RelationalStorageConfiguration.PREFIX + '.default.datasource'): 'postgres',
+            (RelationalStorageConfiguration.PREFIX + '.default.table-name'): 'relational_storage_postgres_tck_objects',
+        ]
+    }
+
+    void 'it streams large PostgreSQL LOB payloads without losing metadata or ordering'() {
+        given:
+        Path payload = Files.createTempFile('relational-postgres-large-', '.bin')
+        byte[] buffer = new byte[8192]
+        for (int index = 0; index < buffer.length; index++) {
+            buffer[index] = (byte) (index % 251)
+        }
+        Files.newOutputStream(payload).withCloseable { outputStream ->
+            int remaining = LARGE_PAYLOAD_SIZE
+            while (remaining > 0) {
+                int chunkSize = Math.min(remaining, buffer.length)
+                outputStream.write(buffer, 0, chunkSize)
+                remaining -= chunkSize
+            }
+        }
+        UploadRequest uploadRequest = UploadRequest.fromPath(payload, 'large')
+        uploadRequest.contentType = 'application/octet-stream'
+        uploadRequest.metadata = [profile: 'streaming']
+
+        when:
+        def response = operations.upload(uploadRequest)
+        def entry = operations.retrieve(uploadRequest.key).orElseThrow()
+
+        then:
+        response.ETag
+        entry.metadata == [profile: 'streaming']
+        entry.contentType == Optional.of('application/octet-stream')
+        digest(entry.inputStream) == digest(Files.newInputStream(payload))
+        entry.inputStream.bytes.length == LARGE_PAYLOAD_SIZE
+        operations.listObjects().contains(uploadRequest.key)
+
+        cleanup:
+        operations?.delete(uploadRequest.key)
+        Files.deleteIfExists(payload)
+    }
+
+    private static String digest(InputStream inputStream) {
+        MessageDigest digest = MessageDigest.getInstance('SHA-256')
+        inputStream.withCloseable { stream ->
+            byte[] buffer = new byte[8192]
+            int read
+            while ((read = stream.read(buffer)) != -1) {
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().encodeHex().toString()
+    }
+}

--- a/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStorageSpec.groovy
+++ b/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStorageSpec.groovy
@@ -1,0 +1,95 @@
+package io.micronaut.objectstorage.relational
+
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+import jakarta.inject.Named
+
+import javax.sql.DataSource
+import java.sql.ResultSet
+
+@MicronautTest
+class RelationalStorageSpec extends spock.lang.Specification implements TestPropertyProvider {
+
+    @Inject
+    RelationalStorageOperations operations
+
+    @Inject
+    @Named("default")
+    DataSource dataSource
+
+    @Override
+    Map<String, String> getProperties() {
+        [
+            (RelationalStorageConfiguration.PREFIX + '.default.enabled'): 'true',
+            (RelationalStorageConfiguration.PREFIX + '.default.table-name'): 'relational_storage_spec_objects',
+            (RelationalStorageConfiguration.PREFIX + '.default.key-prefix'): 'tenant-a/',
+        ]
+    }
+
+    void cleanup() {
+        operations.listObjects().each { operations.delete(it) }
+    }
+
+    void 'it uploads retrieves copies updates and deletes objects while storing rows under the configured namespace'() {
+        given:
+        def uploadRequest = UploadRequest.fromBytes('v1-body'.bytes, 'docs/report.txt', 'text/plain')
+        uploadRequest.metadata = [owner: 'ops', project: 'micronaut']
+
+        when:
+        def uploadResponse = operations.upload(uploadRequest)
+        def retrieved = operations.retrieve('docs/report.txt').orElseThrow()
+
+        then:
+        uploadResponse.ETag
+        operations.exists('docs/report.txt')
+        operations.listObjects() == ['docs/report.txt'] as Set
+        retrieved.key == 'docs/report.txt'
+        retrieved.inputStream.text == 'v1-body'
+        retrieved.metadata == [owner: 'ops', project: 'micronaut']
+        retrieved.contentType == Optional.of('text/plain')
+        storedKeys() == ['tenant-a/docs/report.txt']
+
+        when:
+        def updateRequest = UploadRequest.fromBytes('v2-body'.bytes, 'docs/report.txt', 'text/plain')
+        updateRequest.metadata = [owner: 'ops', revision: '2']
+        def updateResponse = operations.upload(updateRequest)
+        operations.copy('docs/report.txt', 'archive/report.txt')
+        def copied = operations.retrieve('archive/report.txt').orElseThrow()
+
+        then:
+        updateResponse.ETag
+        operations.retrieve('docs/report.txt').orElseThrow().inputStream.text == 'v2-body'
+        operations.retrieve('docs/report.txt').orElseThrow().metadata == [owner: 'ops', revision: '2']
+        copied.inputStream.text == 'v2-body'
+        copied.metadata == [owner: 'ops', revision: '2']
+        copied.contentType == Optional.of('text/plain')
+        storedKeys() == ['tenant-a/archive/report.txt', 'tenant-a/docs/report.txt']
+
+        when:
+        operations.delete('docs/report.txt')
+        operations.delete('archive/report.txt')
+
+        then:
+        !operations.exists('docs/report.txt')
+        !operations.exists('archive/report.txt')
+        operations.retrieve('docs/report.txt').empty
+        operations.listObjects().empty
+        storedKeys().empty
+    }
+
+    private List<String> storedKeys() {
+        dataSource.connection.withCloseable { connection ->
+            connection.prepareStatement('SELECT object_key FROM relational_storage_spec_objects ORDER BY object_key ASC').withCloseable { statement ->
+                ResultSet resultSet = statement.executeQuery()
+                List<String> keys = []
+                while (resultSet.next()) {
+                    keys << resultSet.getString(1)
+                }
+                resultSet.close()
+                return keys
+            }
+        }
+    }
+}

--- a/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStorageTestDataSourceFactory.groovy
+++ b/object-storage-relational/src/test/groovy/io/micronaut/objectstorage/relational/RelationalStorageTestDataSourceFactory.groovy
@@ -1,0 +1,39 @@
+package io.micronaut.objectstorage.relational
+
+import io.micronaut.context.annotation.Factory
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import org.h2.jdbcx.JdbcDataSource
+
+import javax.sql.DataSource
+import java.util.UUID
+
+@Factory
+class RelationalStorageTestDataSourceFactory {
+
+    @Singleton
+    @Named("default")
+    DataSource defaultDataSource() {
+        return createDataSource("default")
+    }
+
+    @Singleton
+    @Named("other")
+    DataSource otherDataSource() {
+        return createDataSource("other")
+    }
+
+    @Singleton
+    @Named("analytics")
+    DataSource analyticsDataSource() {
+        return createDataSource("analytics")
+    }
+
+    private static DataSource createDataSource(String name) {
+        JdbcDataSource dataSource = new JdbcDataSource()
+        dataSource.setURL("jdbc:h2:mem:${name}-${UUID.randomUUID()};MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false")
+        dataSource.setUser("sa")
+        dataSource.setPassword("")
+        return dataSource
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ include("object-storage-azure")
 include("object-storage-gcp")
 include("object-storage-oracle-cloud")
 include("object-storage-local")
+include("object-storage-relational")
 include("test-suite-graal")
 
 include("doc-examples:example-java")

--- a/src/main/docs/guide/relational.adoc
+++ b/src/main/docs/guide/relational.adoc
@@ -1,0 +1,42 @@
+To use the relational backend, add the following dependency:
+
+dependency:io.micronaut.objectstorage:micronaut-object-storage-relational[]
+
+Then configure at least one datasource bean together with one relational object storage:
+
+[configuration]
+----
+datasources:
+  default:
+    url: jdbc:h2:mem:object-storage;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+    driverClassName: org.h2.Driver
+    username: sa
+    password: ''
+
+micronaut:
+  object-storage:
+    relational:
+      default:
+        enabled: true
+        table-name: micronaut_object_storage_object
+----
+
+The first relational implementation keeps the existing api:objectstorage.ObjectStorageOperations[] API intact:
+
+- payload bytes are written to a BLOB column
+- metadata, content type, content length, and ETag are stored in relational columns
+- paginated listing uses deterministic key ordering and the existing continuation-token contract
+
+Optional namespacing is available through `key-prefix`, and you can point each storage bean at a specific datasource bean with `datasource`.
+
+The relational module creates its schema and table on startup when they do not already exist.
+
+include::{includedir}configurationProperties/io.micronaut.objectstorage.relational.RelationalStorageConfiguration.adoc[]
+
+The current scope is intentionally narrow:
+
+- one datasource per storage bean
+- one table per storage bean
+- CRUD, copy, existence checks, and paginated listing
+
+Multipart uploads and advanced metadata-query APIs remain out of scope for this first relational backend slice.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -5,6 +5,7 @@ reactiveOperations: Reactive Operations
 preSignedUploads: Pre-Signed Uploads
 paginatedListing: Paginated Listing
 bucketManagement: Bucket and Container Management
+relational: Relational Backend
 aws: Amazon S3
 azure: Azure Blob Storage
 gcp: Google Cloud Storage


### PR DESCRIPTION
## Summary
- add an optional JDBC-backed relational object storage module
- keep existing core/provider APIs unchanged while supporting named datasources and configurable schema/table/key prefixes
- cover the module with H2 and PostgreSQL-backed specs, including large-payload and failure-path cases
- document the new relational backend module in the guide

## Verification
- ./gradlew :micronaut-object-storage-relational:test
- ./gradlew :micronaut-object-storage-relational:japiCmp docs

Closes #758