### PR TITLE
feat: add tus resumable upload support

### DIFF
--- a/object-storage-aws/build.gradle.kts
+++ b/object-storage-aws/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     api(libs.amazon.awssdk.s3)
 
     implementation(platform(mnAws.micronaut.aws.bom))
+    implementation(projects.micronautObjectStorageTus)
     annotationProcessor(mnValidation.micronaut.validation.processor)
     implementation(mnValidation.micronaut.validation)
 

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3TusUploadBackend.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3TusUploadBackend.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.tus.TusConflictException;
 import io.micronaut.objectstorage.tus.TusGoneException;
@@ -49,13 +50,19 @@ import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 
 /**
  * AWS S3 multipart-backed tus upload backend.
@@ -65,10 +72,12 @@ import java.util.UUID;
  */
 @EachBean(AwsS3Configuration.class)
 @Requires(beans = TusModuleConfiguration.class)
+@Requires(property = TusModuleConfiguration.PREFIX + ".enabled", value = StringUtils.TRUE)
 @Singleton
 @Internal
 final class AwsS3TusUploadBackend implements TusUploadBackend {
 
+    private static final System.Logger LOGGER = System.getLogger(AwsS3TusUploadBackend.class.getName());
     private static final long MIN_PART_SIZE = 5L * 1024L * 1024L;
     private static final String STATUS = "status";
     private static final String KEY = "key";
@@ -86,6 +95,7 @@ final class AwsS3TusUploadBackend implements TusUploadBackend {
     private final S3Client s3Client;
     private final Path sessionsPath;
     private final Path stagingPath;
+    private final ConcurrentMap<String, ReentrantLock> uploadLocks = new ConcurrentHashMap<>();
 
     AwsS3TusUploadBackend(@Parameter String name,
                           AwsS3Configuration configuration,
@@ -144,7 +154,11 @@ final class AwsS3TusUploadBackend implements TusUploadBackend {
             }
             CreateMultipartUploadResponse response = s3Client.createMultipartUpload(requestBuilder.build());
             AwsTusSession session = new AwsTusSession(upload, response.uploadId(), 0L, 1, List.of());
-            save(session);
+            try {
+                save(session);
+            } catch (RuntimeException e) {
+                abortMultipartUploadAfterCreateFailure(key, response.uploadId(), e);
+            }
             return upload;
         } catch (AwsServiceException e) {
             throw new ObjectStorageException("Unable to create AWS S3 multipart upload for tus resource", e);
@@ -164,48 +178,53 @@ final class AwsS3TusUploadBackend implements TusUploadBackend {
     @Override
     @NonNull
     public TusUpload append(@NonNull String uploadId, long expectedOffset, byte[] chunk) {
-        AwsTusSession session = readRequired(uploadId);
-        TusUpload upload = session.upload();
-        if (!upload.inProgress()) {
-            throw new TusGoneException("Upload is no longer writable: " + uploadId);
-        }
-        if (expectedOffset != upload.offset()) {
-            throw new TusConflictException("Upload-Offset does not match the committed offset");
-        }
-        long nextOffset = upload.offset() + chunk.length;
-        if (nextOffset > upload.uploadLength()) {
-            throw new IllegalArgumentException("Chunk exceeds declared Upload-Length");
-        }
+        return withUploadLock(uploadId, () -> {
+            AwsTusSession session = readRequired(uploadId);
+            TusUpload upload = session.upload();
+            if (!upload.inProgress()) {
+                throw new TusGoneException("Upload is no longer writable: " + uploadId);
+            }
+            if (expectedOffset != upload.offset()) {
+                throw new TusConflictException("Upload-Offset does not match the committed offset");
+            }
+            long nextOffset = upload.offset() + chunk.length;
+            if (nextOffset > upload.uploadLength()) {
+                throw new IllegalArgumentException("Chunk exceeds declared Upload-Length");
+            }
 
-        appendToStaging(uploadId, chunk);
-        session = session.withUpload(upload.withStatus(upload.status(), nextOffset));
-        save(session);
+            appendToStaging(uploadId, chunk);
+            session = session.withUpload(upload.withStatus(upload.status(), nextOffset));
+            save(session);
 
-        if (nextOffset == upload.uploadLength()) {
-            return finalizeUpload(session).upload();
-        }
-        return flushReadyParts(session).upload();
+            if (nextOffset == upload.uploadLength()) {
+                return finalizeUpload(session).upload();
+            }
+            return flushReadyParts(session).upload();
+        });
     }
 
     @Override
     public void abort(@NonNull String uploadId) {
-        AwsTusSession session = readRequired(uploadId);
-        if (!session.upload().inProgress()) {
-            throw new TusGoneException("Upload is no longer abortable: " + uploadId);
-        }
-        if (session.multipartUploadId() != null) {
-            try {
-                s3Client.abortMultipartUpload(AbortMultipartUploadRequest.builder()
-                    .bucket(configuration.getBucket())
-                    .key(session.upload().key())
-                    .uploadId(session.multipartUploadId())
-                    .build());
-            } catch (S3Exception e) {
-                throw new ObjectStorageException("Unable to abort AWS S3 multipart upload for tus resource", e);
+        withUploadLock(uploadId, () -> {
+            AwsTusSession session = readRequired(uploadId);
+            if (!session.upload().inProgress()) {
+                throw new TusGoneException("Upload is no longer abortable: " + uploadId);
             }
-        }
-        deleteQuietly(stagingFile(uploadId));
-        save(session.withUpload(session.upload().withStatus(TusUploadStatus.ABORTED, session.upload().offset())));
+            if (session.multipartUploadId() != null) {
+                try {
+                    s3Client.abortMultipartUpload(AbortMultipartUploadRequest.builder()
+                        .bucket(configuration.getBucket())
+                        .key(session.upload().key())
+                        .uploadId(session.multipartUploadId())
+                        .build());
+                } catch (S3Exception e) {
+                    throw new ObjectStorageException("Unable to abort AWS S3 multipart upload for tus resource", e);
+                }
+            }
+            save(session.withUpload(session.upload().withStatus(TusUploadStatus.ABORTED, session.upload().offset())));
+            deleteQuietly(stagingFile(uploadId));
+            return null;
+        });
     }
 
     private AwsTusSession finalizeUpload(AwsTusSession session) {
@@ -228,9 +247,9 @@ final class AwsS3TusUploadBackend implements TusUploadBackend {
                 throw new ObjectStorageException("Unable to complete AWS S3 multipart upload for tus resource", e);
             }
         }
-        deleteQuietly(stagingFile(session.upload().id()));
         AwsTusSession completed = session.withUpload(session.upload().withStatus(TusUploadStatus.COMPLETED, session.upload().uploadLength()));
         save(completed);
+        deleteQuietly(stagingFile(session.upload().id()));
         return completed;
     }
 
@@ -243,7 +262,8 @@ final class AwsS3TusUploadBackend implements TusUploadBackend {
     }
 
     private AwsTusSession uploadPart(AwsTusSession session, long partSize) {
-        byte[] bytes = readBytes(stagingFile(session.upload().id()), session.uploadedOffset(), partSize);
+        Path stagingFile = stagingFile(session.upload().id());
+        byte[] bytes = readBytes(stagingFile, 0L, partSize);
         try {
             UploadPartResponse response = s3Client.uploadPart(
                 UploadPartRequest.builder()
@@ -267,7 +287,13 @@ final class AwsS3TusUploadBackend implements TusUploadBackend {
                 session.nextPartNumber() + 1,
                 completedParts
             );
-            save(updated);
+            Path backupFile = compactStagingPrefix(stagingFile, bytes.length);
+            try {
+                save(updated);
+            } catch (RuntimeException e) {
+                restoreCompactedStaging(stagingFile, backupFile, e);
+            }
+            deleteBackupQuietly(backupFile);
             return updated;
         } catch (AwsServiceException e) {
             throw new ObjectStorageException("Unable to upload AWS S3 multipart tus chunk", e);
@@ -356,7 +382,7 @@ final class AwsS3TusUploadBackend implements TusUploadBackend {
                     .build());
             }
         }
-        completedParts.sort(java.util.Comparator.comparingInt(CompletedPart::partNumber));
+        completedParts.sort(Comparator.comparingInt(CompletedPart::partNumber));
 
         String uploadId = sessionFile.getFileName().toString().replaceFirst("\\.properties$", "");
         TusUpload upload = new TusUpload(
@@ -400,11 +426,98 @@ final class AwsS3TusUploadBackend implements TusUploadBackend {
         }
     }
 
+    private <T> T withUploadLock(String uploadId, Supplier<T> supplier) {
+        ReentrantLock lock = uploadLocks.computeIfAbsent(uploadId, ignored -> new ReentrantLock());
+        lock.lock();
+        try {
+            return supplier.get();
+        } finally {
+            lock.unlock();
+            if (!lock.hasQueuedThreads()) {
+                uploadLocks.remove(uploadId, lock);
+            }
+        }
+    }
+
+    private void abortMultipartUploadAfterCreateFailure(String key, String multipartUploadId, RuntimeException original) {
+        try {
+            s3Client.abortMultipartUpload(AbortMultipartUploadRequest.builder()
+                .bucket(configuration.getBucket())
+                .key(key)
+                .uploadId(multipartUploadId)
+                .build());
+        } catch (RuntimeException cleanupFailure) {
+            original.addSuppressed(cleanupFailure);
+        }
+        throw original;
+    }
+
+    private static Path compactStagingPrefix(Path stagingFile, long bytesToDiscard) {
+        if (bytesToDiscard <= 0L || !Files.exists(stagingFile)) {
+            return null;
+        }
+        Path tempFile = stagingFile.resolveSibling(stagingFile.getFileName() + ".tmp");
+        Path backupFile = stagingFile.resolveSibling(stagingFile.getFileName() + ".bak");
+        try (InputStream inputStream = Files.newInputStream(stagingFile);
+             OutputStream outputStream = Files.newOutputStream(tempFile)) {
+            inputStream.skipNBytes(bytesToDiscard);
+            inputStream.transferTo(outputStream);
+            moveReplacing(stagingFile, backupFile);
+            try {
+                moveReplacing(tempFile, stagingFile);
+            } catch (IOException e) {
+                moveReplacing(backupFile, stagingFile);
+                throw e;
+            }
+            return backupFile;
+        } catch (IOException e) {
+            deleteIfExistsQuietly(tempFile);
+            deleteIfExistsQuietly(backupFile);
+            throw new IllegalStateException("Unable to compact staged AWS tus upload data", e);
+        }
+    }
+
+    private static void restoreCompactedStaging(Path stagingFile, @Nullable Path backupFile, RuntimeException original) {
+        if (backupFile == null || !Files.exists(backupFile)) {
+            throw original;
+        }
+        try {
+            moveReplacing(backupFile, stagingFile);
+        } catch (IOException restoreFailure) {
+            original.addSuppressed(restoreFailure);
+        }
+        throw original;
+    }
+
+    private static void deleteBackupQuietly(@Nullable Path backupFile) {
+        if (backupFile != null) {
+            deleteIfExistsQuietly(backupFile);
+        }
+    }
+
     private static void deleteQuietly(Path path) {
         try {
             Files.deleteIfExists(path);
         } catch (IOException e) {
-            throw new IllegalStateException("Unable to clean staged AWS tus upload data", e);
+            LOGGER.log(System.Logger.Level.WARNING,
+                "Unable to clean staged AWS tus upload data: " + path,
+                e);
+        }
+    }
+
+    private static void deleteIfExistsQuietly(Path path) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException ignored) {
+            // best effort cleanup
+        }
+    }
+
+    private static void moveReplacing(Path source, Path target) throws IOException {
+        try {
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
         }
     }
 

--- a/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3TusUploadBackend.java
+++ b/object-storage-aws/src/main/java/io/micronaut/objectstorage/aws/AwsS3TusUploadBackend.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.aws;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.ObjectStorageException;
+import io.micronaut.objectstorage.tus.TusConflictException;
+import io.micronaut.objectstorage.tus.TusGoneException;
+import io.micronaut.objectstorage.tus.TusModuleConfiguration;
+import io.micronaut.objectstorage.tus.TusUpload;
+import io.micronaut.objectstorage.tus.TusUploadBackend;
+import io.micronaut.objectstorage.tus.TusUploadStatus;
+import jakarta.inject.Singleton;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.UUID;
+
+/**
+ * AWS S3 multipart-backed tus upload backend.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@EachBean(AwsS3Configuration.class)
+@Requires(beans = TusModuleConfiguration.class)
+@Singleton
+@Internal
+final class AwsS3TusUploadBackend implements TusUploadBackend {
+
+    private static final long MIN_PART_SIZE = 5L * 1024L * 1024L;
+    private static final String STATUS = "status";
+    private static final String KEY = "key";
+    private static final String LENGTH = "length";
+    private static final String OFFSET = "offset";
+    private static final String CONTENT_TYPE = "contentType";
+    private static final String MULTIPART_UPLOAD_ID = "aws.multipartUploadId";
+    private static final String REMOTE_OFFSET = "aws.remoteOffset";
+    private static final String NEXT_PART_NUMBER = "aws.nextPartNumber";
+    private static final String PART_PREFIX = "aws.part.";
+    private static final String METADATA_PREFIX = "metadata.";
+
+    private final String name;
+    private final AwsS3Configuration configuration;
+    private final S3Client s3Client;
+    private final Path sessionsPath;
+    private final Path stagingPath;
+
+    AwsS3TusUploadBackend(@Parameter String name,
+                          AwsS3Configuration configuration,
+                          TusModuleConfiguration tusModuleConfiguration,
+                          S3Client s3Client) {
+        this.name = name;
+        this.configuration = configuration;
+        this.s3Client = s3Client;
+        Path rootPath = tusModuleConfiguration.getStorageDirectory()
+            .resolve("aws")
+            .resolve(name);
+        this.sessionsPath = rootPath.resolve("sessions");
+        this.stagingPath = rootPath.resolve("staging");
+        mkdirs(this.sessionsPath);
+        mkdirs(this.stagingPath);
+    }
+
+    @Override
+    @NonNull
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    @NonNull
+    public TusUpload create(@NonNull String key,
+                            long uploadLength,
+                            @Nullable String contentType,
+                            @NonNull Map<String, String> metadata) {
+        String uploadId = UUID.randomUUID().toString();
+        TusUpload upload = new TusUpload(
+            uploadId,
+            key,
+            uploadLength,
+            0L,
+            contentType,
+            new LinkedHashMap<>(metadata),
+            TusUploadStatus.IN_PROGRESS
+        );
+        if (uploadLength == 0L) {
+            putEmptyObject(upload);
+            AwsTusSession session = new AwsTusSession(upload.withStatus(TusUploadStatus.COMPLETED, upload.uploadLength()), null, 0L, 1, List.of());
+            save(session);
+            return session.upload();
+        }
+
+        try {
+            CreateMultipartUploadRequest.Builder requestBuilder = CreateMultipartUploadRequest.builder()
+                .bucket(configuration.getBucket())
+                .key(key);
+            if (contentType != null) {
+                requestBuilder.contentType(contentType);
+            }
+            if (!metadata.isEmpty()) {
+                requestBuilder.metadata(metadata);
+            }
+            CreateMultipartUploadResponse response = s3Client.createMultipartUpload(requestBuilder.build());
+            AwsTusSession session = new AwsTusSession(upload, response.uploadId(), 0L, 1, List.of());
+            save(session);
+            return upload;
+        } catch (AwsServiceException e) {
+            throw new ObjectStorageException("Unable to create AWS S3 multipart upload for tus resource", e);
+        }
+    }
+
+    @Override
+    @NonNull
+    public Optional<TusUpload> find(@NonNull String uploadId) {
+        Path sessionFile = sessionFile(uploadId);
+        if (!Files.exists(sessionFile)) {
+            return Optional.empty();
+        }
+        return Optional.of(read(sessionFile).upload());
+    }
+
+    @Override
+    @NonNull
+    public TusUpload append(@NonNull String uploadId, long expectedOffset, byte[] chunk) {
+        AwsTusSession session = readRequired(uploadId);
+        TusUpload upload = session.upload();
+        if (!upload.inProgress()) {
+            throw new TusGoneException("Upload is no longer writable: " + uploadId);
+        }
+        if (expectedOffset != upload.offset()) {
+            throw new TusConflictException("Upload-Offset does not match the committed offset");
+        }
+        long nextOffset = upload.offset() + chunk.length;
+        if (nextOffset > upload.uploadLength()) {
+            throw new IllegalArgumentException("Chunk exceeds declared Upload-Length");
+        }
+
+        appendToStaging(uploadId, chunk);
+        session = session.withUpload(upload.withStatus(upload.status(), nextOffset));
+        save(session);
+
+        if (nextOffset == upload.uploadLength()) {
+            return finalizeUpload(session).upload();
+        }
+        return flushReadyParts(session).upload();
+    }
+
+    @Override
+    public void abort(@NonNull String uploadId) {
+        AwsTusSession session = readRequired(uploadId);
+        if (!session.upload().inProgress()) {
+            throw new TusGoneException("Upload is no longer abortable: " + uploadId);
+        }
+        if (session.multipartUploadId() != null) {
+            try {
+                s3Client.abortMultipartUpload(AbortMultipartUploadRequest.builder()
+                    .bucket(configuration.getBucket())
+                    .key(session.upload().key())
+                    .uploadId(session.multipartUploadId())
+                    .build());
+            } catch (S3Exception e) {
+                throw new ObjectStorageException("Unable to abort AWS S3 multipart upload for tus resource", e);
+            }
+        }
+        deleteQuietly(stagingFile(uploadId));
+        save(session.withUpload(session.upload().withStatus(TusUploadStatus.ABORTED, session.upload().offset())));
+    }
+
+    private AwsTusSession finalizeUpload(AwsTusSession session) {
+        session = flushReadyParts(session);
+        long pendingBytes = pendingBytes(session);
+        if (pendingBytes > 0L) {
+            session = uploadPart(session, pendingBytes);
+        }
+        if (session.multipartUploadId() != null) {
+            try {
+                s3Client.completeMultipartUpload(CompleteMultipartUploadRequest.builder()
+                    .bucket(configuration.getBucket())
+                    .key(session.upload().key())
+                    .uploadId(session.multipartUploadId())
+                    .multipartUpload(CompletedMultipartUpload.builder()
+                        .parts(session.completedParts())
+                        .build())
+                    .build());
+            } catch (AwsServiceException e) {
+                throw new ObjectStorageException("Unable to complete AWS S3 multipart upload for tus resource", e);
+            }
+        }
+        deleteQuietly(stagingFile(session.upload().id()));
+        AwsTusSession completed = session.withUpload(session.upload().withStatus(TusUploadStatus.COMPLETED, session.upload().uploadLength()));
+        save(completed);
+        return completed;
+    }
+
+    private AwsTusSession flushReadyParts(AwsTusSession session) {
+        AwsTusSession current = session;
+        while (pendingBytes(current) >= MIN_PART_SIZE) {
+            current = uploadPart(current, MIN_PART_SIZE);
+        }
+        return current;
+    }
+
+    private AwsTusSession uploadPart(AwsTusSession session, long partSize) {
+        byte[] bytes = readBytes(stagingFile(session.upload().id()), session.uploadedOffset(), partSize);
+        try {
+            UploadPartResponse response = s3Client.uploadPart(
+                UploadPartRequest.builder()
+                    .bucket(configuration.getBucket())
+                    .key(session.upload().key())
+                    .uploadId(session.multipartUploadId())
+                    .partNumber(session.nextPartNumber())
+                    .contentLength((long) bytes.length)
+                    .build(),
+                RequestBody.fromBytes(bytes)
+            );
+            List<CompletedPart> completedParts = new ArrayList<>(session.completedParts());
+            completedParts.add(CompletedPart.builder()
+                .partNumber(session.nextPartNumber())
+                .eTag(response.eTag())
+                .build());
+            AwsTusSession updated = new AwsTusSession(
+                session.upload(),
+                session.multipartUploadId(),
+                session.uploadedOffset() + bytes.length,
+                session.nextPartNumber() + 1,
+                completedParts
+            );
+            save(updated);
+            return updated;
+        } catch (AwsServiceException e) {
+            throw new ObjectStorageException("Unable to upload AWS S3 multipart tus chunk", e);
+        }
+    }
+
+    private AwsTusSession readRequired(String uploadId) {
+        Path sessionFile = sessionFile(uploadId);
+        if (!Files.exists(sessionFile)) {
+            throw new IllegalArgumentException("Unknown upload: " + uploadId);
+        }
+        return read(sessionFile);
+    }
+
+    private void appendToStaging(String uploadId, byte[] chunk) {
+        Path stagingFile = stagingFile(uploadId);
+        mkdirs(stagingFile.getParent());
+        try (OutputStream outputStream = Files.newOutputStream(
+            stagingFile,
+            java.nio.file.StandardOpenOption.CREATE,
+            java.nio.file.StandardOpenOption.APPEND
+        )) {
+            outputStream.write(chunk);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to persist AWS tus upload chunk", e);
+        }
+    }
+
+    private void putEmptyObject(TusUpload upload) {
+        try {
+            PutObjectRequest.Builder requestBuilder = PutObjectRequest.builder()
+                .bucket(configuration.getBucket())
+                .key(upload.key());
+            upload.getContentType().ifPresent(requestBuilder::contentType);
+            if (!upload.metadata().isEmpty()) {
+                requestBuilder.metadata(upload.metadata());
+            }
+            s3Client.putObject(requestBuilder.build(), RequestBody.fromBytes(new byte[0]));
+        } catch (AwsServiceException e) {
+            throw new ObjectStorageException("Unable to create empty AWS S3 object for tus upload", e);
+        }
+    }
+
+    private void save(AwsTusSession session) {
+        Properties properties = new Properties();
+        properties.setProperty(KEY, session.upload().key());
+        properties.setProperty(LENGTH, Long.toString(session.upload().uploadLength()));
+        properties.setProperty(OFFSET, Long.toString(session.upload().offset()));
+        properties.setProperty(STATUS, session.upload().status().name());
+        properties.setProperty(REMOTE_OFFSET, Long.toString(session.uploadedOffset()));
+        properties.setProperty(NEXT_PART_NUMBER, Integer.toString(session.nextPartNumber()));
+        if (session.multipartUploadId() != null) {
+            properties.setProperty(MULTIPART_UPLOAD_ID, session.multipartUploadId());
+        }
+        session.upload().getContentType().ifPresent(contentType -> properties.setProperty(CONTENT_TYPE, contentType));
+        session.upload().metadata().forEach((key, value) -> properties.setProperty(METADATA_PREFIX + key, value));
+        session.completedParts().forEach(part -> properties.setProperty(PART_PREFIX + part.partNumber(), part.eTag()));
+
+        Path sessionFile = sessionFile(session.upload().id());
+        mkdirs(sessionFile.getParent());
+        try (OutputStream outputStream = Files.newOutputStream(sessionFile)) {
+            properties.store(outputStream, null);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to persist AWS tus upload state", e);
+        }
+    }
+
+    private AwsTusSession read(Path sessionFile) {
+        Properties properties = new Properties();
+        try (InputStream inputStream = Files.newInputStream(sessionFile)) {
+            properties.load(inputStream);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to read AWS tus upload state", e);
+        }
+
+        Map<String, String> metadata = new LinkedHashMap<>();
+        List<CompletedPart> completedParts = new ArrayList<>();
+        for (String propertyName : properties.stringPropertyNames()) {
+            if (propertyName.startsWith(METADATA_PREFIX)) {
+                metadata.put(propertyName.substring(METADATA_PREFIX.length()), properties.getProperty(propertyName));
+            } else if (propertyName.startsWith(PART_PREFIX)) {
+                int partNumber = Integer.parseInt(propertyName.substring(PART_PREFIX.length()));
+                completedParts.add(CompletedPart.builder()
+                    .partNumber(partNumber)
+                    .eTag(properties.getProperty(propertyName))
+                    .build());
+            }
+        }
+        completedParts.sort(java.util.Comparator.comparingInt(CompletedPart::partNumber));
+
+        String uploadId = sessionFile.getFileName().toString().replaceFirst("\\.properties$", "");
+        TusUpload upload = new TusUpload(
+            uploadId,
+            properties.getProperty(KEY),
+            Long.parseLong(properties.getProperty(LENGTH)),
+            Long.parseLong(properties.getProperty(OFFSET)),
+            properties.getProperty(CONTENT_TYPE),
+            metadata,
+            TusUploadStatus.valueOf(properties.getProperty(STATUS))
+        );
+        return new AwsTusSession(
+            upload,
+            properties.getProperty(MULTIPART_UPLOAD_ID),
+            Long.parseLong(properties.getProperty(REMOTE_OFFSET, "0")),
+            Integer.parseInt(properties.getProperty(NEXT_PART_NUMBER, "1")),
+            completedParts
+        );
+    }
+
+    private Path sessionFile(String uploadId) {
+        return sessionsPath.resolve(uploadId + ".properties");
+    }
+
+    private Path stagingFile(String uploadId) {
+        return stagingPath.resolve(uploadId + ".bin");
+    }
+
+    private long pendingBytes(AwsTusSession session) {
+        return session.upload().offset() - session.uploadedOffset();
+    }
+
+    private static byte[] readBytes(Path file, long start, long length) {
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file.toFile(), "r")) {
+            randomAccessFile.seek(start);
+            byte[] bytes = new byte[Math.toIntExact(length)];
+            randomAccessFile.readFully(bytes);
+            return bytes;
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to read staged AWS tus upload data", e);
+        }
+    }
+
+    private static void deleteQuietly(Path path) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to clean staged AWS tus upload data", e);
+        }
+    }
+
+    private static void mkdirs(Path path) {
+        try {
+            Files.createDirectories(path);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to create tus storage path: " + path, e);
+        }
+    }
+
+    private record AwsTusSession(
+        TusUpload upload,
+        @Nullable String multipartUploadId,
+        long uploadedOffset,
+        int nextPartNumber,
+        List<CompletedPart> completedParts
+    ) {
+        private AwsTusSession withUpload(TusUpload upload) {
+            return new AwsTusSession(upload, multipartUploadId, uploadedOffset, nextPartNumber, completedParts);
+        }
+    }
+}

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3ConfigurationSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3ConfigurationSpec.groovy
@@ -7,6 +7,8 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.tus.TusModuleConfiguration
+import io.micronaut.objectstorage.tus.TusUploadBackend
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
@@ -55,6 +57,23 @@ class AwsS3ConfigurationSpec extends Specification {
         context.containsBean(AwsS3Configuration, Qualifiers.byName("default"))
         !context.containsBean(ObjectStorageOperations, Qualifiers.byName("enabled"))
         !context.containsBean(AwsS3Configuration, Qualifiers.byName("enabled"))
+
+        cleanup:
+        context.close()
+    }
+
+    void "aws tus backend stays disabled until the tus module is enabled"() {
+        given:
+        def context = ApplicationContext.run([
+            'micronaut.object-storage.aws.default.bucket': 'pictures-bucket',
+            (TusModuleConfiguration.PREFIX + '.enabled') : false,
+            'aws.region'                                : 'us-east-1',
+            'aws.accessKeyId'                           : 'test',
+            'aws.secretKey'                             : 'test'
+        ])
+
+        expect:
+        context.getBeansOfType(TusUploadBackend).isEmpty()
 
         cleanup:
         context.close()

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3TusUploadBackendLocalstackSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3TusUploadBackendLocalstackSpec.groovy
@@ -17,6 +17,7 @@ import spock.lang.Specification
 
 import java.io.ByteArrayOutputStream
 import java.nio.file.Files
+import java.nio.file.Path
 import java.util.Arrays
 
 import static io.micronaut.objectstorage.test.ObjectStorageTestConstants.LOCAL_STACK_DOCKER_IMAGE
@@ -78,43 +79,53 @@ class AwsS3TusUploadBackendLocalstackSpec extends Specification implements TestP
         byte[] third = repeated((byte) 'c', 2 * 1024 * 1024)
         byte[] expected = joined(first, second, third)
 
-        String location = controller.create(OBJECT_STORAGE_NAME, expected.length, TusMetadataCodec.encode([
+        String location = controller.create(OBJECT_STORAGE_NAME, TusHeaders.VERSION, expected.length, TusMetadataCodec.encode([
             key        : 'videos/demo.bin',
             contentType: 'application/octet-stream',
             owner      : 'micronaut'
         ])).header('Location')
         String uploadId = location.tokenize('/').last()
+        Path stagedFile = workingDirectory.toPath()
+            .resolve('aws')
+            .resolve(OBJECT_STORAGE_NAME)
+            .resolve('staging')
+            .resolve(uploadId + '.bin')
 
         when:
-        def firstPatch = controller.patch(OBJECT_STORAGE_NAME, uploadId, 0L, first)
-        def secondPatch = controller.patch(OBJECT_STORAGE_NAME, uploadId, first.length, second)
-        def headResponse = controller.head(OBJECT_STORAGE_NAME, uploadId)
-        def thirdPatch = controller.patch(OBJECT_STORAGE_NAME, uploadId, first.length + second.length, third)
+        def firstPatch = controller.patch(OBJECT_STORAGE_NAME, uploadId, TusHeaders.VERSION, 0L, first)
+        long stagedBytesAfterFirstPatch = stagedBytes(stagedFile)
+        def secondPatch = controller.patch(OBJECT_STORAGE_NAME, uploadId, TusHeaders.VERSION, first.length, second)
+        long stagedBytesAfterSecondPatch = stagedBytes(stagedFile)
+        def headResponse = controller.head(OBJECT_STORAGE_NAME, uploadId, TusHeaders.VERSION)
+        def thirdPatch = controller.patch(OBJECT_STORAGE_NAME, uploadId, TusHeaders.VERSION, first.length + second.length, third)
         def stored = operations.retrieve('videos/demo.bin').orElseThrow()
 
         then:
         firstPatch.status() == HttpStatus.NO_CONTENT
         firstPatch.header(TusHeaders.OFFSET) == Integer.toString(first.length)
+        stagedBytesAfterFirstPatch == first.length
         secondPatch.status() == HttpStatus.NO_CONTENT
         secondPatch.header(TusHeaders.OFFSET) == Integer.toString(first.length + second.length)
+        stagedBytesAfterSecondPatch == 0L
         headResponse.status() == HttpStatus.NO_CONTENT
         headResponse.header(TusHeaders.OFFSET) == Integer.toString(first.length + second.length)
         thirdPatch.status() == HttpStatus.NO_CONTENT
         thirdPatch.header(TusHeaders.OFFSET) == Integer.toString(expected.length)
+        !Files.exists(stagedFile)
         stored.inputStream.bytes == expected
         stored.metadata == [owner: 'micronaut']
     }
 
     void 'it aborts an in-progress AWS tus upload without creating an object'() {
         given:
-        String uploadId = controller.create(OBJECT_STORAGE_NAME, 4, TusMetadataCodec.encode([
+        String uploadId = controller.create(OBJECT_STORAGE_NAME, TusHeaders.VERSION, 4, TusMetadataCodec.encode([
             key: 'videos/abort.bin'
         ])).header('Location').tokenize('/').last()
-        controller.patch(OBJECT_STORAGE_NAME, uploadId, 0L, 'ab'.bytes)
+        controller.patch(OBJECT_STORAGE_NAME, uploadId, TusHeaders.VERSION, 0L, 'ab'.bytes)
 
         when:
-        def deleteResponse = controller.delete(OBJECT_STORAGE_NAME, uploadId)
-        def headResponse = controller.head(OBJECT_STORAGE_NAME, uploadId)
+        def deleteResponse = controller.delete(OBJECT_STORAGE_NAME, uploadId, TusHeaders.VERSION)
+        def headResponse = controller.head(OBJECT_STORAGE_NAME, uploadId, TusHeaders.VERSION)
 
         then:
         deleteResponse.status() == HttpStatus.NO_CONTENT
@@ -132,5 +143,9 @@ class AwsS3TusUploadBackendLocalstackSpec extends Specification implements TestP
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
         chunks.each(outputStream::write)
         outputStream.toByteArray()
+    }
+
+    private static long stagedBytes(Path stagedFile) {
+        Files.exists(stagedFile) ? Files.size(stagedFile) : 0L
     }
 }

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3TusUploadBackendLocalstackSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3TusUploadBackendLocalstackSpec.groovy
@@ -1,0 +1,136 @@
+package io.micronaut.objectstorage.aws
+
+import io.micronaut.http.HttpStatus
+import io.micronaut.objectstorage.tus.TusController
+import io.micronaut.objectstorage.tus.TusHeaders
+import io.micronaut.objectstorage.tus.TusMetadataCodec
+import io.micronaut.objectstorage.tus.TusModuleConfiguration
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+import jakarta.inject.Named
+import org.testcontainers.localstack.LocalStackContainer
+import org.testcontainers.utility.DockerImageName
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.io.ByteArrayOutputStream
+import java.nio.file.Files
+import java.util.Arrays
+
+import static io.micronaut.objectstorage.test.ObjectStorageTestConstants.LOCAL_STACK_DOCKER_IMAGE
+
+@MicronautTest(startApplication = false)
+class AwsS3TusUploadBackendLocalstackSpec extends Specification implements TestPropertyProvider {
+
+    private static final String OBJECT_STORAGE_NAME = 'default'
+    private static final String BUCKET_NAME = "tus-${System.currentTimeMillis()}"
+
+    @Shared
+    @AutoCleanup
+    LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
+        .withServices('s3')
+
+    @Shared
+    File workingDirectory = Files.createTempDirectory('micronaut-object-storage-tus-aws-spec').toFile()
+
+    @Inject
+    TusController controller
+
+    @Inject
+    @Named(OBJECT_STORAGE_NAME)
+    AwsS3Operations operations
+
+    @Inject
+    @Named(OBJECT_STORAGE_NAME)
+    AwsS3BucketOperations bucketOperations
+
+    void setup() {
+        bucketOperations.create(BUCKET_NAME)
+    }
+
+    void cleanup() {
+        operations.listObjects().each { operations.delete(it) }
+        if (bucketOperations.exists(BUCKET_NAME)) {
+            bucketOperations.delete(BUCKET_NAME)
+        }
+    }
+
+    @Override
+    Map<String, String> getProperties() {
+        localstack.start()
+        [
+            (AwsS3Configuration.PREFIX + '.' + OBJECT_STORAGE_NAME + '.bucket') : BUCKET_NAME,
+            (TusModuleConfiguration.PREFIX + '.enabled')                        : 'true',
+            (TusModuleConfiguration.PREFIX + '.storage-directory')              : workingDirectory.absolutePath,
+            'aws.accessKeyId'                                                   : localstack.accessKey,
+            'aws.secretKey'                                                     : localstack.secretKey,
+            'aws.region'                                                        : localstack.region,
+            'aws.services.s3.endpoint-override'                                 : localstack.getEndpoint().toString()
+        ]
+    }
+
+    void 'it buffers small tus chunks into AWS multipart uploads and finalizes the object'() {
+        given:
+        byte[] first = repeated((byte) 'a', 3 * 1024 * 1024)
+        byte[] second = repeated((byte) 'b', 2 * 1024 * 1024)
+        byte[] third = repeated((byte) 'c', 2 * 1024 * 1024)
+        byte[] expected = joined(first, second, third)
+
+        String location = controller.create(OBJECT_STORAGE_NAME, expected.length, TusMetadataCodec.encode([
+            key        : 'videos/demo.bin',
+            contentType: 'application/octet-stream',
+            owner      : 'micronaut'
+        ])).header('Location')
+        String uploadId = location.tokenize('/').last()
+
+        when:
+        def firstPatch = controller.patch(OBJECT_STORAGE_NAME, uploadId, 0L, first)
+        def secondPatch = controller.patch(OBJECT_STORAGE_NAME, uploadId, first.length, second)
+        def headResponse = controller.head(OBJECT_STORAGE_NAME, uploadId)
+        def thirdPatch = controller.patch(OBJECT_STORAGE_NAME, uploadId, first.length + second.length, third)
+        def stored = operations.retrieve('videos/demo.bin').orElseThrow()
+
+        then:
+        firstPatch.status() == HttpStatus.NO_CONTENT
+        firstPatch.header(TusHeaders.OFFSET) == Integer.toString(first.length)
+        secondPatch.status() == HttpStatus.NO_CONTENT
+        secondPatch.header(TusHeaders.OFFSET) == Integer.toString(first.length + second.length)
+        headResponse.status() == HttpStatus.NO_CONTENT
+        headResponse.header(TusHeaders.OFFSET) == Integer.toString(first.length + second.length)
+        thirdPatch.status() == HttpStatus.NO_CONTENT
+        thirdPatch.header(TusHeaders.OFFSET) == Integer.toString(expected.length)
+        stored.inputStream.bytes == expected
+        stored.metadata == [owner: 'micronaut']
+    }
+
+    void 'it aborts an in-progress AWS tus upload without creating an object'() {
+        given:
+        String uploadId = controller.create(OBJECT_STORAGE_NAME, 4, TusMetadataCodec.encode([
+            key: 'videos/abort.bin'
+        ])).header('Location').tokenize('/').last()
+        controller.patch(OBJECT_STORAGE_NAME, uploadId, 0L, 'ab'.bytes)
+
+        when:
+        def deleteResponse = controller.delete(OBJECT_STORAGE_NAME, uploadId)
+        def headResponse = controller.head(OBJECT_STORAGE_NAME, uploadId)
+
+        then:
+        deleteResponse.status() == HttpStatus.NO_CONTENT
+        headResponse.status() == HttpStatus.GONE
+        !operations.retrieve('videos/abort.bin').present
+    }
+
+    private static byte[] repeated(byte value, int length) {
+        byte[] bytes = new byte[length]
+        Arrays.fill(bytes, value)
+        bytes
+    }
+
+    private static byte[] joined(byte[]... chunks) {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
+        chunks.each(outputStream::write)
+        outputStream.toByteArray()
+    }
+}

--- a/object-storage-tus/build.gradle.kts
+++ b/object-storage-tus/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    io.micronaut.build.internal.`objectstorage-module`
+}
+
+dependencies {
+    api(projects.micronautObjectStorageCore)
+
+    implementation(projects.micronautObjectStorageLocal)
+    implementation(mn.micronaut.http.server)
+
+    testImplementation(projects.micronautObjectStorageLocal)
+}
+
+micronautBuild {
+    binaryCompatibility {
+        enabledAfter("3.0.0")
+    }
+}

--- a/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/LocalTusUploadBackend.java
+++ b/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/LocalTusUploadBackend.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.tus;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.request.FileUploadRequest;
+import io.micronaut.objectstorage.local.LocalStorageConfiguration;
+import io.micronaut.objectstorage.local.LocalStorageOperations;
+import jakarta.inject.Singleton;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.UUID;
+
+/**
+ * Filesystem-backed tus upload backend for local storage.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@EachBean(LocalStorageConfiguration.class)
+@Singleton
+@Internal
+public class LocalTusUploadBackend implements TusUploadBackend {
+
+    private static final String STATUS = "status";
+    private static final String KEY = "key";
+    private static final String LENGTH = "length";
+    private static final String OFFSET = "offset";
+    private static final String CONTENT_TYPE = "contentType";
+    private static final String METADATA_PREFIX = "metadata.";
+
+    private final String name;
+    private final LocalStorageOperations operations;
+    private final Path sessionsPath;
+    private final Path stagingPath;
+
+    public LocalTusUploadBackend(@Parameter String name,
+                                 LocalStorageConfiguration configuration,
+                                 LocalStorageOperations operations) {
+        this.name = name;
+        this.operations = operations;
+        Path metadataRoot = configuration.getPath()
+            .resolve(LocalStorageOperations.METADATA_DIRECTORY)
+            .resolve("tus")
+            .resolve(name);
+        this.sessionsPath = metadataRoot.resolve("sessions");
+        this.stagingPath = metadataRoot.resolve("staging");
+        mkdirs(this.sessionsPath);
+        mkdirs(this.stagingPath);
+    }
+
+    @Override
+    @NonNull
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    @NonNull
+    public TusUpload create(@NonNull String key,
+                            long uploadLength,
+                            @Nullable String contentType,
+                            @NonNull Map<String, String> metadata) {
+        String uploadId = UUID.randomUUID().toString();
+        TusUpload upload = new TusUpload(uploadId, key, uploadLength, 0L, contentType, new LinkedHashMap<>(metadata), TusUploadStatus.IN_PROGRESS);
+        save(upload);
+        if (uploadLength == 0L) {
+            return finalizeUpload(upload);
+        }
+        return upload;
+    }
+
+    @Override
+    @NonNull
+    public Optional<TusUpload> find(@NonNull String uploadId) {
+        Path sessionFile = sessionFile(uploadId);
+        if (!Files.exists(sessionFile)) {
+            return Optional.empty();
+        }
+        return Optional.of(read(sessionFile));
+    }
+
+    @Override
+    @NonNull
+    public TusUpload append(@NonNull String uploadId, long expectedOffset, byte[] chunk) {
+        TusUpload upload = find(uploadId).orElseThrow(() -> new IllegalArgumentException("Unknown upload: " + uploadId));
+        if (upload.completed() || upload.aborted()) {
+            throw new TusGoneException("Upload is no longer writable: " + uploadId);
+        }
+        if (expectedOffset != upload.offset()) {
+            throw new TusConflictException("Upload-Offset does not match the committed offset");
+        }
+        long nextOffset = upload.offset() + chunk.length;
+        if (nextOffset > upload.uploadLength()) {
+            throw new IllegalArgumentException("Chunk exceeds declared Upload-Length");
+        }
+
+        Path stagingFile = stagingFile(uploadId);
+        try {
+            mkdirs(stagingFile.getParent());
+            try (OutputStream outputStream = Files.newOutputStream(stagingFile,
+                java.nio.file.StandardOpenOption.CREATE,
+                java.nio.file.StandardOpenOption.APPEND)) {
+                outputStream.write(chunk);
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to persist tus upload chunk", e);
+        }
+
+        TusUpload updated = new TusUpload(
+            upload.id(),
+            upload.key(),
+            upload.uploadLength(),
+            nextOffset,
+            upload.getContentType().orElse(null),
+            upload.metadata(),
+            TusUploadStatus.IN_PROGRESS
+        );
+        save(updated);
+        if (nextOffset == upload.uploadLength()) {
+            return finalizeUpload(updated);
+        }
+        return updated;
+    }
+
+    @Override
+    public void abort(@NonNull String uploadId) {
+        TusUpload upload = find(uploadId).orElseThrow(() -> new IllegalArgumentException("Unknown upload: " + uploadId));
+        if (upload.completed() || upload.aborted()) {
+            throw new TusGoneException("Upload is no longer abortable: " + uploadId);
+        }
+        try {
+            Files.deleteIfExists(stagingFile(uploadId));
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to delete staged tus upload data", e);
+        }
+        save(new TusUpload(upload.id(), upload.key(), upload.uploadLength(), upload.offset(), upload.getContentType().orElse(null), upload.metadata(), TusUploadStatus.ABORTED));
+    }
+
+    private TusUpload finalizeUpload(TusUpload upload) {
+        Path stagingFile = stagingFile(upload.id());
+        if (!Files.exists(stagingFile)) {
+            try {
+                mkdirs(stagingFile.getParent());
+                Files.createFile(stagingFile);
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to create staged tus upload file", e);
+            }
+        }
+        FileUploadRequest uploadRequest = new FileUploadRequest(upload.key(), upload.getContentType().orElse(null), stagingFile, upload.metadata());
+        operations.upload(uploadRequest);
+        try {
+            Files.deleteIfExists(stagingFile);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to clean staged tus upload data", e);
+        }
+        TusUpload completed = new TusUpload(upload.id(), upload.key(), upload.uploadLength(), upload.uploadLength(), upload.getContentType().orElse(null), upload.metadata(), TusUploadStatus.COMPLETED);
+        save(completed);
+        return completed;
+    }
+
+    private void save(TusUpload upload) {
+        Properties properties = new Properties();
+        properties.setProperty(KEY, upload.key());
+        properties.setProperty(LENGTH, Long.toString(upload.uploadLength()));
+        properties.setProperty(OFFSET, Long.toString(upload.offset()));
+        properties.setProperty(STATUS, upload.status().name());
+        upload.getContentType().ifPresent(contentType -> properties.setProperty(CONTENT_TYPE, contentType));
+        upload.metadata().forEach((key, value) -> properties.setProperty(METADATA_PREFIX + key, value));
+        Path sessionFile = sessionFile(upload.id());
+        mkdirs(sessionFile.getParent());
+        try (OutputStream outputStream = Files.newOutputStream(sessionFile)) {
+            properties.store(outputStream, null);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to persist tus upload state", e);
+        }
+    }
+
+    private TusUpload read(Path sessionFile) {
+        Properties properties = new Properties();
+        try (InputStream inputStream = Files.newInputStream(sessionFile)) {
+            properties.load(inputStream);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to read tus upload state", e);
+        }
+
+        Map<String, String> metadata = new LinkedHashMap<>();
+        for (String propertyName : properties.stringPropertyNames()) {
+            if (propertyName.startsWith(METADATA_PREFIX)) {
+                metadata.put(propertyName.substring(METADATA_PREFIX.length()), properties.getProperty(propertyName));
+            }
+        }
+        String uploadId = sessionFile.getFileName().toString().replaceFirst("\\.properties$", "");
+        return new TusUpload(
+            uploadId,
+            properties.getProperty(KEY),
+            Long.parseLong(properties.getProperty(LENGTH)),
+            Long.parseLong(properties.getProperty(OFFSET)),
+            properties.getProperty(CONTENT_TYPE),
+            metadata,
+            TusUploadStatus.valueOf(properties.getProperty(STATUS))
+        );
+    }
+
+    private Path sessionFile(String uploadId) {
+        return sessionsPath.resolve(uploadId + ".properties");
+    }
+
+    private Path stagingFile(String uploadId) {
+        return stagingPath.resolve(uploadId + ".bin");
+    }
+
+    private static void mkdirs(Path path) {
+        try {
+            Files.createDirectories(path);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to create tus storage path: " + path, e);
+        }
+    }
+}

--- a/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/LocalTusUploadBackend.java
+++ b/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/LocalTusUploadBackend.java
@@ -17,7 +17,9 @@ package io.micronaut.objectstorage.tus;
 
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.objectstorage.request.FileUploadRequest;
 import io.micronaut.objectstorage.local.LocalStorageConfiguration;
 import io.micronaut.objectstorage.local.LocalStorageOperations;
@@ -30,6 +32,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -43,10 +49,12 @@ import java.util.UUID;
  * @since 3.0.0
  */
 @EachBean(LocalStorageConfiguration.class)
+@Requires(property = TusModuleConfiguration.PREFIX + ".enabled", value = StringUtils.TRUE)
 @Singleton
 @Internal
 public class LocalTusUploadBackend implements TusUploadBackend {
 
+    private static final System.Logger LOGGER = System.getLogger(LocalTusUploadBackend.class.getName());
     private static final String STATUS = "status";
     private static final String KEY = "key";
     private static final String LENGTH = "length";
@@ -58,6 +66,7 @@ public class LocalTusUploadBackend implements TusUploadBackend {
     private final LocalStorageOperations operations;
     private final Path sessionsPath;
     private final Path stagingPath;
+    private final ConcurrentMap<String, ReentrantLock> uploadLocks = new ConcurrentHashMap<>();
 
     public LocalTusUploadBackend(@Parameter String name,
                                  LocalStorageConfiguration configuration,
@@ -108,58 +117,59 @@ public class LocalTusUploadBackend implements TusUploadBackend {
     @Override
     @NonNull
     public TusUpload append(@NonNull String uploadId, long expectedOffset, byte[] chunk) {
-        TusUpload upload = find(uploadId).orElseThrow(() -> new IllegalArgumentException("Unknown upload: " + uploadId));
-        if (upload.completed() || upload.aborted()) {
-            throw new TusGoneException("Upload is no longer writable: " + uploadId);
-        }
-        if (expectedOffset != upload.offset()) {
-            throw new TusConflictException("Upload-Offset does not match the committed offset");
-        }
-        long nextOffset = upload.offset() + chunk.length;
-        if (nextOffset > upload.uploadLength()) {
-            throw new IllegalArgumentException("Chunk exceeds declared Upload-Length");
-        }
-
-        Path stagingFile = stagingFile(uploadId);
-        try {
-            mkdirs(stagingFile.getParent());
-            try (OutputStream outputStream = Files.newOutputStream(stagingFile,
-                java.nio.file.StandardOpenOption.CREATE,
-                java.nio.file.StandardOpenOption.APPEND)) {
-                outputStream.write(chunk);
+        return withUploadLock(uploadId, () -> {
+            TusUpload upload = find(uploadId).orElseThrow(() -> new IllegalArgumentException("Unknown upload: " + uploadId));
+            if (upload.completed() || upload.aborted()) {
+                throw new TusGoneException("Upload is no longer writable: " + uploadId);
             }
-        } catch (IOException e) {
-            throw new IllegalStateException("Unable to persist tus upload chunk", e);
-        }
+            if (expectedOffset != upload.offset()) {
+                throw new TusConflictException("Upload-Offset does not match the committed offset");
+            }
+            long nextOffset = upload.offset() + chunk.length;
+            if (nextOffset > upload.uploadLength()) {
+                throw new IllegalArgumentException("Chunk exceeds declared Upload-Length");
+            }
 
-        TusUpload updated = new TusUpload(
-            upload.id(),
-            upload.key(),
-            upload.uploadLength(),
-            nextOffset,
-            upload.getContentType().orElse(null),
-            upload.metadata(),
-            TusUploadStatus.IN_PROGRESS
-        );
-        save(updated);
-        if (nextOffset == upload.uploadLength()) {
-            return finalizeUpload(updated);
-        }
-        return updated;
+            Path stagingFile = stagingFile(uploadId);
+            try {
+                mkdirs(stagingFile.getParent());
+                try (OutputStream outputStream = Files.newOutputStream(stagingFile,
+                    java.nio.file.StandardOpenOption.CREATE,
+                    java.nio.file.StandardOpenOption.APPEND)) {
+                    outputStream.write(chunk);
+                }
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to persist tus upload chunk", e);
+            }
+
+            TusUpload updated = new TusUpload(
+                upload.id(),
+                upload.key(),
+                upload.uploadLength(),
+                nextOffset,
+                upload.getContentType().orElse(null),
+                upload.metadata(),
+                TusUploadStatus.IN_PROGRESS
+            );
+            save(updated);
+            if (nextOffset == upload.uploadLength()) {
+                return finalizeUpload(updated);
+            }
+            return updated;
+        });
     }
 
     @Override
     public void abort(@NonNull String uploadId) {
-        TusUpload upload = find(uploadId).orElseThrow(() -> new IllegalArgumentException("Unknown upload: " + uploadId));
-        if (upload.completed() || upload.aborted()) {
-            throw new TusGoneException("Upload is no longer abortable: " + uploadId);
-        }
-        try {
-            Files.deleteIfExists(stagingFile(uploadId));
-        } catch (IOException e) {
-            throw new IllegalStateException("Unable to delete staged tus upload data", e);
-        }
-        save(new TusUpload(upload.id(), upload.key(), upload.uploadLength(), upload.offset(), upload.getContentType().orElse(null), upload.metadata(), TusUploadStatus.ABORTED));
+        withUploadLock(uploadId, () -> {
+            TusUpload upload = find(uploadId).orElseThrow(() -> new IllegalArgumentException("Unknown upload: " + uploadId));
+            if (upload.completed() || upload.aborted()) {
+                throw new TusGoneException("Upload is no longer abortable: " + uploadId);
+            }
+            save(new TusUpload(upload.id(), upload.key(), upload.uploadLength(), upload.offset(), upload.getContentType().orElse(null), upload.metadata(), TusUploadStatus.ABORTED));
+            deleteStagingBestEffort(stagingFile(uploadId));
+            return null;
+        });
     }
 
     private TusUpload finalizeUpload(TusUpload upload) {
@@ -174,13 +184,9 @@ public class LocalTusUploadBackend implements TusUploadBackend {
         }
         FileUploadRequest uploadRequest = new FileUploadRequest(upload.key(), upload.getContentType().orElse(null), stagingFile, upload.metadata());
         operations.upload(uploadRequest);
-        try {
-            Files.deleteIfExists(stagingFile);
-        } catch (IOException e) {
-            throw new IllegalStateException("Unable to clean staged tus upload data", e);
-        }
         TusUpload completed = new TusUpload(upload.id(), upload.key(), upload.uploadLength(), upload.uploadLength(), upload.getContentType().orElse(null), upload.metadata(), TusUploadStatus.COMPLETED);
         save(completed);
+        deleteStagingBestEffort(stagingFile);
         return completed;
     }
 
@@ -233,6 +239,29 @@ public class LocalTusUploadBackend implements TusUploadBackend {
 
     private Path stagingFile(String uploadId) {
         return stagingPath.resolve(uploadId + ".bin");
+    }
+
+    private <T> T withUploadLock(String uploadId, Supplier<T> supplier) {
+        ReentrantLock lock = uploadLocks.computeIfAbsent(uploadId, ignored -> new ReentrantLock());
+        lock.lock();
+        try {
+            return supplier.get();
+        } finally {
+            lock.unlock();
+            if (!lock.hasQueuedThreads()) {
+                uploadLocks.remove(uploadId, lock);
+            }
+        }
+    }
+
+    private static void deleteStagingBestEffort(Path path) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException e) {
+            LOGGER.log(System.Logger.Level.WARNING,
+                "Unable to clean staged tus upload data: " + path,
+                e);
+        }
     }
 
     private static void mkdirs(Path path) {

--- a/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusConflictException.java
+++ b/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusConflictException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.tus;
+
+/**
+ * Raised when a client writes against a stale or invalid upload offset.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+public class TusConflictException extends RuntimeException {
+    public TusConflictException(String message) {
+        super(message);
+    }
+}

--- a/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusController.java
+++ b/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusController.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.tus;
+
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.Head;
+import io.micronaut.http.annotation.Header;
+import io.micronaut.http.annotation.Options;
+import io.micronaut.http.annotation.Patch;
+import io.micronaut.http.annotation.PathVariable;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.exceptions.HttpStatusException;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.context.annotation.Requires;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * HTTP entrypoint for tus resumable uploads.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Controller("${micronaut.object-storage.tus.base-path:/tus}")
+@Requires(property = TusModuleConfiguration.PREFIX + ".enabled", value = StringUtils.TRUE)
+public final class TusController {
+
+    private final TusModuleConfiguration configuration;
+    private final Map<String, TusUploadBackend> backends;
+
+    public TusController(TusModuleConfiguration configuration,
+                         Collection<TusUploadBackend> backends) {
+        this.configuration = configuration;
+        this.backends = new LinkedHashMap<>(backends.size());
+        for (TusUploadBackend backend : backends) {
+            this.backends.put(backend.getName(), backend);
+        }
+    }
+
+    @Options(uri = "/{storageName}")
+    public MutableHttpResponse<?> options(@PathVariable String storageName) {
+        backend(storageName);
+        return tus(HttpResponse.ok()
+            .header(TusHeaders.VERSION_HEADER, TusHeaders.VERSION)
+            .header(TusHeaders.EXTENSION_HEADER, TusHeaders.EXTENSIONS));
+    }
+
+    @Options(uri = "/{storageName}/{uploadId}")
+    public MutableHttpResponse<?> optionsUpload(@PathVariable String storageName,
+                                                @PathVariable String uploadId) {
+        return options(storageName);
+    }
+
+    @Post(uri = "/{storageName}")
+    public MutableHttpResponse<?> create(@PathVariable String storageName,
+                                         @Header(TusHeaders.LENGTH) long uploadLength,
+                                         @Header(TusHeaders.METADATA) @Nullable String encodedMetadata) {
+        if (uploadLength < 0L) {
+            throw new HttpStatusException(HttpStatus.BAD_REQUEST, "Upload-Length must be zero or greater");
+        }
+        Map<String, String> metadata = decodeMetadata(encodedMetadata);
+        String key = metadata.remove("key");
+        if (key == null || key.isBlank()) {
+            throw new HttpStatusException(HttpStatus.BAD_REQUEST, "Upload-Metadata must contain a base64 encoded key entry");
+        }
+        String contentType = metadata.remove("contentType");
+        TusUpload upload = backend(storageName).create(key, uploadLength, contentType, metadata);
+        return tus(HttpResponse.status(HttpStatus.CREATED)
+            .header("Location", configuration.getBasePath() + "/" + storageName + "/" + upload.id())
+            .header(TusHeaders.OFFSET, Long.toString(upload.offset()))
+            .header(TusHeaders.LENGTH, Long.toString(upload.uploadLength())));
+    }
+
+    @Head(uri = "/{storageName}/{uploadId}")
+    public MutableHttpResponse<?> head(@PathVariable String storageName,
+                                       @PathVariable String uploadId) {
+        TusUpload upload = getUpload(storageName, uploadId);
+        if (upload.aborted()) {
+            return tus(HttpResponse.status(HttpStatus.GONE));
+        }
+        return tus(HttpResponse.noContent()
+            .header(TusHeaders.OFFSET, Long.toString(upload.offset()))
+            .header(TusHeaders.LENGTH, Long.toString(upload.uploadLength()))
+            .header(TusHeaders.METADATA, encodeMetadata(upload)));
+    }
+
+    @Patch(uri = "/{storageName}/{uploadId}", consumes = "application/offset+octet-stream")
+    public MutableHttpResponse<?> patch(@PathVariable String storageName,
+                                        @PathVariable String uploadId,
+                                        @Header(TusHeaders.OFFSET) long uploadOffset,
+                                        @Body byte[] body) {
+        if (body.length > configuration.getMaxChunkSize()) {
+            throw new HttpStatusException(HttpStatus.REQUEST_ENTITY_TOO_LARGE, "Chunk exceeds configured tus max chunk size");
+        }
+        try {
+            TusUpload upload = backend(storageName).append(uploadId, uploadOffset, body);
+            return tus(HttpResponse.noContent()
+                .header(TusHeaders.OFFSET, Long.toString(upload.offset()))
+                .header(TusHeaders.LENGTH, Long.toString(upload.uploadLength())));
+        } catch (IllegalArgumentException e) {
+            throw new HttpStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+        } catch (TusConflictException e) {
+            throw new HttpStatusException(HttpStatus.CONFLICT, e.getMessage());
+        } catch (TusGoneException e) {
+            throw new HttpStatusException(HttpStatus.GONE, e.getMessage());
+        }
+    }
+
+    @Delete(uri = "/{storageName}/{uploadId}")
+    public MutableHttpResponse<?> delete(@PathVariable String storageName,
+                                         @PathVariable String uploadId) {
+        try {
+            backend(storageName).abort(uploadId);
+            return tus(HttpResponse.noContent());
+        } catch (IllegalArgumentException e) {
+            throw new HttpStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        } catch (TusGoneException e) {
+            throw new HttpStatusException(HttpStatus.GONE, e.getMessage());
+        }
+    }
+
+    private TusUpload getUpload(String storageName, String uploadId) {
+        return backend(storageName).find(uploadId)
+            .orElseThrow(() -> new HttpStatusException(HttpStatus.NOT_FOUND, "Unknown upload: " + uploadId));
+    }
+
+    private TusUploadBackend backend(String storageName) {
+        TusUploadBackend backend = backends.get(storageName);
+        if (backend == null) {
+            throw new HttpStatusException(HttpStatus.NOT_FOUND, "Unknown object storage backend: " + storageName);
+        }
+        return backend;
+    }
+
+    private static Map<String, String> decodeMetadata(@Nullable String encodedMetadata) {
+        if (encodedMetadata == null || encodedMetadata.isBlank()) {
+            return new LinkedHashMap<>();
+        }
+        try {
+            return new LinkedHashMap<>(TusMetadataCodec.decode(encodedMetadata));
+        } catch (IllegalArgumentException e) {
+            throw new HttpStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+        }
+    }
+
+    private static String encodeMetadata(TusUpload upload) {
+        Map<String, String> metadata = new LinkedHashMap<>();
+        metadata.put("key", upload.key());
+        upload.getContentType().ifPresent(contentType -> metadata.put("contentType", contentType));
+        metadata.putAll(upload.metadata());
+        return TusMetadataCodec.encode(metadata);
+    }
+
+    private static MutableHttpResponse<?> tus(MutableHttpResponse<?> response) {
+        return response.header(TusHeaders.RESUMABLE, TusHeaders.VERSION);
+    }
+}

--- a/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusController.java
+++ b/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusController.java
@@ -74,8 +74,10 @@ public final class TusController {
 
     @Post(uri = "/{storageName}")
     public MutableHttpResponse<?> create(@PathVariable String storageName,
+                                         @Header(TusHeaders.RESUMABLE) @Nullable String tusResumable,
                                          @Header(TusHeaders.LENGTH) long uploadLength,
                                          @Header(TusHeaders.METADATA) @Nullable String encodedMetadata) {
+        validateTusResumable(tusResumable);
         if (uploadLength < 0L) {
             throw new HttpStatusException(HttpStatus.BAD_REQUEST, "Upload-Length must be zero or greater");
         }
@@ -94,7 +96,9 @@ public final class TusController {
 
     @Head(uri = "/{storageName}/{uploadId}")
     public MutableHttpResponse<?> head(@PathVariable String storageName,
-                                       @PathVariable String uploadId) {
+                                       @PathVariable String uploadId,
+                                       @Header(TusHeaders.RESUMABLE) @Nullable String tusResumable) {
+        validateTusResumable(tusResumable);
         TusUpload upload = getUpload(storageName, uploadId);
         if (upload.aborted()) {
             return tus(HttpResponse.status(HttpStatus.GONE));
@@ -108,8 +112,10 @@ public final class TusController {
     @Patch(uri = "/{storageName}/{uploadId}", consumes = "application/offset+octet-stream")
     public MutableHttpResponse<?> patch(@PathVariable String storageName,
                                         @PathVariable String uploadId,
+                                        @Header(TusHeaders.RESUMABLE) @Nullable String tusResumable,
                                         @Header(TusHeaders.OFFSET) long uploadOffset,
                                         @Body byte[] body) {
+        validateTusResumable(tusResumable);
         if (body.length > configuration.getMaxChunkSize()) {
             throw new HttpStatusException(HttpStatus.REQUEST_ENTITY_TOO_LARGE, "Chunk exceeds configured tus max chunk size");
         }
@@ -129,7 +135,9 @@ public final class TusController {
 
     @Delete(uri = "/{storageName}/{uploadId}")
     public MutableHttpResponse<?> delete(@PathVariable String storageName,
-                                         @PathVariable String uploadId) {
+                                         @PathVariable String uploadId,
+                                         @Header(TusHeaders.RESUMABLE) @Nullable String tusResumable) {
+        validateTusResumable(tusResumable);
         try {
             backend(storageName).abort(uploadId);
             return tus(HttpResponse.noContent());
@@ -170,6 +178,13 @@ public final class TusController {
         upload.getContentType().ifPresent(contentType -> metadata.put("contentType", contentType));
         metadata.putAll(upload.metadata());
         return TusMetadataCodec.encode(metadata);
+    }
+
+    private static void validateTusResumable(@Nullable String tusResumable) {
+        if (!TusHeaders.VERSION.equals(tusResumable)) {
+            throw new HttpStatusException(HttpStatus.PRECONDITION_FAILED,
+                "Tus-Resumable must be " + TusHeaders.VERSION);
+        }
     }
 
     private static MutableHttpResponse<?> tus(MutableHttpResponse<?> response) {

--- a/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusGoneException.java
+++ b/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusGoneException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.tus;
+
+/**
+ * Raised when an upload was already completed or aborted.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+public class TusGoneException extends RuntimeException {
+    public TusGoneException(String message) {
+        super(message);
+    }
+}

--- a/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusHeaders.java
+++ b/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusHeaders.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.tus;
+
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * tus protocol constants.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Internal
+public final class TusHeaders {
+
+    public static final String VERSION = "1.0.0";
+    public static final String EXTENSIONS = "creation,termination";
+    public static final String RESUMABLE = "Tus-Resumable";
+    public static final String VERSION_HEADER = "Tus-Version";
+    public static final String EXTENSION_HEADER = "Tus-Extension";
+    public static final String OFFSET = "Upload-Offset";
+    public static final String LENGTH = "Upload-Length";
+    public static final String METADATA = "Upload-Metadata";
+
+    private TusHeaders() {
+    }
+}

--- a/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusMetadataCodec.java
+++ b/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusMetadataCodec.java
@@ -48,8 +48,12 @@ public final class TusMetadataCodec {
                 continue;
             }
             String[] parts = trimmed.split(" ", 2);
-            if (parts.length != 2 || parts[0].isBlank() || parts[1].isBlank()) {
+            if (parts[0].isBlank()) {
                 throw new IllegalArgumentException("Invalid Upload-Metadata entry: " + trimmed);
+            }
+            if (parts.length == 1 || parts[1].isEmpty()) {
+                metadata.put(parts[0], "");
+                continue;
             }
             byte[] decoded = Base64.getDecoder().decode(parts[1]);
             metadata.put(parts[0], new String(decoded, StandardCharsets.UTF_8));

--- a/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusMetadataCodec.java
+++ b/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusMetadataCodec.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.tus;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.NonNull;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.StringJoiner;
+
+/**
+ * Encodes and decodes tus metadata headers.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Internal
+public final class TusMetadataCodec {
+
+    private TusMetadataCodec() {
+    }
+
+    @NonNull
+    public static Map<String, String> decode(@NonNull String headerValue) {
+        Map<String, String> metadata = new LinkedHashMap<>();
+        if (headerValue.isBlank()) {
+            return metadata;
+        }
+        for (String entry : headerValue.split(",")) {
+            String trimmed = entry.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            String[] parts = trimmed.split(" ", 2);
+            if (parts.length != 2 || parts[0].isBlank() || parts[1].isBlank()) {
+                throw new IllegalArgumentException("Invalid Upload-Metadata entry: " + trimmed);
+            }
+            byte[] decoded = Base64.getDecoder().decode(parts[1]);
+            metadata.put(parts[0], new String(decoded, StandardCharsets.UTF_8));
+        }
+        return metadata;
+    }
+
+    @NonNull
+    public static String encode(@NonNull Map<String, String> metadata) {
+        StringJoiner joiner = new StringJoiner(",");
+        metadata.forEach((key, value) -> {
+            String encodedValue = Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+            joiner.add(key + " " + encodedValue);
+        });
+        return joiner.toString();
+    }
+}

--- a/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusModuleConfiguration.java
+++ b/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusModuleConfiguration.java
@@ -17,6 +17,9 @@ package io.micronaut.objectstorage.tus;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 /**
  * tus module configuration.
  *
@@ -31,6 +34,7 @@ public final class TusModuleConfiguration {
     private boolean enabled;
     private String basePath = "/tus";
     private long maxChunkSize = 16L * 1024L * 1024L;
+    private Path storageDirectory = Paths.get(System.getProperty("java.io.tmpdir"), "micronaut-object-storage-tus");
 
     public boolean isEnabled() {
         return enabled;
@@ -54,5 +58,13 @@ public final class TusModuleConfiguration {
 
     public void setMaxChunkSize(long maxChunkSize) {
         this.maxChunkSize = maxChunkSize;
+    }
+
+    public Path getStorageDirectory() {
+        return storageDirectory;
+    }
+
+    public void setStorageDirectory(Path storageDirectory) {
+        this.storageDirectory = storageDirectory;
     }
 }

--- a/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusModuleConfiguration.java
+++ b/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusModuleConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.tus;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+/**
+ * tus module configuration.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@ConfigurationProperties(TusModuleConfiguration.PREFIX)
+public final class TusModuleConfiguration {
+
+    public static final String PREFIX = "micronaut.object-storage.tus";
+
+    private boolean enabled;
+    private String basePath = "/tus";
+    private long maxChunkSize = 16L * 1024L * 1024L;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getBasePath() {
+        return basePath;
+    }
+
+    public void setBasePath(String basePath) {
+        this.basePath = basePath;
+    }
+
+    public long getMaxChunkSize() {
+        return maxChunkSize;
+    }
+
+    public void setMaxChunkSize(long maxChunkSize) {
+        this.maxChunkSize = maxChunkSize;
+    }
+}

--- a/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusUpload.java
+++ b/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusUpload.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.tus;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Persistent tus upload state.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ * @param id The upload identifier
+ * @param key The destination object key
+ * @param uploadLength The declared upload length
+ * @param offset The committed upload offset
+ * @param contentType The completed object content type
+ * @param metadata User metadata to persist with the completed object
+ * @param status The current upload status
+ */
+public record TusUpload(
+    @NonNull String id,
+    @NonNull String key,
+    long uploadLength,
+    long offset,
+    @Nullable String contentType,
+    @NonNull Map<String, String> metadata,
+    @NonNull TusUploadStatus status
+) {
+    public boolean inProgress() {
+        return status == TusUploadStatus.IN_PROGRESS;
+    }
+
+    public boolean completed() {
+        return status == TusUploadStatus.COMPLETED;
+    }
+
+    public boolean aborted() {
+        return status == TusUploadStatus.ABORTED;
+    }
+
+    @NonNull
+    public Optional<String> getContentType() {
+        return Optional.ofNullable(contentType);
+    }
+}

--- a/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusUpload.java
+++ b/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusUpload.java
@@ -43,6 +43,11 @@ public record TusUpload(
     @NonNull Map<String, String> metadata,
     @NonNull TusUploadStatus status
 ) {
+    @NonNull
+    public TusUpload withStatus(@NonNull TusUploadStatus nextStatus, long nextOffset) {
+        return new TusUpload(id, key, uploadLength, nextOffset, contentType, metadata, nextStatus);
+    }
+
     public boolean inProgress() {
         return status == TusUploadStatus.IN_PROGRESS;
     }

--- a/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusUploadBackend.java
+++ b/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusUploadBackend.java
@@ -17,6 +17,7 @@ package io.micronaut.objectstorage.tus;
 
 import io.micronaut.core.naming.Named;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
 import java.util.Optional;
@@ -32,7 +33,7 @@ public interface TusUploadBackend extends Named {
     @NonNull
     TusUpload create(@NonNull String key,
                      long uploadLength,
-                     String contentType,
+                     @Nullable String contentType,
                      @NonNull Map<String, String> metadata);
 
     @NonNull

--- a/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusUploadBackend.java
+++ b/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusUploadBackend.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.tus;
+
+import io.micronaut.core.naming.Named;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Backend contract for resumable tus uploads.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+public interface TusUploadBackend extends Named {
+
+    @NonNull
+    TusUpload create(@NonNull String key,
+                     long uploadLength,
+                     String contentType,
+                     @NonNull Map<String, String> metadata);
+
+    @NonNull
+    Optional<TusUpload> find(@NonNull String uploadId);
+
+    @NonNull
+    TusUpload append(@NonNull String uploadId, long expectedOffset, byte[] chunk);
+
+    void abort(@NonNull String uploadId);
+}

--- a/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusUploadStatus.java
+++ b/object-storage-tus/src/main/java/io/micronaut/objectstorage/tus/TusUploadStatus.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.tus;
+
+/**
+ * Persistent tus upload lifecycle status.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+public enum TusUploadStatus {
+    IN_PROGRESS,
+    COMPLETED,
+    ABORTED
+}

--- a/object-storage-tus/src/test/groovy/io/micronaut/objectstorage/tus/TusControllerSpec.groovy
+++ b/object-storage-tus/src/test/groovy/io/micronaut/objectstorage/tus/TusControllerSpec.groovy
@@ -1,0 +1,107 @@
+package io.micronaut.objectstorage.tus
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.exceptions.HttpStatusException
+import io.micronaut.objectstorage.local.LocalStorageConfiguration
+import io.micronaut.objectstorage.local.LocalStorageOperations
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class TusControllerSpec extends Specification implements TestPropertyProvider {
+
+    @Inject
+    TusController controller
+
+    @Inject
+    LocalStorageOperations operations
+
+    void cleanup() {
+        operations.listObjects().each { operations.delete(it) }
+    }
+
+    @Override
+    Map<String, String> getProperties() {
+        [
+            (LocalStorageConfiguration.PREFIX + '.default.enabled'): 'true',
+            (TusModuleConfiguration.PREFIX + '.enabled')         : 'true'
+        ]
+    }
+
+    void 'it can create resume and finalize a tus upload against local storage'() {
+        given:
+        def createRequest = HttpRequest.POST('/tus/default', '')
+            .header(TusHeaders.RESUMABLE, TusHeaders.VERSION)
+            .header(TusHeaders.LENGTH, '11')
+            .header(TusHeaders.METADATA, TusMetadataCodec.encode([
+                key        : 'photos/hello.txt',
+                contentType: 'text/plain',
+                owner      : 'micronaut'
+            ]))
+
+        when:
+        def createResponse = controller.create('default', 11, createRequest.headers.get(TusHeaders.METADATA))
+        String location = createResponse.header('Location')
+        String uploadId = location.tokenize('/').last()
+
+        then:
+        createResponse.status() == HttpStatus.CREATED
+        createResponse.header(TusHeaders.OFFSET) == '0'
+        location == '/tus/default/' + uploadId
+
+        when:
+        def firstPatch = controller.patch('default', uploadId, 0L, 'hello'.bytes)
+        def head = controller.head('default', uploadId)
+        def secondPatch = controller.patch('default', uploadId, 5L, ' world'.bytes)
+
+        then:
+        firstPatch.status() == HttpStatus.NO_CONTENT
+        firstPatch.header(TusHeaders.OFFSET) == '5'
+        head.status() == HttpStatus.NO_CONTENT
+        head.header(TusHeaders.OFFSET) == '5'
+        secondPatch.status() == HttpStatus.NO_CONTENT
+        secondPatch.header(TusHeaders.OFFSET) == '11'
+        operations.retrieve('photos/hello.txt').present
+        operations.retrieve('photos/hello.txt').get().inputStream.text == 'hello world'
+        operations.retrieve('photos/hello.txt').get().metadata == [owner: 'micronaut']
+    }
+
+    void 'it rejects stale offsets without corrupting the upload'() {
+        given:
+        String location = createUpload('photos/stale.txt', 8)
+        String uploadId = location.tokenize('/').last()
+        controller.patch('default', uploadId, 0L, 'abcd'.bytes)
+
+        when:
+        controller.patch('default', uploadId, 0L, 'efgh'.bytes)
+
+        then:
+        def e = thrown(HttpStatusException)
+        e.status == HttpStatus.CONFLICT
+        controller.head('default', uploadId).header(TusHeaders.OFFSET) == '4'
+        !operations.retrieve('photos/stale.txt').present
+    }
+
+    void 'it can abort an in-progress upload'() {
+        given:
+        String location = createUpload('photos/abort.txt', 4)
+        String uploadId = location.tokenize('/').last()
+
+        when:
+        def deleteResponse = controller.delete('default', uploadId)
+        def headResponse = controller.head('default', uploadId)
+
+        then:
+        deleteResponse.status() == HttpStatus.NO_CONTENT
+        headResponse.status() == HttpStatus.GONE
+        !operations.retrieve('photos/abort.txt').present
+    }
+
+    private String createUpload(String key, int length) {
+        controller.create('default', length, TusMetadataCodec.encode([key: key]))
+            .header('Location')
+    }
+}

--- a/object-storage-tus/src/test/groovy/io/micronaut/objectstorage/tus/TusControllerSpec.groovy
+++ b/object-storage-tus/src/test/groovy/io/micronaut/objectstorage/tus/TusControllerSpec.groovy
@@ -43,7 +43,7 @@ class TusControllerSpec extends Specification implements TestPropertyProvider {
             ]))
 
         when:
-        def createResponse = controller.create('default', 11, createRequest.headers.get(TusHeaders.METADATA))
+        def createResponse = controller.create('default', TusHeaders.VERSION, 11, createRequest.headers.get(TusHeaders.METADATA))
         String location = createResponse.header('Location')
         String uploadId = location.tokenize('/').last()
 
@@ -53,9 +53,9 @@ class TusControllerSpec extends Specification implements TestPropertyProvider {
         location == '/tus/default/' + uploadId
 
         when:
-        def firstPatch = controller.patch('default', uploadId, 0L, 'hello'.bytes)
-        def head = controller.head('default', uploadId)
-        def secondPatch = controller.patch('default', uploadId, 5L, ' world'.bytes)
+        def firstPatch = controller.patch('default', uploadId, TusHeaders.VERSION, 0L, 'hello'.bytes)
+        def head = controller.head('default', uploadId, TusHeaders.VERSION)
+        def secondPatch = controller.patch('default', uploadId, TusHeaders.VERSION, 5L, ' world'.bytes)
 
         then:
         firstPatch.status() == HttpStatus.NO_CONTENT
@@ -73,15 +73,15 @@ class TusControllerSpec extends Specification implements TestPropertyProvider {
         given:
         String location = createUpload('photos/stale.txt', 8)
         String uploadId = location.tokenize('/').last()
-        controller.patch('default', uploadId, 0L, 'abcd'.bytes)
+        controller.patch('default', uploadId, TusHeaders.VERSION, 0L, 'abcd'.bytes)
 
         when:
-        controller.patch('default', uploadId, 0L, 'efgh'.bytes)
+        controller.patch('default', uploadId, TusHeaders.VERSION, 0L, 'efgh'.bytes)
 
         then:
         def e = thrown(HttpStatusException)
         e.status == HttpStatus.CONFLICT
-        controller.head('default', uploadId).header(TusHeaders.OFFSET) == '4'
+        controller.head('default', uploadId, TusHeaders.VERSION).header(TusHeaders.OFFSET) == '4'
         !operations.retrieve('photos/stale.txt').present
     }
 
@@ -91,8 +91,8 @@ class TusControllerSpec extends Specification implements TestPropertyProvider {
         String uploadId = location.tokenize('/').last()
 
         when:
-        def deleteResponse = controller.delete('default', uploadId)
-        def headResponse = controller.head('default', uploadId)
+        def deleteResponse = controller.delete('default', uploadId, TusHeaders.VERSION)
+        def headResponse = controller.head('default', uploadId, TusHeaders.VERSION)
 
         then:
         deleteResponse.status() == HttpStatus.NO_CONTENT
@@ -100,8 +100,50 @@ class TusControllerSpec extends Specification implements TestPropertyProvider {
         !operations.retrieve('photos/abort.txt').present
     }
 
+    void 'it rejects missing or unsupported Tus-Resumable headers'() {
+        given:
+        String uploadId = createUpload('photos/versioned.txt', 4).tokenize('/').last()
+
+        when:
+        controller.create('default', null, 1, TusMetadataCodec.encode([key: 'photos/missing.txt']))
+
+        then:
+        def createException = thrown(HttpStatusException)
+        createException.status == HttpStatus.PRECONDITION_FAILED
+
+        when:
+        controller.head('default', uploadId, '0.2.2')
+
+        then:
+        def headException = thrown(HttpStatusException)
+        headException.status == HttpStatus.PRECONDITION_FAILED
+
+        when:
+        controller.patch('default', uploadId, null, 0L, 'ab'.bytes)
+
+        then:
+        def patchException = thrown(HttpStatusException)
+        patchException.status == HttpStatus.PRECONDITION_FAILED
+
+        when:
+        controller.delete('default', uploadId, null)
+
+        then:
+        def deleteException = thrown(HttpStatusException)
+        deleteException.status == HttpStatus.PRECONDITION_FAILED
+    }
+
+    void 'it decodes empty Upload-Metadata values'() {
+        expect:
+        TusMetadataCodec.decode('filename Zm9vLnR4dA==,flag,empty ') == [
+            filename: 'foo.txt',
+            flag    : '',
+            empty   : ''
+        ]
+    }
+
     private String createUpload(String key, int length) {
-        controller.create('default', length, TusMetadataCodec.encode([key: key]))
+        controller.create('default', TusHeaders.VERSION, length, TusMetadataCodec.encode([key: key]))
             .header('Location')
     }
 }

--- a/object-storage-tus/src/test/groovy/io/micronaut/objectstorage/tus/TusModuleDisabledSpec.groovy
+++ b/object-storage-tus/src/test/groovy/io/micronaut/objectstorage/tus/TusModuleDisabledSpec.groovy
@@ -1,0 +1,23 @@
+package io.micronaut.objectstorage.tus
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.objectstorage.local.LocalStorageConfiguration
+import spock.lang.Specification
+
+class TusModuleDisabledSpec extends Specification {
+
+    void 'local tus backends stay disabled until the module is enabled'() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+            (LocalStorageConfiguration.PREFIX + '.default.enabled'): 'true',
+            (TusModuleConfiguration.PREFIX + '.enabled')         : 'false'
+        ])
+
+        expect:
+        !context.containsBean(TusController)
+        context.getBeansOfType(TusUploadBackend).isEmpty()
+
+        cleanup:
+        context.close()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ include("object-storage-azure")
 include("object-storage-gcp")
 include("object-storage-oracle-cloud")
 include("object-storage-local")
+include("object-storage-tus")
 include("test-suite-graal")
 
 include("doc-examples:example-java")

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -5,6 +5,7 @@ reactiveOperations: Reactive Operations
 preSignedUploads: Pre-Signed Uploads
 paginatedListing: Paginated Listing
 bucketManagement: Bucket and Container Management
+tusUploads: tus Resumable Uploads
 aws: Amazon S3
 azure: Azure Blob Storage
 gcp: Google Cloud Storage

--- a/src/main/docs/guide/tusUploads.adoc
+++ b/src/main/docs/guide/tusUploads.adoc
@@ -1,6 +1,6 @@
 The `object-storage-tus` module adds an opt-in tus 1.0 resumable upload endpoint for Micronaut Object Storage.
 
-Enable the module and configure at least one local object storage backend:
+Enable the module and configure at least one supported object storage backend:
 
 [configuration]
 ----
@@ -9,14 +9,20 @@ micronaut:
     tus:
       enabled: true
       base-path: /tus
-    local:
+      storage-directory: /var/lib/object-storage-tus
+    aws:
       default:
-        enabled: true
+        bucket: uploads
 ----
 
 Requests use the route pattern `/tus/{storageName}` and `/tus/{storageName}/{uploadId}`.
 
-The initial reference implementation is backed by `LocalStorageOperations`:
+The current backends are:
+
+- Local storage, which persists incomplete uploads under the local provider metadata directory before moving them into the configured object key on completion.
+- AWS S3, which creates a multipart upload immediately, persists tus session state under `micronaut.object-storage.tus.storage-directory`, uploads 5 MiB parts as data accumulates, and completes or aborts the multipart upload when the tus resource finishes.
+
+The module supports the following protocol behavior across those backends:
 
 - `OPTIONS` advertises tus version `1.0.0` plus the `creation` and `termination` extensions.
 - `POST` creates a resumable upload and requires `Upload-Length` plus `Upload-Metadata` containing a base64-encoded `key`.
@@ -33,4 +39,4 @@ Upload-Metadata: key cGhvdG9zL3Byb2ZpbGUucG5n,contentType aW1hZ2UvcG5n
 
 Additional metadata entries are persisted with the completed object.
 
-The local backend stores temporary tus session state under the local storage metadata directory so incomplete uploads do not appear in normal object listings.
+Incomplete uploads never appear in normal object listings. Local temporary state lives beside the local provider metadata, while AWS-backed uploads use the configured tus storage directory for session records and staged chunk data.

--- a/src/main/docs/guide/tusUploads.adoc
+++ b/src/main/docs/guide/tusUploads.adoc
@@ -25,6 +25,7 @@ The current backends are:
 The module supports the following protocol behavior across those backends:
 
 - `OPTIONS` advertises tus version `1.0.0` plus the `creation` and `termination` extensions.
+- `POST`, `HEAD`, `PATCH`, and `DELETE` require `Tus-Resumable: 1.0.0`; unsupported or missing versions are rejected with `412 Precondition Failed`.
 - `POST` creates a resumable upload and requires `Upload-Length` plus `Upload-Metadata` containing a base64-encoded `key`.
 - `HEAD` returns the authoritative `Upload-Offset`.
 - `PATCH` appends bytes at the exact `Upload-Offset` and finalizes the object automatically when the declared length is reached.

--- a/src/main/docs/guide/tusUploads.adoc
+++ b/src/main/docs/guide/tusUploads.adoc
@@ -1,0 +1,36 @@
+The `object-storage-tus` module adds an opt-in tus 1.0 resumable upload endpoint for Micronaut Object Storage.
+
+Enable the module and configure at least one local object storage backend:
+
+[configuration]
+----
+micronaut:
+  object-storage:
+    tus:
+      enabled: true
+      base-path: /tus
+    local:
+      default:
+        enabled: true
+----
+
+Requests use the route pattern `/tus/{storageName}` and `/tus/{storageName}/{uploadId}`.
+
+The initial reference implementation is backed by `LocalStorageOperations`:
+
+- `OPTIONS` advertises tus version `1.0.0` plus the `creation` and `termination` extensions.
+- `POST` creates a resumable upload and requires `Upload-Length` plus `Upload-Metadata` containing a base64-encoded `key`.
+- `HEAD` returns the authoritative `Upload-Offset`.
+- `PATCH` appends bytes at the exact `Upload-Offset` and finalizes the object automatically when the declared length is reached.
+- `DELETE` aborts an in-progress upload.
+
+Example `Upload-Metadata` header:
+
+[source,text]
+----
+Upload-Metadata: key cGhvdG9zL3Byb2ZpbGUucG5n,contentType aW1hZ2UvcG5n
+----
+
+Additional metadata entries are persisted with the completed object.
+
+The local backend stores temporary tus session state under the local storage metadata directory so incomplete uploads do not appear in normal object listings.


### PR DESCRIPTION
## Summary
- add an opt-in `object-storage-tus` module with tus protocol endpoints and configuration
- provide local and AWS S3 multipart-backed resumable upload backends without changing `ObjectStorageOperations`
- document supported backends and tus configuration for the initial additive release

## Verification
- `./gradlew --no-daemon --rerun-tasks :micronaut-object-storage-tus:test --tests "io.micronaut.objectstorage.tus.TusControllerSpec" :micronaut-object-storage-aws:test --tests "io.micronaut.objectstorage.aws.AwsS3TusUploadBackendLocalstackSpec" :micronaut-object-storage-aws:japiCmp docs`

Closes #756