### PR TITLE
feat: add s3-compatible API surface

### DIFF
--- a/object-storage-s3-compat/build.gradle.kts
+++ b/object-storage-s3-compat/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    io.micronaut.build.internal.`objectstorage-module`
+}
+
+dependencies {
+    annotationProcessor(mn.micronaut.inject.java)
+    annotationProcessor(mnValidation.micronaut.validation.processor)
+
+    api(projects.micronautObjectStorageCore)
+
+    implementation(mn.micronaut.jackson.databind)
+    implementation(mn.micronaut.http.server)
+    implementation(mnValidation.micronaut.validation)
+    implementation(projects.micronautObjectStorageLocal)
+
+    testImplementation(mn.micronaut.http.client)
+    testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mnValidation.micronaut.validation.processor)
+}
+
+micronautBuild {
+    binaryCompatibility {
+        enabledAfter("3.0.0")
+    }
+}

--- a/object-storage-s3-compat/build.gradle.kts
+++ b/object-storage-s3-compat/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(mn.micronaut.jackson.databind)
     implementation(mn.micronaut.http.server)
     implementation(mnValidation.micronaut.validation)
+    implementation(projects.micronautObjectStorageAws)
     implementation(projects.micronautObjectStorageLocal)
 
     testImplementation(platform(mnAws.micronaut.aws.bom))
@@ -19,6 +20,12 @@ dependencies {
     testImplementation(mn.micronaut.http.client)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mnValidation.micronaut.validation.processor)
+    testImplementation(mnTestResources.testcontainers.localstack)
+    testImplementation(project(":test-suite-utils"))
+
+    testImplementation(libs.amazon.awssdk.v1) {
+        because("it is required by testcontainers-localstack")
+    }
 }
 
 micronautBuild {

--- a/object-storage-s3-compat/build.gradle.kts
+++ b/object-storage-s3-compat/build.gradle.kts
@@ -13,6 +13,9 @@ dependencies {
     implementation(mnValidation.micronaut.validation)
     implementation(projects.micronautObjectStorageLocal)
 
+    testImplementation(platform(mnAws.micronaut.aws.bom))
+    testImplementation(mnAws.micronaut.aws.sdk.v2)
+    testImplementation(libs.amazon.awssdk.s3)
     testImplementation(mn.micronaut.http.client)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mnValidation.micronaut.validation.processor)

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/AbstractS3CompatibleOperations.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/AbstractS3CompatibleOperations.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Base class for S3-compatible backend adapters that expose one configured bucket.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+abstract class AbstractS3CompatibleOperations implements S3CompatibleOperations {
+
+    private final S3CompatibilityConfiguration configuration;
+
+    AbstractS3CompatibleOperations(@NonNull S3CompatibilityConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @NonNull
+    protected final String resolveStorageKey(@NonNull String key) {
+        String normalizedKey = normalizeKey(key);
+        return configuration.getBasePath()
+            .map(basePath -> basePath + normalizedKey)
+            .orElse(normalizedKey);
+    }
+
+    @Nullable
+    protected final String resolveListPrefix(@Nullable String prefix) {
+        String normalizedPrefix = prefix == null ? null : normalizeKey(prefix);
+        if (normalizedPrefix == null || normalizedPrefix.isEmpty()) {
+            return configuration.getBasePath().orElse(null);
+        }
+        return configuration.getBasePath()
+            .map(basePath -> basePath + normalizedPrefix)
+            .orElse(normalizedPrefix);
+    }
+
+    @NonNull
+    protected final String stripBasePath(@NonNull String key) {
+        return configuration.getBasePath()
+            .filter(key::startsWith)
+            .map(basePath -> key.substring(basePath.length()))
+            .orElse(key);
+    }
+
+    @NonNull
+    private static String normalizeKey(@NonNull String key) {
+        String normalized = key;
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        return normalized;
+    }
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/AwsS3CompatibleOperations.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/AwsS3CompatibleOperations.java
@@ -21,7 +21,6 @@ import io.micronaut.objectstorage.aws.AwsS3ObjectStorageEntry;
 import io.micronaut.objectstorage.aws.AwsS3Operations;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.objectstorage.request.ListObjectsRequest;
-import io.micronaut.objectstorage.request.UploadRequest;
 import io.micronaut.objectstorage.response.UploadResponse;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -79,15 +78,12 @@ public final class AwsS3CompatibleOperations extends AbstractS3CompatibleOperati
                                        @NonNull InputStream inputStream,
                                        @Nullable Long contentLength,
                                        @Nullable String contentType) {
-        try {
-            UploadRequest request = UploadRequest.fromBytes(inputStream.readAllBytes(), resolveStorageKey(key));
-            if (contentType != null && !contentType.isBlank()) {
-                request.setContentType(contentType);
-            }
-            return operations.upload(request);
-        } catch (IOException e) {
-            throw new ObjectStorageException("Error reading request body for S3-compatible upload", e);
-        }
+        return operations.upload(new S3CompatibilityUploadRequest(
+            inputStream,
+            resolveStorageKey(key),
+            contentLength,
+            contentType
+        ));
     }
 
     @Override
@@ -101,7 +97,7 @@ public final class AwsS3CompatibleOperations extends AbstractS3CompatibleOperati
         ListObjectsRequest storageRequest = new ListObjectsRequest(
             request.getPageSize(),
             resolveListPrefix(request.getPrefix().orElse(null)),
-            request.getContinuationToken().map(this::resolveStorageKey).orElse(null)
+            request.getContinuationToken().orElse(null)
         );
         io.micronaut.objectstorage.response.ListObjectsResponse response = operations.listObjects(storageRequest);
         List<S3ObjectSummary> objects = response.getKeys().stream()

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/AwsS3CompatibleOperations.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/AwsS3CompatibleOperations.java
@@ -16,43 +16,52 @@
 package io.micronaut.objectstorage.s3compat;
 
 import io.micronaut.objectstorage.ObjectStorageException;
-import io.micronaut.objectstorage.local.LocalStorageEntry;
-import io.micronaut.objectstorage.local.LocalStorageOperations;
+import io.micronaut.objectstorage.aws.AwsS3Configuration;
+import io.micronaut.objectstorage.aws.AwsS3ObjectStorageEntry;
+import io.micronaut.objectstorage.aws.AwsS3Operations;
 import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
 import io.micronaut.objectstorage.response.UploadResponse;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
 /**
- * Local storage bridge for the S3-compatible transport layer.
+ * AWS S3 bridge for the S3-compatible transport layer.
  *
  * @author Álvaro Sánchez-Mariscal
  * @since 3.0.0
  */
-public final class LocalStorageS3CompatibleOperations extends AbstractS3CompatibleOperations {
+public final class AwsS3CompatibleOperations extends AbstractS3CompatibleOperations {
 
-    private final LocalStorageOperations operations;
+    private final AwsS3Configuration awsConfiguration;
+    private final AwsS3Operations operations;
+    private final S3Client s3Client;
 
-    LocalStorageS3CompatibleOperations(@NonNull S3CompatibilityConfiguration configuration,
-                                       @NonNull LocalStorageOperations operations) {
+    AwsS3CompatibleOperations(@NonNull S3CompatibilityConfiguration configuration,
+                              @NonNull AwsS3Configuration awsConfiguration,
+                              @NonNull AwsS3Operations operations,
+                              @NonNull S3Client s3Client) {
         super(configuration);
+        this.awsConfiguration = awsConfiguration;
         this.operations = operations;
+        this.s3Client = s3Client;
     }
 
     @Override
     @NonNull
     public Optional<S3Object> getObject(@NonNull String key) {
         return operations.retrieve(resolveStorageKey(key))
-            .map(entry -> new S3Object(stripBasePath(entry.getKey()), entry, size(entry.getNativeEntry()), lastModified(entry.getNativeEntry())));
+            .map(entry -> toObject(stripBasePath(entry.getKey()), entry));
     }
 
     @Override
@@ -96,32 +105,35 @@ public final class LocalStorageS3CompatibleOperations extends AbstractS3Compatib
     }
 
     @NonNull
-    private S3ObjectSummary toObjectSummary(@NonNull String storageKey) {
-        Path path = operations.retrieve(storageKey)
-            .map(LocalStorageEntry::getNativeEntry)
-            .orElse(null);
-        return new S3ObjectSummary(
-            stripBasePath(storageKey),
-            path == null ? null : size(path),
-            path == null ? null : lastModified(path)
+    private S3Object toObject(@NonNull String key, @NonNull AwsS3ObjectStorageEntry entry) {
+        return new S3Object(
+            key,
+            entry,
+            entry.getNativeEntry().contentLength(),
+            entry.getNativeEntry().lastModified()
         );
     }
 
-    @Nullable
-    private static Long size(@NonNull Path path) {
+    @NonNull
+    private S3ObjectSummary toObjectSummary(@NonNull String storageKey) {
+        HeadObjectResponse response = headObject(storageKey);
+        return new S3ObjectSummary(
+            stripBasePath(storageKey),
+            response.contentLength(),
+            response.lastModified()
+        );
+    }
+
+    @NonNull
+    private HeadObjectResponse headObject(@NonNull String storageKey) {
         try {
-            return Files.size(path);
-        } catch (IOException e) {
-            throw new ObjectStorageException("Error reading local object size: " + path, e);
+            return s3Client.headObject(HeadObjectRequest.builder()
+                .bucket(awsConfiguration.getBucket())
+                .key(storageKey)
+                .build());
+        } catch (AwsServiceException | SdkClientException e) {
+            throw new ObjectStorageException("Error reading object metadata from Amazon S3 for key [" + storageKey + ']', e);
         }
     }
 
-    @Nullable
-    private static Instant lastModified(@NonNull Path path) {
-        try {
-            return Files.getLastModifiedTime(path).toInstant();
-        } catch (IOException e) {
-            throw new ObjectStorageException("Error reading local object timestamp: " + path, e);
-        }
-    }
 }

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/AwsS3CompatibleOperations.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/AwsS3CompatibleOperations.java
@@ -19,6 +19,7 @@ import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.aws.AwsS3Configuration;
 import io.micronaut.objectstorage.aws.AwsS3ObjectStorageEntry;
 import io.micronaut.objectstorage.aws.AwsS3Operations;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.objectstorage.request.UploadRequest;
 import io.micronaut.objectstorage.response.UploadResponse;
@@ -26,9 +27,17 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListPartsRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -104,6 +113,136 @@ public final class AwsS3CompatibleOperations extends AbstractS3CompatibleOperati
         );
     }
 
+    @Override
+    public boolean supportsMultipart() {
+        return true;
+    }
+
+    @Override
+    @NonNull
+    public S3MultipartUpload createMultipartUpload(@NonNull String key, @Nullable String contentType) {
+        CreateMultipartUploadRequest.Builder request = CreateMultipartUploadRequest.builder()
+            .bucket(awsConfiguration.getBucket())
+            .key(resolveStorageKey(key));
+        if (contentType != null && !contentType.isBlank()) {
+            request.contentType(contentType);
+        }
+        try {
+            return new S3MultipartUpload(s3Client.createMultipartUpload(request.build()).uploadId());
+        } catch (AwsServiceException e) {
+            throw s3Exception(e);
+        } catch (SdkClientException e) {
+            throw new ObjectStorageException("Error initiating multipart upload for key [" + key + ']', e);
+        }
+    }
+
+    @Override
+    @NonNull
+    public S3MultipartPart uploadPart(@NonNull String key,
+                                      @NonNull String uploadId,
+                                      int partNumber,
+                                      @NonNull InputStream inputStream,
+                                      @Nullable Long contentLength) {
+        UploadPartRequest request = UploadPartRequest.builder()
+            .bucket(awsConfiguration.getBucket())
+            .key(resolveStorageKey(key))
+            .uploadId(uploadId)
+            .partNumber(partNumber)
+            .build();
+        try {
+            UploadPartResponse response = s3Client.uploadPart(
+                request,
+                contentLength != null
+                    ? RequestBody.fromInputStream(inputStream, contentLength)
+                    : RequestBody.fromBytes(inputStream.readAllBytes())
+            );
+            return new S3MultipartPart(partNumber, response.eTag(), contentLength, null);
+        } catch (AwsServiceException e) {
+            throw s3Exception(e);
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error reading multipart request body for key [" + key + ']', e);
+        } catch (SdkClientException e) {
+            throw new ObjectStorageException("Error uploading multipart part for key [" + key + ']', e);
+        }
+    }
+
+    @Override
+    @NonNull
+    public S3MultipartListPartsResponse listParts(@NonNull String key,
+                                                  @NonNull String uploadId,
+                                                  @Nullable Integer partNumberMarker,
+                                                  int maxParts) {
+        ListPartsRequest.Builder request = ListPartsRequest.builder()
+            .bucket(awsConfiguration.getBucket())
+            .key(resolveStorageKey(key))
+            .uploadId(uploadId)
+            .maxParts(maxParts);
+        if (partNumberMarker != null) {
+            request.partNumberMarker(partNumberMarker);
+        }
+        try {
+            var response = s3Client.listParts(request.build());
+            return new S3MultipartListPartsResponse(
+                response.parts().stream()
+                    .map(part -> new S3MultipartPart(
+                        part.partNumber(),
+                        part.eTag(),
+                        part.size(),
+                        part.lastModified()
+                    ))
+                    .toList(),
+                response.isTruncated() ? response.nextPartNumberMarker() : null,
+                response.isTruncated()
+            );
+        } catch (AwsServiceException e) {
+            throw s3Exception(e);
+        } catch (SdkClientException e) {
+            throw new ObjectStorageException("Error listing multipart parts for key [" + key + ']', e);
+        }
+    }
+
+    @Override
+    @NonNull
+    public S3MultipartCompletedUpload completeMultipartUpload(@NonNull String key,
+                                                              @NonNull String uploadId,
+                                                              @NonNull List<S3CompletedPart> completedParts) {
+        List<CompletedPart> parts = completedParts.stream()
+            .map(part -> CompletedPart.builder()
+                .partNumber(part.partNumber())
+                .eTag(part.eTag())
+                .build())
+            .toList();
+        CompleteMultipartUploadRequest request = CompleteMultipartUploadRequest.builder()
+            .bucket(awsConfiguration.getBucket())
+            .key(resolveStorageKey(key))
+            .uploadId(uploadId)
+            .multipartUpload(upload -> upload.parts(parts))
+            .build();
+        try {
+            return new S3MultipartCompletedUpload(s3Client.completeMultipartUpload(request).eTag());
+        } catch (AwsServiceException e) {
+            throw s3Exception(e);
+        } catch (SdkClientException e) {
+            throw new ObjectStorageException("Error completing multipart upload for key [" + key + ']', e);
+        }
+    }
+
+    @Override
+    public void abortMultipartUpload(@NonNull String key, @NonNull String uploadId) {
+        AbortMultipartUploadRequest request = AbortMultipartUploadRequest.builder()
+            .bucket(awsConfiguration.getBucket())
+            .key(resolveStorageKey(key))
+            .uploadId(uploadId)
+            .build();
+        try {
+            s3Client.abortMultipartUpload(request);
+        } catch (AwsServiceException e) {
+            throw s3Exception(e);
+        } catch (SdkClientException e) {
+            throw new ObjectStorageException("Error aborting multipart upload for key [" + key + ']', e);
+        }
+    }
+
     @NonNull
     private S3Object toObject(@NonNull String key, @NonNull AwsS3ObjectStorageEntry entry) {
         return new S3Object(
@@ -134,6 +273,17 @@ public final class AwsS3CompatibleOperations extends AbstractS3CompatibleOperati
         } catch (AwsServiceException | SdkClientException e) {
             throw new ObjectStorageException("Error reading object metadata from Amazon S3 for key [" + storageKey + ']', e);
         }
+    }
+
+    @NonNull
+    private static S3CompatibilityException s3Exception(@NonNull AwsServiceException e) {
+        String code = e.awsErrorDetails() != null && e.awsErrorDetails().errorCode() != null
+            ? e.awsErrorDetails().errorCode()
+            : "InternalError";
+        String message = e.awsErrorDetails() != null && e.awsErrorDetails().errorMessage() != null
+            ? e.awsErrorDetails().errorMessage()
+            : e.getMessage();
+        return new S3CompatibilityException(HttpStatus.valueOf(e.statusCode()), code, message);
     }
 
 }

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/LocalStorageS3CompatibleOperations.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/LocalStorageS3CompatibleOperations.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.objectstorage.ObjectStorageException;
+import io.micronaut.objectstorage.local.LocalStorageEntry;
+import io.micronaut.objectstorage.local.LocalStorageOperations;
+import io.micronaut.objectstorage.request.ListObjectsRequest;
+import io.micronaut.objectstorage.request.UploadRequest;
+import io.micronaut.objectstorage.response.UploadResponse;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Local storage bridge for the S3-compatible transport layer.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@EachBean(S3CompatibilityConfiguration.class)
+public class LocalStorageS3CompatibleOperations implements S3CompatibleOperations {
+
+    private final S3CompatibilityConfiguration configuration;
+    private final LocalStorageOperations operations;
+
+    public LocalStorageS3CompatibleOperations(@Parameter S3CompatibilityConfiguration configuration,
+                                              BeanContext beanContext) {
+        this.configuration = configuration;
+        this.operations = beanContext.getBean(LocalStorageOperations.class, Qualifiers.byName(configuration.getStorage()));
+    }
+
+    @Override
+    @NonNull
+    public Optional<S3Object> getObject(@NonNull String key) {
+        return operations.retrieve(resolveStorageKey(key))
+            .map(entry -> new S3Object(stripBasePath(entry.getKey()), entry, size(entry.getNativeEntry()), lastModified(entry.getNativeEntry())));
+    }
+
+    @Override
+    @NonNull
+    public UploadResponse<?> putObject(@NonNull String key,
+                                       @NonNull InputStream inputStream,
+                                       @Nullable Long contentLength,
+                                       @Nullable String contentType) {
+        try {
+            UploadRequest request = UploadRequest.fromBytes(inputStream.readAllBytes(), resolveStorageKey(key));
+            if (contentType != null && !contentType.isBlank()) {
+                request.setContentType(contentType);
+            }
+            return operations.upload(request);
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error reading request body for S3-compatible upload", e);
+        }
+    }
+
+    @Override
+    public void deleteObject(@NonNull String key) {
+        operations.delete(resolveStorageKey(key));
+    }
+
+    @Override
+    @NonNull
+    public S3ListResponse listObjects(@NonNull ListObjectsRequest request) {
+        ListObjectsRequest storageRequest = new ListObjectsRequest(
+            request.getPageSize(),
+            resolveListPrefix(request.getPrefix().orElse(null)),
+            request.getContinuationToken().map(this::resolveStorageKey).orElse(null)
+        );
+        io.micronaut.objectstorage.response.ListObjectsResponse response = operations.listObjects(storageRequest);
+        List<S3ObjectSummary> objects = response.getKeys().stream()
+            .map(this::toObjectSummary)
+            .toList();
+        return new S3ListResponse(
+            objects,
+            response.getContinuationToken().map(this::stripBasePath).orElse(null)
+        );
+    }
+
+    @NonNull
+    private S3ObjectSummary toObjectSummary(@NonNull String storageKey) {
+        Path path = operations.retrieve(storageKey)
+            .map(LocalStorageEntry::getNativeEntry)
+            .orElse(null);
+        return new S3ObjectSummary(
+            stripBasePath(storageKey),
+            path == null ? null : size(path),
+            path == null ? null : lastModified(path)
+        );
+    }
+
+    @NonNull
+    private String resolveStorageKey(@NonNull String key) {
+        String normalizedKey = normalizeKey(key);
+        return configuration.getBasePath()
+            .map(basePath -> basePath + normalizedKey)
+            .orElse(normalizedKey);
+    }
+
+    @Nullable
+    private String resolveListPrefix(@Nullable String prefix) {
+        String normalizedPrefix = prefix == null ? null : normalizeKey(prefix);
+        if (normalizedPrefix == null || normalizedPrefix.isEmpty()) {
+            return configuration.getBasePath().orElse(null);
+        }
+        return configuration.getBasePath()
+            .map(basePath -> basePath + normalizedPrefix)
+            .orElse(normalizedPrefix);
+    }
+
+    @NonNull
+    private String stripBasePath(@NonNull String key) {
+        return configuration.getBasePath()
+            .filter(key::startsWith)
+            .map(basePath -> key.substring(basePath.length()))
+            .orElse(key);
+    }
+
+    @NonNull
+    private static String normalizeKey(@NonNull String key) {
+        String normalized = key;
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        return normalized;
+    }
+
+    @Nullable
+    private static Long size(@NonNull Path path) {
+        try {
+            return Files.size(path);
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error reading local object size: " + path, e);
+        }
+    }
+
+    @Nullable
+    private static Instant lastModified(@NonNull Path path) {
+        try {
+            return Files.getLastModifiedTime(path).toInstant();
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error reading local object timestamp: " + path, e);
+        }
+    }
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/LocalStorageS3CompatibleOperations.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/LocalStorageS3CompatibleOperations.java
@@ -19,7 +19,6 @@ import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.local.LocalStorageEntry;
 import io.micronaut.objectstorage.local.LocalStorageOperations;
 import io.micronaut.objectstorage.request.ListObjectsRequest;
-import io.micronaut.objectstorage.request.UploadRequest;
 import io.micronaut.objectstorage.response.UploadResponse;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -61,15 +60,12 @@ public final class LocalStorageS3CompatibleOperations extends AbstractS3Compatib
                                        @NonNull InputStream inputStream,
                                        @Nullable Long contentLength,
                                        @Nullable String contentType) {
-        try {
-            UploadRequest request = UploadRequest.fromBytes(inputStream.readAllBytes(), resolveStorageKey(key));
-            if (contentType != null && !contentType.isBlank()) {
-                request.setContentType(contentType);
-            }
-            return operations.upload(request);
-        } catch (IOException e) {
-            throw new ObjectStorageException("Error reading request body for S3-compatible upload", e);
-        }
+        return operations.upload(new S3CompatibilityUploadRequest(
+            inputStream,
+            resolveStorageKey(key),
+            contentLength,
+            contentType
+        ));
     }
 
     @Override

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/ResolvedS3Bucket.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/ResolvedS3Bucket.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Resolved S3-compatible bucket mapping.
+ *
+ * @param bucket the exposed bucket name
+ * @param configuration the bucket configuration
+ * @param operations the backend bridge
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Internal
+public record ResolvedS3Bucket(
+    @NonNull String bucket,
+    @NonNull S3CompatibilityConfiguration configuration,
+    @NonNull S3CompatibleOperations operations
+) {
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityAuthMode.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityAuthMode.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+/**
+ * Request authentication modes supported by the S3-compatible HTTP surface.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+public enum S3CompatibilityAuthMode {
+    /**
+     * Development-only mode without request authentication.
+     */
+    NONE,
+    /**
+     * Validates AWS Signature Version 4 request headers.
+     */
+    SIGV4
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityBucketResolver.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityBucketResolver.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import jakarta.inject.Singleton;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Optional;
+
+/**
+ * Resolves exposed S3-compatible bucket names to configured backend bridges.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Singleton
+@Internal
+public class S3CompatibilityBucketResolver {
+
+    private final BeanContext beanContext;
+
+    public S3CompatibilityBucketResolver(BeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
+    /**
+     * @param bucket the exposed bucket name
+     * @return the resolved bucket mapping if available
+     */
+    @NonNull
+    public Optional<ResolvedS3Bucket> resolve(@NonNull String bucket) {
+        if (!beanContext.containsBean(S3CompatibilityConfiguration.class, Qualifiers.byName(bucket))
+            || !beanContext.containsBean(S3CompatibleOperations.class, Qualifiers.byName(bucket))) {
+            return Optional.empty();
+        }
+        return Optional.of(
+            new ResolvedS3Bucket(
+                bucket,
+                beanContext.getBean(S3CompatibilityConfiguration.class, Qualifiers.byName(bucket)),
+                beanContext.getBean(S3CompatibleOperations.class, Qualifiers.byName(bucket))
+            )
+        );
+    }
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityConfiguration.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityConfiguration.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.objectstorage.configuration.AbstractObjectStorageConfiguration;
+import io.micronaut.objectstorage.configuration.EachPropertyContainsEntriesCondition;
+import io.micronaut.objectstorage.configuration.ObjectStorageConfiguration;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Optional;
+
+/**
+ * Configuration for one exposed S3-compatible bucket.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@EachProperty(S3CompatibilityConfiguration.PREFIX)
+@Requires(condition = EachPropertyContainsEntriesCondition.class)
+@Introspected
+public class S3CompatibilityConfiguration extends AbstractObjectStorageConfiguration {
+
+    /**
+     * Configuration prefix ending.
+     */
+    public static final String NAME = "s3-compat";
+
+    /**
+     * Configuration prefix.
+     */
+    public static final String PREFIX = ObjectStorageConfiguration.PREFIX + '.' + NAME;
+
+    @NonNull
+    private String storage;
+
+    @Nullable
+    private String basePath;
+
+    public S3CompatibilityConfiguration(@Parameter String name) {
+        super(name);
+    }
+
+    /**
+     * @return The name of the backing object-storage bean.
+     */
+    @NonNull
+    public String getStorage() {
+        return storage;
+    }
+
+    /**
+     * @param storage The backing object-storage bean name.
+     */
+    public void setStorage(@NonNull String storage) {
+        this.storage = storage;
+    }
+
+    /**
+     * @return The optional internal prefix used for exposed keys.
+     */
+    @NonNull
+    public Optional<String> getBasePath() {
+        return Optional.ofNullable(basePath);
+    }
+
+    /**
+     * @param basePath The internal prefix used for exposed keys.
+     */
+    public void setBasePath(@Nullable String basePath) {
+        this.basePath = normalizeBasePath(basePath);
+    }
+
+    /**
+     * Whether to enable or disable this S3-compatible bucket.
+     */
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Nullable
+    private static String normalizeBasePath(@Nullable String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String normalized = value;
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized.isEmpty() ? null : normalized + '/';
+    }
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityConfiguration.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityConfiguration.java
@@ -52,6 +52,9 @@ public class S3CompatibilityConfiguration extends AbstractObjectStorageConfigura
     private String storage;
 
     @Nullable
+    private S3CompatibilityStorageProvider storageProvider;
+
+    @Nullable
     private String basePath;
 
     public S3CompatibilityConfiguration(@Parameter String name) {
@@ -71,6 +74,21 @@ public class S3CompatibilityConfiguration extends AbstractObjectStorageConfigura
      */
     public void setStorage(@NonNull String storage) {
         this.storage = storage;
+    }
+
+    /**
+     * @return The optional backing provider hint used when multiple providers share the same storage bean name.
+     */
+    @NonNull
+    public Optional<S3CompatibilityStorageProvider> getStorageProvider() {
+        return Optional.ofNullable(storageProvider);
+    }
+
+    /**
+     * @param storageProvider The optional backing provider hint.
+     */
+    public void setStorageProvider(@Nullable S3CompatibilityStorageProvider storageProvider) {
+        this.storageProvider = storageProvider;
     }
 
     /**

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityController.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityController.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Head;
+import io.micronaut.http.annotation.PathVariable;
+import io.micronaut.http.annotation.Put;
+import io.micronaut.http.annotation.QueryValue;
+import io.micronaut.objectstorage.request.ListObjectsRequest;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Minimal path-style S3-compatible controller backed by configured object-storage beans.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Controller
+public final class S3CompatibilityController {
+
+    private static final DateTimeFormatter RFC_1123 = DateTimeFormatter.RFC_1123_DATE_TIME;
+
+    private final S3CompatibilityBucketResolver bucketResolver;
+
+    public S3CompatibilityController(S3CompatibilityBucketResolver bucketResolver) {
+        this.bucketResolver = bucketResolver;
+    }
+
+    @Put(uri = "/{bucket}/{+key}")
+    public HttpResponse<?> putObject(@PathVariable String bucket,
+                                     @PathVariable String key,
+                                     HttpRequest<?> request,
+                                     @Body byte[] body) {
+        var resolved = bucketResolver.resolve(bucket);
+        if (resolved.isEmpty()) {
+            return HttpResponse.notFound();
+        }
+        Long contentLength = request.getHeaders().contentLength().isPresent()
+            ? request.getHeaders().contentLength().getAsLong()
+            : null;
+        var response = resolved.get().operations().putObject(
+            key,
+            new java.io.ByteArrayInputStream(body),
+            contentLength,
+            request.getContentType().map(MediaType::toString).orElse(null)
+        );
+        return HttpResponse.ok().header(HttpHeaders.ETAG, response.getETag());
+    }
+
+    @Get(uri = "/{bucket}/{+key}")
+    public HttpResponse<?> getObject(@PathVariable String bucket,
+                                     @PathVariable String key) {
+        return bucketResolver.resolve(bucket)
+            .flatMap(resolved -> resolved.operations().getObject(key).map(this::ok))
+            .orElseGet(HttpResponse::notFound);
+    }
+
+    @Head(uri = "/{bucket}/{+key}")
+    public HttpResponse<?> headObject(@PathVariable String bucket,
+                                      @PathVariable String key) {
+        return bucketResolver.resolve(bucket)
+            .flatMap(resolved -> resolved.operations().getObject(key).map(this::head))
+            .orElseGet(HttpResponse::notFound);
+    }
+
+    @Delete(uri = "/{bucket}/{+key}")
+    public HttpResponse<?> deleteObject(@PathVariable String bucket,
+                                        @PathVariable String key) {
+        return bucketResolver.resolve(bucket)
+            .map(resolved -> {
+                resolved.operations().deleteObject(key);
+                return HttpResponse.noContent();
+            })
+            .orElseGet(HttpResponse::notFound);
+    }
+
+    @Get(uri = "/{bucket}", produces = MediaType.APPLICATION_XML)
+    public HttpResponse<String> listObjectsV2(@PathVariable String bucket,
+                                              @QueryValue("list-type") int listType,
+                                              @Nullable @QueryValue String prefix,
+                                              @Nullable @QueryValue("continuation-token") String continuationToken,
+                                              @QueryValue(value = "max-keys", defaultValue = "1000") int maxKeys) {
+        if (listType != 2) {
+            return HttpResponse.notFound();
+        }
+        return bucketResolver.resolve(bucket)
+            .map(resolved -> {
+                S3ListResponse response = resolved.operations()
+                    .listObjects(new ListObjectsRequest(maxKeys, prefix, continuationToken));
+                return HttpResponse.ok(renderListObjectsV2(bucket, prefix, maxKeys, continuationToken, response))
+                    .contentType(MediaType.APPLICATION_XML_TYPE);
+            })
+            .orElseGet(HttpResponse::notFound);
+    }
+
+    private MutableHttpResponse<?> ok(S3Object object) {
+        MutableHttpResponse<?> response = HttpResponse.ok(object.entry().toStreamedFile());
+        return applyObjectHeaders(response, object);
+    }
+
+    private MutableHttpResponse<?> head(S3Object object) {
+        return applyObjectHeaders(HttpResponse.ok(), object);
+    }
+
+    private MutableHttpResponse<?> applyObjectHeaders(MutableHttpResponse<?> response, S3Object object) {
+        object.entry().getContentType().ifPresent(contentType -> response.header(HttpHeaders.CONTENT_TYPE, contentType));
+        object.getSize().ifPresent(size -> response.header(HttpHeaders.CONTENT_LENGTH, Long.toString(size)));
+        object.getLastModified().ifPresent(lastModified -> response.header(HttpHeaders.LAST_MODIFIED, RFC_1123.format(lastModified.atOffset(ZoneOffset.UTC))));
+        return response;
+    }
+
+    private String renderListObjectsV2(String bucket,
+                                       @Nullable String prefix,
+                                       int maxKeys,
+                                       @Nullable String continuationToken,
+                                       S3ListResponse response) {
+        StringBuilder xml = new StringBuilder(256);
+        xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        xml.append("<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">");
+        xml.append("<Name>").append(escapeXml(bucket)).append("</Name>");
+        xml.append("<Prefix>").append(escapeXml(prefix == null ? "" : prefix)).append("</Prefix>");
+        xml.append("<MaxKeys>").append(maxKeys).append("</MaxKeys>");
+        xml.append("<KeyCount>").append(response.objects().size()).append("</KeyCount>");
+        xml.append("<IsTruncated>").append(response.getContinuationToken().isPresent()).append("</IsTruncated>");
+        if (continuationToken != null && !continuationToken.isEmpty()) {
+            xml.append("<ContinuationToken>").append(escapeXml(continuationToken)).append("</ContinuationToken>");
+        }
+        response.getContinuationToken().ifPresent(next -> xml.append("<NextContinuationToken>").append(escapeXml(next)).append("</NextContinuationToken>"));
+        for (S3ObjectSummary object : response.objects()) {
+            xml.append("<Contents>");
+            xml.append("<Key>").append(escapeXml(object.key())).append("</Key>");
+            object.getLastModified().ifPresent(lastModified -> xml.append("<LastModified>").append(lastModified).append("</LastModified>"));
+            xml.append("<Size>").append(object.getSize().orElse(0L)).append("</Size>");
+            xml.append("</Contents>");
+        }
+        xml.append("</ListBucketResult>");
+        return xml.toString();
+    }
+
+    private static String escapeXml(String value) {
+        return value
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+            .replace("'", "&apos;");
+    }
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityController.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityController.java
@@ -30,10 +30,13 @@ import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.Put;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.objectstorage.request.ListObjectsRequest;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 
 import java.io.InputStream;
 import java.time.format.DateTimeFormatter;
 import java.time.ZoneOffset;
+import java.util.Optional;
 
 /**
  * Minimal path-style S3-compatible controller backed by configured object-storage beans.
@@ -42,21 +45,29 @@ import java.time.ZoneOffset;
  * @since 3.0.0
  */
 @Controller
+@ExecuteOn(TaskExecutors.BLOCKING)
 public final class S3CompatibilityController {
 
     private static final DateTimeFormatter RFC_1123 = DateTimeFormatter.RFC_1123_DATE_TIME;
 
     private final S3CompatibilityBucketResolver bucketResolver;
+    private final S3CompatibilityRequestValidator requestValidator;
 
-    public S3CompatibilityController(S3CompatibilityBucketResolver bucketResolver) {
+    public S3CompatibilityController(S3CompatibilityBucketResolver bucketResolver,
+                                     S3CompatibilityRequestValidator requestValidator) {
         this.bucketResolver = bucketResolver;
+        this.requestValidator = requestValidator;
     }
 
-    @Put(uri = "/{bucket}/{+key}")
+    @Put(uri = "/{bucket}/{+key}", consumes = MediaType.ALL)
     public HttpResponse<?> putObject(@PathVariable String bucket,
                                      @PathVariable String key,
                                      HttpRequest<?> request,
                                      @Body InputStream body) {
+        Optional<HttpResponse<String>> validation = requestValidator.validate(request);
+        if (validation.isPresent()) {
+            return validation.get();
+        }
         var resolved = bucketResolver.resolve(bucket);
         if (resolved.isEmpty()) {
             return noSuchBucket(bucket);
@@ -73,9 +84,14 @@ public final class S3CompatibilityController {
         return HttpResponse.ok().header(HttpHeaders.ETAG, response.getETag());
     }
 
-    @Get(uri = "/{bucket}/{+key}")
+    @Get(uri = "/{bucket}/{+key}", headRoute = false)
     public HttpResponse<?> getObject(@PathVariable String bucket,
-                                     @PathVariable String key) {
+                                     @PathVariable String key,
+                                     HttpRequest<?> request) {
+        Optional<HttpResponse<String>> validation = requestValidator.validate(request);
+        if (validation.isPresent()) {
+            return validation.get();
+        }
         var resolved = bucketResolver.resolve(bucket);
         if (resolved.isEmpty()) {
             return noSuchBucket(bucket);
@@ -87,7 +103,12 @@ public final class S3CompatibilityController {
 
     @Head(uri = "/{bucket}/{+key}")
     public HttpResponse<?> headObject(@PathVariable String bucket,
-                                      @PathVariable String key) {
+                                      @PathVariable String key,
+                                      HttpRequest<?> request) {
+        Optional<HttpResponse<String>> validation = requestValidator.validate(request);
+        if (validation.isPresent()) {
+            return validation.get();
+        }
         var resolved = bucketResolver.resolve(bucket);
         if (resolved.isEmpty()) {
             return noSuchBucket(bucket);
@@ -99,7 +120,12 @@ public final class S3CompatibilityController {
 
     @Delete(uri = "/{bucket}/{+key}")
     public HttpResponse<?> deleteObject(@PathVariable String bucket,
-                                        @PathVariable String key) {
+                                        @PathVariable String key,
+                                        HttpRequest<?> request) {
+        Optional<HttpResponse<String>> validation = requestValidator.validate(request);
+        if (validation.isPresent()) {
+            return validation.get();
+        }
         var resolved = bucketResolver.resolve(bucket);
         if (resolved.isEmpty()) {
             return noSuchBucket(bucket);
@@ -108,12 +134,17 @@ public final class S3CompatibilityController {
         return HttpResponse.noContent();
     }
 
-    @Get(uri = "/{bucket}", produces = MediaType.APPLICATION_XML)
+    @Get(uri = "/{bucket}", produces = MediaType.APPLICATION_XML, headRoute = false)
     public HttpResponse<String> listObjectsV2(@PathVariable String bucket,
                                               @QueryValue("list-type") int listType,
                                               @Nullable @QueryValue String prefix,
                                               @Nullable @QueryValue("continuation-token") String continuationToken,
-                                              @QueryValue(value = "max-keys", defaultValue = "1000") int maxKeys) {
+                                              @QueryValue(value = "max-keys", defaultValue = "1000") int maxKeys,
+                                              HttpRequest<?> request) {
+        Optional<HttpResponse<String>> validation = requestValidator.validate(request);
+        if (validation.isPresent()) {
+            return validation.get();
+        }
         if (listType != 2) {
             return error(
                 io.micronaut.http.HttpStatus.BAD_REQUEST,

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityController.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityController.java
@@ -19,12 +19,14 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Delete;
 import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Head;
 import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.Put;
@@ -34,9 +36,15 @@ import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 
 import java.io.InputStream;
+import java.io.StringReader;
 import java.time.format.DateTimeFormatter;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.xml.sax.InputSource;
 
 /**
  * Minimal path-style S3-compatible controller backed by configured object-storage beans.
@@ -62,6 +70,8 @@ public final class S3CompatibilityController {
     @Put(uri = "/{bucket}/{+key}", consumes = MediaType.ALL)
     public HttpResponse<?> putObject(@PathVariable String bucket,
                                      @PathVariable String key,
+                                     @Nullable @QueryValue Integer partNumber,
+                                     @Nullable @QueryValue String uploadId,
                                      HttpRequest<?> request,
                                      @Body InputStream body) {
         Optional<HttpResponse<String>> validation = requestValidator.validate(request);
@@ -71,6 +81,23 @@ public final class S3CompatibilityController {
         var resolved = bucketResolver.resolve(bucket);
         if (resolved.isEmpty()) {
             return noSuchBucket(bucket);
+        }
+        if (uploadId != null || partNumber != null) {
+            if (uploadId == null || partNumber == null) {
+                return error(HttpStatus.BAD_REQUEST, "InvalidRequest", "Multipart uploads require both uploadId and partNumber", bucket, key);
+            }
+            if (!resolved.get().operations().supportsMultipart()) {
+                return multipartNotImplemented(bucket, key);
+            }
+            Long contentLength = request.getHeaders().contentLength().isPresent()
+                ? request.getHeaders().contentLength().getAsLong()
+                : null;
+            try {
+                S3MultipartPart part = resolved.get().operations().uploadPart(key, uploadId, partNumber, body, contentLength);
+                return HttpResponse.ok().header(HttpHeaders.ETAG, part.eTag());
+            } catch (S3CompatibilityException e) {
+                return error(e.getStatus(), e.getCode(), e.getMessage(), bucket, key);
+            }
         }
         Long contentLength = request.getHeaders().contentLength().isPresent()
             ? request.getHeaders().contentLength().getAsLong()
@@ -87,6 +114,9 @@ public final class S3CompatibilityController {
     @Get(uri = "/{bucket}/{+key}", headRoute = false)
     public HttpResponse<?> getObject(@PathVariable String bucket,
                                      @PathVariable String key,
+                                     @Nullable @QueryValue("uploadId") String uploadId,
+                                     @Nullable @QueryValue("part-number-marker") Integer partNumberMarker,
+                                     @QueryValue(value = "max-parts", defaultValue = "1000") int maxParts,
                                      HttpRequest<?> request) {
         Optional<HttpResponse<String>> validation = requestValidator.validate(request);
         if (validation.isPresent()) {
@@ -95,6 +125,18 @@ public final class S3CompatibilityController {
         var resolved = bucketResolver.resolve(bucket);
         if (resolved.isEmpty()) {
             return noSuchBucket(bucket);
+        }
+        if (uploadId != null) {
+            if (!resolved.get().operations().supportsMultipart()) {
+                return multipartNotImplemented(bucket, key);
+            }
+            try {
+                S3MultipartListPartsResponse response = resolved.get().operations().listParts(key, uploadId, partNumberMarker, maxParts);
+                return HttpResponse.ok(renderListParts(bucket, key, uploadId, partNumberMarker, maxParts, response))
+                    .contentType(MediaType.APPLICATION_XML_TYPE);
+            } catch (S3CompatibilityException e) {
+                return error(e.getStatus(), e.getCode(), e.getMessage(), bucket, key);
+            }
         }
         return resolved.get().operations().getObject(key)
             .<HttpResponse<?>>map(this::ok)
@@ -121,6 +163,7 @@ public final class S3CompatibilityController {
     @Delete(uri = "/{bucket}/{+key}")
     public HttpResponse<?> deleteObject(@PathVariable String bucket,
                                         @PathVariable String key,
+                                        @Nullable @QueryValue String uploadId,
                                         HttpRequest<?> request) {
         Optional<HttpResponse<String>> validation = requestValidator.validate(request);
         if (validation.isPresent()) {
@@ -130,8 +173,61 @@ public final class S3CompatibilityController {
         if (resolved.isEmpty()) {
             return noSuchBucket(bucket);
         }
+        if (uploadId != null) {
+            if (!resolved.get().operations().supportsMultipart()) {
+                return multipartNotImplemented(bucket, key);
+            }
+            try {
+                resolved.get().operations().abortMultipartUpload(key, uploadId);
+                return HttpResponse.noContent();
+            } catch (S3CompatibilityException e) {
+                return error(e.getStatus(), e.getCode(), e.getMessage(), bucket, key);
+            }
+        }
         resolved.get().operations().deleteObject(key);
         return HttpResponse.noContent();
+    }
+
+    @Post(uri = "/{bucket}/{+key}", consumes = MediaType.ALL, produces = MediaType.APPLICATION_XML)
+    public HttpResponse<String> postObject(@PathVariable String bucket,
+                                           @PathVariable String key,
+                                           @Nullable @QueryValue String uploadId,
+                                           HttpRequest<?> request,
+                                           @Nullable @Body String body) {
+        Optional<HttpResponse<String>> validation = requestValidator.validate(request);
+        if (validation.isPresent()) {
+            return validation.get();
+        }
+        var resolved = bucketResolver.resolve(bucket);
+        if (resolved.isEmpty()) {
+            return noSuchBucket(bucket);
+        }
+        boolean initiateMultipart = hasQueryParameter(request, "uploads");
+        if (!initiateMultipart && uploadId == null) {
+            return error(HttpStatus.BAD_REQUEST, "InvalidRequest", "Unsupported POST request for this S3-compatible endpoint", bucket, key);
+        }
+        if (!resolved.get().operations().supportsMultipart()) {
+            return multipartNotImplemented(bucket, key);
+        }
+        try {
+            if (initiateMultipart) {
+                S3MultipartUpload response = resolved.get().operations()
+                    .createMultipartUpload(key, request.getContentType().map(MediaType::toString).orElse(null));
+                return HttpResponse.ok(renderCreateMultipartUpload(bucket, key, response))
+                    .contentType(MediaType.APPLICATION_XML_TYPE);
+            }
+            List<S3CompletedPart> completedParts = parseCompletedParts(body);
+            if (completedParts.isEmpty()) {
+                return error(HttpStatus.BAD_REQUEST, "MalformedXML", "The CompleteMultipartUpload request body must contain at least one part", bucket, key);
+            }
+            S3MultipartCompletedUpload response = resolved.get().operations().completeMultipartUpload(key, uploadId, completedParts);
+            return HttpResponse.ok(renderCompleteMultipartUpload(bucket, key, response))
+                .contentType(MediaType.APPLICATION_XML_TYPE);
+        } catch (S3CompatibilityException e) {
+            return error(e.getStatus(), e.getCode(), e.getMessage(), bucket, key);
+        } catch (IllegalArgumentException e) {
+            return error(HttpStatus.BAD_REQUEST, "MalformedXML", e.getMessage(), bucket, key);
+        }
     }
 
     @Get(uri = "/{bucket}", produces = MediaType.APPLICATION_XML, headRoute = false)
@@ -212,6 +308,127 @@ public final class S3CompatibilityController {
         return xml.toString();
     }
 
+    private String renderCreateMultipartUpload(String bucket, String key, S3MultipartUpload response) {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<InitiateMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
+            + "<Bucket>" + escapeXml(bucket) + "</Bucket>"
+            + "<Key>" + escapeXml(key) + "</Key>"
+            + "<UploadId>" + escapeXml(response.uploadId()) + "</UploadId>"
+            + "</InitiateMultipartUploadResult>";
+    }
+
+    private String renderCompleteMultipartUpload(String bucket, String key, S3MultipartCompletedUpload response) {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<CompleteMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
+            + "<Location>" + escapeXml('/' + bucket + '/' + key) + "</Location>"
+            + "<Bucket>" + escapeXml(bucket) + "</Bucket>"
+            + "<Key>" + escapeXml(key) + "</Key>"
+            + "<ETag>" + escapeXml(response.eTag()) + "</ETag>"
+            + "</CompleteMultipartUploadResult>";
+    }
+
+    private String renderListParts(String bucket,
+                                   String key,
+                                   String uploadId,
+                                   @Nullable Integer partNumberMarker,
+                                   int maxParts,
+                                   S3MultipartListPartsResponse response) {
+        StringBuilder xml = new StringBuilder(256);
+        xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        xml.append("<ListPartsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">");
+        xml.append("<Bucket>").append(escapeXml(bucket)).append("</Bucket>");
+        xml.append("<Key>").append(escapeXml(key)).append("</Key>");
+        xml.append("<UploadId>").append(escapeXml(uploadId)).append("</UploadId>");
+        xml.append("<PartNumberMarker>").append(partNumberMarker == null ? 0 : partNumberMarker).append("</PartNumberMarker>");
+        xml.append("<MaxParts>").append(maxParts).append("</MaxParts>");
+        xml.append("<IsTruncated>").append(response.truncated()).append("</IsTruncated>");
+        response.getNextPartNumberMarker()
+            .ifPresent(next -> xml.append("<NextPartNumberMarker>").append(next).append("</NextPartNumberMarker>"));
+        for (S3MultipartPart part : response.parts()) {
+            xml.append("<Part>");
+            xml.append("<PartNumber>").append(part.partNumber()).append("</PartNumber>");
+            xml.append("<ETag>").append(escapeXml(part.eTag())).append("</ETag>");
+            part.getLastModified().ifPresent(lastModified -> xml.append("<LastModified>").append(lastModified).append("</LastModified>"));
+            xml.append("<Size>").append(part.getSize().orElse(0L)).append("</Size>");
+            xml.append("</Part>");
+        }
+        xml.append("</ListPartsResult>");
+        return xml.toString();
+    }
+
+    private HttpResponse<String> multipartNotImplemented(String bucket, String key) {
+        return error(
+            HttpStatus.NOT_IMPLEMENTED,
+            "NotImplemented",
+            "Multipart uploads are only supported for S3-compatible buckets backed by AWS storage",
+            bucket,
+            key
+        );
+    }
+
+    private static boolean hasQueryParameter(HttpRequest<?> request, String name) {
+        String rawQuery = request.getUri().getRawQuery();
+        if (rawQuery == null || rawQuery.isEmpty()) {
+            return false;
+        }
+        for (String token : rawQuery.split("&")) {
+            String queryName = token;
+            int equalsAt = token.indexOf('=');
+            if (equalsAt >= 0) {
+                queryName = token.substring(0, equalsAt);
+            }
+            if (name.equals(queryName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static List<S3CompletedPart> parseCompletedParts(String body) {
+        if (body == null || body.isBlank()) {
+            return List.of();
+        }
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            factory.setNamespaceAware(true);
+            var builder = factory.newDocumentBuilder();
+            var document = builder.parse(new InputSource(new StringReader(body)));
+            var partNodes = document.getElementsByTagNameNS("*", "Part");
+            List<S3CompletedPart> parts = new ArrayList<>(partNodes.getLength());
+            for (int i = 0; i < partNodes.getLength(); i++) {
+                var element = partNodes.item(i);
+                String partNumber = childText(element, "PartNumber");
+                String eTag = childText(element, "ETag");
+                if (partNumber == null || eTag == null || partNumber.isBlank() || eTag.isBlank()) {
+                    throw new IllegalArgumentException("Each multipart completion part must include PartNumber and ETag elements");
+                }
+                parts.add(new S3CompletedPart(Integer.parseInt(partNumber.trim()), eTag.trim()));
+            }
+            return parts;
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Multipart completion PartNumber values must be integers", e);
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to parse the CompleteMultipartUpload request body", e);
+        }
+    }
+
+    @Nullable
+    private static String childText(org.w3c.dom.Node node, String localName) {
+        var children = node.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            var child = children.item(i);
+            if (localName.equals(child.getLocalName())) {
+                return child.getTextContent();
+            }
+        }
+        return null;
+    }
+
     private static String escapeXml(String value) {
         return value
             .replace("&", "&amp;")
@@ -223,7 +440,7 @@ public final class S3CompatibilityController {
 
     private HttpResponse<String> noSuchBucket(String bucket) {
         return error(
-            io.micronaut.http.HttpStatus.NOT_FOUND,
+            HttpStatus.NOT_FOUND,
             "NoSuchBucket",
             "The specified bucket does not exist",
             bucket,
@@ -233,7 +450,7 @@ public final class S3CompatibilityController {
 
     private HttpResponse<String> noSuchKey(String bucket, String key) {
         return error(
-            io.micronaut.http.HttpStatus.NOT_FOUND,
+            HttpStatus.NOT_FOUND,
             "NoSuchKey",
             "The specified key does not exist",
             bucket,
@@ -241,7 +458,7 @@ public final class S3CompatibilityController {
         );
     }
 
-    private HttpResponse<String> error(io.micronaut.http.HttpStatus status,
+    private HttpResponse<String> error(HttpStatus status,
                                        String code,
                                        String message,
                                        @Nullable String bucket,

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityController.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityController.java
@@ -31,8 +31,9 @@ import io.micronaut.http.annotation.Put;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.objectstorage.request.ListObjectsRequest;
 
-import java.time.ZoneOffset;
+import java.io.InputStream;
 import java.time.format.DateTimeFormatter;
+import java.time.ZoneOffset;
 
 /**
  * Minimal path-style S3-compatible controller backed by configured object-storage beans.
@@ -55,17 +56,17 @@ public final class S3CompatibilityController {
     public HttpResponse<?> putObject(@PathVariable String bucket,
                                      @PathVariable String key,
                                      HttpRequest<?> request,
-                                     @Body byte[] body) {
+                                     @Body InputStream body) {
         var resolved = bucketResolver.resolve(bucket);
         if (resolved.isEmpty()) {
-            return HttpResponse.notFound();
+            return noSuchBucket(bucket);
         }
         Long contentLength = request.getHeaders().contentLength().isPresent()
             ? request.getHeaders().contentLength().getAsLong()
             : null;
         var response = resolved.get().operations().putObject(
             key,
-            new java.io.ByteArrayInputStream(body),
+            body,
             contentLength,
             request.getContentType().map(MediaType::toString).orElse(null)
         );
@@ -75,28 +76,36 @@ public final class S3CompatibilityController {
     @Get(uri = "/{bucket}/{+key}")
     public HttpResponse<?> getObject(@PathVariable String bucket,
                                      @PathVariable String key) {
-        return bucketResolver.resolve(bucket)
-            .flatMap(resolved -> resolved.operations().getObject(key).map(this::ok))
-            .orElseGet(HttpResponse::notFound);
+        var resolved = bucketResolver.resolve(bucket);
+        if (resolved.isEmpty()) {
+            return noSuchBucket(bucket);
+        }
+        return resolved.get().operations().getObject(key)
+            .<HttpResponse<?>>map(this::ok)
+            .orElseGet(() -> noSuchKey(bucket, key));
     }
 
     @Head(uri = "/{bucket}/{+key}")
     public HttpResponse<?> headObject(@PathVariable String bucket,
                                       @PathVariable String key) {
-        return bucketResolver.resolve(bucket)
-            .flatMap(resolved -> resolved.operations().getObject(key).map(this::head))
-            .orElseGet(HttpResponse::notFound);
+        var resolved = bucketResolver.resolve(bucket);
+        if (resolved.isEmpty()) {
+            return noSuchBucket(bucket);
+        }
+        return resolved.get().operations().getObject(key)
+            .<HttpResponse<?>>map(this::head)
+            .orElseGet(() -> noSuchKey(bucket, key));
     }
 
     @Delete(uri = "/{bucket}/{+key}")
     public HttpResponse<?> deleteObject(@PathVariable String bucket,
                                         @PathVariable String key) {
-        return bucketResolver.resolve(bucket)
-            .map(resolved -> {
-                resolved.operations().deleteObject(key);
-                return HttpResponse.noContent();
-            })
-            .orElseGet(HttpResponse::notFound);
+        var resolved = bucketResolver.resolve(bucket);
+        if (resolved.isEmpty()) {
+            return noSuchBucket(bucket);
+        }
+        resolved.get().operations().deleteObject(key);
+        return HttpResponse.noContent();
     }
 
     @Get(uri = "/{bucket}", produces = MediaType.APPLICATION_XML)
@@ -106,16 +115,26 @@ public final class S3CompatibilityController {
                                               @Nullable @QueryValue("continuation-token") String continuationToken,
                                               @QueryValue(value = "max-keys", defaultValue = "1000") int maxKeys) {
         if (listType != 2) {
-            return HttpResponse.notFound();
+            return error(
+                io.micronaut.http.HttpStatus.BAD_REQUEST,
+                "InvalidRequest",
+                "This endpoint only supports list-type=2",
+                bucket,
+                null
+            );
         }
-        return bucketResolver.resolve(bucket)
-            .map(resolved -> {
-                S3ListResponse response = resolved.operations()
-                    .listObjects(new ListObjectsRequest(maxKeys, prefix, continuationToken));
-                return HttpResponse.ok(renderListObjectsV2(bucket, prefix, maxKeys, continuationToken, response))
-                    .contentType(MediaType.APPLICATION_XML_TYPE);
-            })
-            .orElseGet(HttpResponse::notFound);
+        var resolved = bucketResolver.resolve(bucket);
+        if (resolved.isEmpty()) {
+            return noSuchBucket(bucket);
+        }
+        try {
+            S3ListResponse response = resolved.get().operations()
+                .listObjects(new ListObjectsRequest(maxKeys, prefix, continuationToken));
+            return HttpResponse.ok(renderListObjectsV2(bucket, prefix, maxKeys, continuationToken, response))
+                .contentType(MediaType.APPLICATION_XML_TYPE);
+        } catch (IllegalArgumentException e) {
+            return error(io.micronaut.http.HttpStatus.BAD_REQUEST, "InvalidArgument", e.getMessage(), bucket, null);
+        }
     }
 
     private MutableHttpResponse<?> ok(S3Object object) {
@@ -169,5 +188,50 @@ public final class S3CompatibilityController {
             .replace(">", "&gt;")
             .replace("\"", "&quot;")
             .replace("'", "&apos;");
+    }
+
+    private HttpResponse<String> noSuchBucket(String bucket) {
+        return error(
+            io.micronaut.http.HttpStatus.NOT_FOUND,
+            "NoSuchBucket",
+            "The specified bucket does not exist",
+            bucket,
+            null
+        );
+    }
+
+    private HttpResponse<String> noSuchKey(String bucket, String key) {
+        return error(
+            io.micronaut.http.HttpStatus.NOT_FOUND,
+            "NoSuchKey",
+            "The specified key does not exist",
+            bucket,
+            key
+        );
+    }
+
+    private HttpResponse<String> error(io.micronaut.http.HttpStatus status,
+                                       String code,
+                                       String message,
+                                       @Nullable String bucket,
+                                       @Nullable String key) {
+        StringBuilder xml = new StringBuilder(192);
+        xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        xml.append("<Error>");
+        xml.append("<Code>").append(escapeXml(code)).append("</Code>");
+        xml.append("<Message>").append(escapeXml(message)).append("</Message>");
+        if (bucket != null && !bucket.isEmpty()) {
+            xml.append("<BucketName>").append(escapeXml(bucket)).append("</BucketName>");
+        }
+        if (key != null && !key.isEmpty()) {
+            xml.append("<Key>").append(escapeXml(key)).append("</Key>");
+            xml.append("<Resource>").append(escapeXml('/' + bucket + '/' + key)).append("</Resource>");
+        } else if (bucket != null && !bucket.isEmpty()) {
+            xml.append("<Resource>").append(escapeXml('/' + bucket)).append("</Resource>");
+        }
+        xml.append("</Error>");
+        return HttpResponse.status(status)
+            .contentType(MediaType.APPLICATION_XML_TYPE)
+            .body(xml.toString());
     }
 }

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityController.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityController.java
@@ -35,8 +35,14 @@ import io.micronaut.objectstorage.request.ListObjectsRequest;
 import io.micronaut.scheduling.TaskExecutors;
 import io.micronaut.scheduling.annotation.ExecuteOn;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.format.DateTimeFormatter;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -74,41 +80,47 @@ public final class S3CompatibilityController {
                                      @Nullable @QueryValue String uploadId,
                                      HttpRequest<?> request,
                                      @Body InputStream body) {
-        Optional<HttpResponse<String>> validation = requestValidator.validate(request);
-        if (validation.isPresent()) {
-            return validation.get();
-        }
-        var resolved = bucketResolver.resolve(bucket);
-        if (resolved.isEmpty()) {
-            return noSuchBucket(bucket);
-        }
-        if (uploadId != null || partNumber != null) {
-            if (uploadId == null || partNumber == null) {
-                return error(HttpStatus.BAD_REQUEST, "InvalidRequest", "Multipart uploads require both uploadId and partNumber", bucket, key);
+        try (StagedPayload payload = stagePayload(body)) {
+            Optional<HttpResponse<String>> validation = requestValidator.validate(request, payload.payloadHash());
+            if (validation.isPresent()) {
+                return validation.get();
             }
-            if (!resolved.get().operations().supportsMultipart()) {
-                return multipartNotImplemented(bucket, key);
+            var resolved = bucketResolver.resolve(bucket);
+            if (resolved.isEmpty()) {
+                return noSuchBucket(bucket);
             }
-            Long contentLength = request.getHeaders().contentLength().isPresent()
-                ? request.getHeaders().contentLength().getAsLong()
-                : null;
-            try {
-                S3MultipartPart part = resolved.get().operations().uploadPart(key, uploadId, partNumber, body, contentLength);
-                return HttpResponse.ok().header(HttpHeaders.ETAG, part.eTag());
-            } catch (S3CompatibilityException e) {
-                return error(e.getStatus(), e.getCode(), e.getMessage(), bucket, key);
+            if (uploadId != null || partNumber != null) {
+                if (uploadId == null || partNumber == null) {
+                    return error(HttpStatus.BAD_REQUEST, "InvalidRequest", "Multipart uploads require both uploadId and partNumber", bucket, key);
+                }
+                if (!resolved.get().operations().supportsMultipart()) {
+                    return multipartNotImplemented(bucket, key);
+                }
+                try (InputStream payloadStream = payload.openStream()) {
+                    S3MultipartPart part = resolved.get().operations().uploadPart(
+                        key,
+                        uploadId,
+                        partNumber,
+                        payloadStream,
+                        payload.contentLength()
+                    );
+                    return HttpResponse.ok().header(HttpHeaders.ETAG, part.eTag());
+                } catch (S3CompatibilityException e) {
+                    return error(e.getStatus(), e.getCode(), e.getMessage(), bucket, key);
+                }
             }
+            try (InputStream payloadStream = payload.openStream()) {
+                var response = resolved.get().operations().putObject(
+                    key,
+                    payloadStream,
+                    payload.contentLength(),
+                    request.getContentType().map(MediaType::toString).orElse(null)
+                );
+                return HttpResponse.ok().header(HttpHeaders.ETAG, response.getETag());
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to stage request payload for S3-compatible upload", e);
         }
-        Long contentLength = request.getHeaders().contentLength().isPresent()
-            ? request.getHeaders().contentLength().getAsLong()
-            : null;
-        var response = resolved.get().operations().putObject(
-            key,
-            body,
-            contentLength,
-            request.getContentType().map(MediaType::toString).orElse(null)
-        );
-        return HttpResponse.ok().header(HttpHeaders.ETAG, response.getETag());
     }
 
     @Get(uri = "/{bucket}/{+key}", headRoute = false)
@@ -194,7 +206,10 @@ public final class S3CompatibilityController {
                                            @Nullable @QueryValue String uploadId,
                                            HttpRequest<?> request,
                                            @Nullable @Body String body) {
-        Optional<HttpResponse<String>> validation = requestValidator.validate(request);
+        Optional<HttpResponse<String>> validation = requestValidator.validate(
+            request,
+            sha256Hex(body == null ? new byte[0] : body.getBytes(StandardCharsets.UTF_8))
+        );
         if (validation.isPresent()) {
             return validation.get();
         }
@@ -391,9 +406,14 @@ public final class S3CompatibilityController {
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
             factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
             factory.setNamespaceAware(true);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
             var builder = factory.newDocumentBuilder();
             var document = builder.parse(new InputSource(new StringReader(body)));
             var partNodes = document.getElementsByTagNameNS("*", "Part");
@@ -436,6 +456,48 @@ public final class S3CompatibilityController {
             .replace(">", "&gt;")
             .replace("\"", "&quot;")
             .replace("'", "&apos;");
+    }
+
+    private static StagedPayload stagePayload(InputStream body) throws IOException {
+        Path path = Files.createTempFile("mn-object-storage-s3compat-", ".payload");
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            long length = 0;
+            try (InputStream input = body;
+                 var output = Files.newOutputStream(path)) {
+                byte[] buffer = new byte[8192];
+                int read;
+                while ((read = input.read(buffer)) != -1) {
+                    digest.update(buffer, 0, read);
+                    output.write(buffer, 0, read);
+                    length += read;
+                }
+            }
+            return new StagedPayload(path, length, toHex(digest.digest()));
+        } catch (IOException | RuntimeException e) {
+            Files.deleteIfExists(path);
+            throw e;
+        } catch (NoSuchAlgorithmException e) {
+            Files.deleteIfExists(path);
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+
+    private static String sha256Hex(byte[] bytes) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return toHex(digest.digest(bytes));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+
+    private static String toHex(byte[] bytes) {
+        StringBuilder builder = new StringBuilder(bytes.length * 2);
+        for (byte current : bytes) {
+            builder.append(String.format("%02x", current));
+        }
+        return builder.toString();
     }
 
     private HttpResponse<String> noSuchBucket(String bucket) {
@@ -481,5 +543,16 @@ public final class S3CompatibilityController {
         return HttpResponse.status(status)
             .contentType(MediaType.APPLICATION_XML_TYPE)
             .body(xml.toString());
+    }
+
+    private record StagedPayload(Path path, long contentLength, String payloadHash) implements AutoCloseable {
+        private InputStream openStream() throws IOException {
+            return Files.newInputStream(path);
+        }
+
+        @Override
+        public void close() throws IOException {
+            Files.deleteIfExists(path);
+        }
     }
 }

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityException.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.http.HttpStatus;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Internal exception that carries an S3-compatible HTTP status and error code.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Internal
+final class S3CompatibilityException extends RuntimeException {
+
+    private final HttpStatus status;
+    private final String code;
+
+    S3CompatibilityException(@NonNull HttpStatus status, @NonNull String code, @NonNull String message) {
+        super(message);
+        this.status = status;
+        this.code = code;
+    }
+
+    @NonNull
+    HttpStatus getStatus() {
+        return status;
+    }
+
+    @NonNull
+    String getCode() {
+        return code;
+    }
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityModuleConfiguration.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityModuleConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.objectstorage.configuration.AbstractObjectStorageModuleConfiguration;
+
+/**
+ * S3-compatible module configuration.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@ConfigurationProperties(S3CompatibilityConfiguration.PREFIX)
+public class S3CompatibilityModuleConfiguration extends AbstractObjectStorageModuleConfiguration {
+
+    /**
+     * Whether to enable or disable the whole S3-compatible module.
+     */
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityModuleConfiguration.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityModuleConfiguration.java
@@ -17,6 +17,10 @@ package io.micronaut.objectstorage.s3compat;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.objectstorage.configuration.AbstractObjectStorageModuleConfiguration;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Optional;
 
 /**
  * S3-compatible module configuration.
@@ -27,11 +31,90 @@ import io.micronaut.objectstorage.configuration.AbstractObjectStorageModuleConfi
 @ConfigurationProperties(S3CompatibilityConfiguration.PREFIX)
 public class S3CompatibilityModuleConfiguration extends AbstractObjectStorageModuleConfiguration {
 
+    private S3CompatibilityAuthMode authMode = S3CompatibilityAuthMode.NONE;
+
+    @Nullable
+    private String accessKeyId;
+
+    @Nullable
+    private String secretAccessKey;
+
+    @NonNull
+    private String region = "us-east-1";
+
     /**
      * Whether to enable or disable the whole S3-compatible module.
      */
     @Override
     public boolean isEnabled() {
         return enabled;
+    }
+
+    /**
+     * @return The request authentication mode for the S3-compatible HTTP surface.
+     */
+    @NonNull
+    public S3CompatibilityAuthMode getAuthMode() {
+        return authMode;
+    }
+
+    /**
+     * @param authMode The request authentication mode.
+     */
+    public void setAuthMode(@NonNull S3CompatibilityAuthMode authMode) {
+        this.authMode = authMode;
+    }
+
+    /**
+     * @return The access key id used for SigV4 verification.
+     */
+    @NonNull
+    public Optional<String> getAccessKeyId() {
+        return Optional.ofNullable(accessKeyId);
+    }
+
+    /**
+     * @param accessKeyId The access key id used for SigV4 verification.
+     */
+    public void setAccessKeyId(@Nullable String accessKeyId) {
+        this.accessKeyId = emptyToNull(accessKeyId);
+    }
+
+    /**
+     * @return The secret access key used for SigV4 verification.
+     */
+    @NonNull
+    public Optional<String> getSecretAccessKey() {
+        return Optional.ofNullable(secretAccessKey);
+    }
+
+    /**
+     * @param secretAccessKey The secret access key used for SigV4 verification.
+     */
+    public void setSecretAccessKey(@Nullable String secretAccessKey) {
+        this.secretAccessKey = emptyToNull(secretAccessKey);
+    }
+
+    /**
+     * @return The SigV4 region expected from incoming requests.
+     */
+    @NonNull
+    public String getRegion() {
+        return region;
+    }
+
+    /**
+     * @param region The SigV4 region expected from incoming requests.
+     */
+    public void setRegion(@NonNull String region) {
+        this.region = region;
+    }
+
+    @Nullable
+    private static String emptyToNull(@Nullable String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value;
     }
 }

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityRequestValidator.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityRequestValidator.java
@@ -27,6 +27,9 @@ import jakarta.inject.Singleton;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.net.URI;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -53,6 +56,10 @@ public final class S3CompatibilityRequestValidator {
     private static final String SERVICE = "s3";
     private static final String TERMINAL = "aws4_request";
     private static final String HMAC_SHA_256 = "HmacSHA256";
+    private static final String UNSIGNED_PAYLOAD = "UNSIGNED-PAYLOAD";
+    private static final String EMPTY_PAYLOAD_SHA_256 = "e3b0c44298fc1c149afbf4c8996fb924"
+        + "27ae41e4649b934ca495991b7852b855";
+    private static final DateTimeFormatter AMZ_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssX");
 
     private final S3CompatibilityModuleConfiguration configuration;
 
@@ -65,6 +72,15 @@ public final class S3CompatibilityRequestValidator {
      * @return An error response if the request is invalid for the configured auth mode.
      */
     public Optional<HttpResponse<String>> validate(HttpRequest<?> request) {
+        return validate(request, EMPTY_PAYLOAD_SHA_256);
+    }
+
+    /**
+     * @param request Incoming HTTP request.
+     * @param actualPayloadHash The SHA-256 of the received request payload.
+     * @return An error response if the request is invalid for the configured auth mode.
+     */
+    public Optional<HttpResponse<String>> validate(HttpRequest<?> request, @Nullable String actualPayloadHash) {
         if (configuration.getAuthMode() == S3CompatibilityAuthMode.NONE) {
             return Optional.empty();
         }
@@ -76,10 +92,13 @@ public final class S3CompatibilityRequestValidator {
                 null
             ));
         }
-        return validateSigV4(request, configuration.getAccessKeyId().get(), configuration.getSecretAccessKey().get());
+        return validateSigV4(request, configuration.getAccessKeyId().get(), configuration.getSecretAccessKey().get(), actualPayloadHash);
     }
 
-    private Optional<HttpResponse<String>> validateSigV4(HttpRequest<?> request, String accessKeyId, String secretAccessKey) {
+    private Optional<HttpResponse<String>> validateSigV4(HttpRequest<?> request,
+                                                         String accessKeyId,
+                                                         String secretAccessKey,
+                                                         @Nullable String actualPayloadHash) {
         String authorization = request.getHeaders().get(HttpHeaders.AUTHORIZATION);
         if (authorization == null || authorization.isBlank()) {
             return Optional.of(error(HttpStatus.FORBIDDEN, "AccessDenied", "Missing Authorization header", request));
@@ -90,6 +109,9 @@ public final class S3CompatibilityRequestValidator {
         String signedAt = request.getHeaders().get("x-amz-date");
         if (signedAt == null || signedAt.isBlank()) {
             return Optional.of(error(HttpStatus.FORBIDDEN, "AccessDenied", "Missing x-amz-date header", request));
+        }
+        if (!isValidAmzDate(signedAt)) {
+            return Optional.of(error(HttpStatus.FORBIDDEN, "AccessDenied", "Malformed x-amz-date header", request));
         }
         String payloadHash = request.getHeaders().get("x-amz-content-sha256");
         if (payloadHash == null || payloadHash.isBlank()) {
@@ -118,16 +140,31 @@ public final class S3CompatibilityRequestValidator {
             return Optional.of(error(HttpStatus.FORBIDDEN, "AuthorizationHeaderMalformed", "Credential scope does not match the configured S3-compatible service", request));
         }
 
-        String canonicalRequest = request.getMethodName() + '\n'
-            + canonicalUri(request.getUri()) + '\n'
-            + canonicalQueryString(request.getUri()) + '\n'
-            + canonicalHeaders(request, signedHeaders) + '\n'
-            + signedHeaders + '\n'
-            + payloadHash;
-        String stringToSign = ALGORITHM + '\n'
-            + signedAt + '\n'
-            + credentialScope[1] + '/' + credentialScope[2] + '/' + credentialScope[3] + '/' + credentialScope[4] + '\n'
-            + sha256Hex(canonicalRequest);
+        if (!UNSIGNED_PAYLOAD.equals(payloadHash)
+            && actualPayloadHash != null
+            && !MessageDigest.isEqual(
+            actualPayloadHash.getBytes(StandardCharsets.US_ASCII),
+            payloadHash.getBytes(StandardCharsets.US_ASCII)
+        )) {
+            return Optional.of(error(HttpStatus.FORBIDDEN, "SignatureDoesNotMatch", "The provided x-amz-content-sha256 does not match the received payload", request));
+        }
+
+        String canonicalRequest;
+        String stringToSign;
+        try {
+            canonicalRequest = request.getMethodName() + '\n'
+                + canonicalUri(request.getUri()) + '\n'
+                + canonicalQueryString(request.getUri()) + '\n'
+                + canonicalHeaders(request, signedHeaders) + '\n'
+                + signedHeaders + '\n'
+                + payloadHash;
+            stringToSign = ALGORITHM + '\n'
+                + signedAt + '\n'
+                + credentialScope[1] + '/' + credentialScope[2] + '/' + credentialScope[3] + '/' + credentialScope[4] + '\n'
+                + sha256Hex(canonicalRequest);
+        } catch (IllegalArgumentException e) {
+            return Optional.of(error(HttpStatus.BAD_REQUEST, "InvalidRequest", e.getMessage(), request));
+        }
         String expectedSignature = toHex(
             hmacSha256(
                 signingKey(secretAccessKey, credentialScope[1], credentialScope[2], credentialScope[3]),
@@ -138,6 +175,15 @@ public final class S3CompatibilityRequestValidator {
             return Optional.of(error(HttpStatus.FORBIDDEN, "SignatureDoesNotMatch", "The request signature we calculated does not match the signature you provided", request));
         }
         return Optional.empty();
+    }
+
+    private static boolean isValidAmzDate(String signedAt) {
+        try {
+            Instant.from(AMZ_DATE_FORMATTER.parse(signedAt));
+            return true;
+        } catch (DateTimeParseException e) {
+            return false;
+        }
     }
 
     private static Map<String, String> parseAuthorizationAttributes(String authorization) {
@@ -242,7 +288,11 @@ public final class S3CompatibilityRequestValidator {
         for (int i = 0; i < value.length(); i++) {
             char current = value.charAt(i);
             if (current == '%' && i + 2 < value.length()) {
-                bytes[length++] = (byte) Integer.parseInt(value.substring(i + 1, i + 3), 16);
+                try {
+                    bytes[length++] = (byte) Integer.parseInt(value.substring(i + 1, i + 3), 16);
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Malformed query parameter encoding", e);
+                }
                 i += 2;
             } else {
                 bytes[length++] = (byte) current;

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityRequestValidator.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityRequestValidator.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import jakarta.inject.Singleton;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Validates incoming requests for the S3-compatible HTTP surface.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Singleton
+@Internal
+public final class S3CompatibilityRequestValidator {
+
+    private static final String ALGORITHM = "AWS4-HMAC-SHA256";
+    private static final String SERVICE = "s3";
+    private static final String TERMINAL = "aws4_request";
+    private static final String HMAC_SHA_256 = "HmacSHA256";
+
+    private final S3CompatibilityModuleConfiguration configuration;
+
+    public S3CompatibilityRequestValidator(S3CompatibilityModuleConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    /**
+     * @param request Incoming HTTP request.
+     * @return An error response if the request is invalid for the configured auth mode.
+     */
+    public Optional<HttpResponse<String>> validate(HttpRequest<?> request) {
+        if (configuration.getAuthMode() == S3CompatibilityAuthMode.NONE) {
+            return Optional.empty();
+        }
+        if (configuration.getAccessKeyId().isEmpty() || configuration.getSecretAccessKey().isEmpty()) {
+            return Optional.of(error(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "InternalError",
+                "SigV4 is enabled but access credentials are not configured",
+                null
+            ));
+        }
+        return validateSigV4(request, configuration.getAccessKeyId().get(), configuration.getSecretAccessKey().get());
+    }
+
+    private Optional<HttpResponse<String>> validateSigV4(HttpRequest<?> request, String accessKeyId, String secretAccessKey) {
+        String authorization = request.getHeaders().get(HttpHeaders.AUTHORIZATION);
+        if (authorization == null || authorization.isBlank()) {
+            return Optional.of(error(HttpStatus.FORBIDDEN, "AccessDenied", "Missing Authorization header", request));
+        }
+        if (!authorization.startsWith(ALGORITHM + " ")) {
+            return Optional.of(error(HttpStatus.FORBIDDEN, "InvalidRequest", "Unsupported Authorization algorithm", request));
+        }
+        String signedAt = request.getHeaders().get("x-amz-date");
+        if (signedAt == null || signedAt.isBlank()) {
+            return Optional.of(error(HttpStatus.FORBIDDEN, "AccessDenied", "Missing x-amz-date header", request));
+        }
+        String payloadHash = request.getHeaders().get("x-amz-content-sha256");
+        if (payloadHash == null || payloadHash.isBlank()) {
+            return Optional.of(error(HttpStatus.FORBIDDEN, "AccessDenied", "Missing x-amz-content-sha256 header", request));
+        }
+
+        Map<String, String> authorizationAttributes = parseAuthorizationAttributes(authorization.substring(ALGORITHM.length()).trim());
+        String credential = authorizationAttributes.get("Credential");
+        String signedHeaders = authorizationAttributes.get("SignedHeaders");
+        String providedSignature = authorizationAttributes.get("Signature");
+        if (credential == null || signedHeaders == null || providedSignature == null) {
+            return Optional.of(error(HttpStatus.FORBIDDEN, "InvalidRequest", "Malformed Authorization header", request));
+        }
+
+        String[] credentialScope = credential.split("/");
+        if (credentialScope.length != 5) {
+            return Optional.of(error(HttpStatus.FORBIDDEN, "AuthorizationHeaderMalformed", "Malformed Credential scope", request));
+        }
+        if (!accessKeyId.equals(credentialScope[0])) {
+            return Optional.of(error(HttpStatus.FORBIDDEN, "InvalidAccessKeyId", "The AWS Access Key Id you provided does not exist", request));
+        }
+        if (!credentialScope[1].equals(signedAt.substring(0, 8))
+            || !configuration.getRegion().equals(credentialScope[2])
+            || !SERVICE.equals(credentialScope[3])
+            || !TERMINAL.equals(credentialScope[4])) {
+            return Optional.of(error(HttpStatus.FORBIDDEN, "AuthorizationHeaderMalformed", "Credential scope does not match the configured S3-compatible service", request));
+        }
+
+        String canonicalRequest = request.getMethodName() + '\n'
+            + canonicalUri(request.getUri()) + '\n'
+            + canonicalQueryString(request.getUri()) + '\n'
+            + canonicalHeaders(request, signedHeaders) + '\n'
+            + signedHeaders + '\n'
+            + payloadHash;
+        String stringToSign = ALGORITHM + '\n'
+            + signedAt + '\n'
+            + credentialScope[1] + '/' + credentialScope[2] + '/' + credentialScope[3] + '/' + credentialScope[4] + '\n'
+            + sha256Hex(canonicalRequest);
+        String expectedSignature = toHex(
+            hmacSha256(
+                signingKey(secretAccessKey, credentialScope[1], credentialScope[2], credentialScope[3]),
+                stringToSign
+            )
+        );
+        if (!MessageDigest.isEqual(expectedSignature.getBytes(StandardCharsets.US_ASCII), providedSignature.getBytes(StandardCharsets.US_ASCII))) {
+            return Optional.of(error(HttpStatus.FORBIDDEN, "SignatureDoesNotMatch", "The request signature we calculated does not match the signature you provided", request));
+        }
+        return Optional.empty();
+    }
+
+    private static Map<String, String> parseAuthorizationAttributes(String authorization) {
+        Map<String, String> attributes = new LinkedHashMap<>();
+        for (String token : authorization.split(",\\s*")) {
+            String[] pair = token.split("=", 2);
+            if (pair.length == 2) {
+                attributes.put(pair[0], pair[1]);
+            }
+        }
+        return attributes;
+    }
+
+    private static String canonicalUri(URI uri) {
+        String rawPath = uri.getRawPath();
+        if (rawPath == null || rawPath.isEmpty()) {
+            return "/";
+        }
+        return rawPath;
+    }
+
+    private static String canonicalQueryString(URI uri) {
+        String rawQuery = uri.getRawQuery();
+        if (rawQuery == null || rawQuery.isEmpty()) {
+            return "";
+        }
+        List<String[]> pairs = new ArrayList<>();
+        for (String token : rawQuery.split("&", -1)) {
+            String[] pair = token.split("=", 2);
+            String name = pair.length > 0 ? percentEncode(percentDecode(pair[0])) : "";
+            String value = pair.length > 1 ? percentEncode(percentDecode(pair[1])) : "";
+            pairs.add(new String[] {name, value});
+        }
+        pairs.sort(Comparator.<String[], String>comparing(parts -> parts[0]).thenComparing(parts -> parts[1]));
+        StringBuilder result = new StringBuilder(rawQuery.length());
+        for (int i = 0; i < pairs.size(); i++) {
+            if (i > 0) {
+                result.append('&');
+            }
+            result.append(pairs.get(i)[0]).append('=').append(pairs.get(i)[1]);
+        }
+        return result.toString();
+    }
+
+    private static String canonicalHeaders(HttpRequest<?> request, String signedHeaders) {
+        StringBuilder canonical = new StringBuilder();
+        for (String headerName : signedHeaders.split(";")) {
+            List<String> values = request.getHeaders().getAll(headerName);
+            String normalizedValue = values.stream()
+                .map(S3CompatibilityRequestValidator::normalizeHeaderValue)
+                .reduce((left, right) -> left + ',' + right)
+                .orElse("");
+            canonical.append(headerName.toLowerCase(Locale.ROOT))
+                .append(':')
+                .append(normalizedValue)
+                .append('\n');
+        }
+        return canonical.toString();
+    }
+
+    private static String normalizeHeaderValue(String value) {
+        return value.trim().replaceAll("\\s+", " ");
+    }
+
+    private static byte[] signingKey(String secretAccessKey, String date, String region, String service) {
+        byte[] kDate = hmacSha256(("AWS4" + secretAccessKey).getBytes(StandardCharsets.UTF_8), date);
+        byte[] kRegion = hmacSha256(kDate, region);
+        byte[] kService = hmacSha256(kRegion, service);
+        return hmacSha256(kService, TERMINAL);
+    }
+
+    private static byte[] hmacSha256(byte[] key, String message) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_SHA_256);
+            mac.init(new SecretKeySpec(key, HMAC_SHA_256));
+            return mac.doFinal(message.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to compute HMAC-SHA256", e);
+        }
+    }
+
+    private static String sha256Hex(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return toHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+
+    private static String toHex(byte[] bytes) {
+        StringBuilder builder = new StringBuilder(bytes.length * 2);
+        for (byte current : bytes) {
+            builder.append(String.format(Locale.ROOT, "%02x", current));
+        }
+        return builder.toString();
+    }
+
+    private static String percentDecode(String value) {
+        byte[] bytes = new byte[value.length()];
+        int length = 0;
+        for (int i = 0; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (current == '%' && i + 2 < value.length()) {
+                bytes[length++] = (byte) Integer.parseInt(value.substring(i + 1, i + 3), 16);
+                i += 2;
+            } else {
+                bytes[length++] = (byte) current;
+            }
+        }
+        return new String(Arrays.copyOf(bytes, length), StandardCharsets.UTF_8);
+    }
+
+    private static String percentEncode(String value) {
+        StringBuilder encoded = new StringBuilder(value.length());
+        for (byte current : value.getBytes(StandardCharsets.UTF_8)) {
+            if ((current >= 'a' && current <= 'z')
+                || (current >= 'A' && current <= 'Z')
+                || (current >= '0' && current <= '9')
+                || current == '-'
+                || current == '_'
+                || current == '.'
+                || current == '~') {
+                encoded.append((char) current);
+            } else {
+                encoded.append('%').append(String.format(Locale.ROOT, "%02X", current));
+            }
+        }
+        return encoded.toString();
+    }
+
+    private static HttpResponse<String> error(HttpStatus status,
+                                              String code,
+                                              String message,
+                                              @Nullable HttpRequest<?> request) {
+        StringBuilder xml = new StringBuilder(192);
+        xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        xml.append("<Error>");
+        xml.append("<Code>").append(escapeXml(code)).append("</Code>");
+        xml.append("<Message>").append(escapeXml(message)).append("</Message>");
+        if (request != null) {
+            xml.append("<Resource>").append(escapeXml(request.getUri().getRawPath())).append("</Resource>");
+        }
+        xml.append("</Error>");
+        return HttpResponse.status(status)
+            .contentType(MediaType.APPLICATION_XML_TYPE)
+            .body(xml.toString());
+    }
+
+    private static String escapeXml(String value) {
+        return value
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+            .replace("'", "&apos;");
+    }
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityStorageProvider.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityStorageProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+/**
+ * Supported backing providers for the S3-compatible bridge.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+public enum S3CompatibilityStorageProvider {
+    /**
+     * Micronaut Local Storage backend.
+     */
+    LOCAL,
+    /**
+     * Micronaut AWS S3 backend.
+     */
+    AWS
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityUploadRequest.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibilityUploadRequest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.objectstorage.request.AbstractUploadRequest;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * Internal streaming upload request used by the S3 compatibility transport.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+final class S3CompatibilityUploadRequest extends AbstractUploadRequest {
+
+    private final InputStream inputStream;
+    private final String key;
+    private final Long contentSize;
+
+    S3CompatibilityUploadRequest(@NonNull InputStream inputStream,
+                                 @NonNull String key,
+                                 @Nullable Long contentSize,
+                                 @Nullable String contentType) {
+        this.inputStream = inputStream;
+        this.key = key;
+        this.contentSize = contentSize;
+        this.contentType = contentType;
+        this.metadata = Collections.emptyMap();
+    }
+
+    @Override
+    @NonNull
+    public Optional<String> getContentType() {
+        return Optional.ofNullable(contentType);
+    }
+
+    @Override
+    @NonNull
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    @NonNull
+    public Optional<Long> getContentSize() {
+        return Optional.ofNullable(contentSize);
+    }
+
+    @Override
+    @NonNull
+    public InputStream getInputStream() {
+        return inputStream;
+    }
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibleOperations.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibleOperations.java
@@ -22,6 +22,7 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import java.io.InputStream;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -70,4 +71,84 @@ public interface S3CompatibleOperations {
      */
     @NonNull
     S3ListResponse listObjects(@NonNull ListObjectsRequest request);
+
+    /**
+     * @return Whether the backing storage can expose S3 multipart routes.
+     */
+    default boolean supportsMultipart() {
+        return false;
+    }
+
+    /**
+     * Starts a new multipart upload.
+     *
+     * @param key the exposed object key
+     * @param contentType the requested content type if known
+     * @return the initiated multipart upload
+     */
+    @NonNull
+    default S3MultipartUpload createMultipartUpload(@NonNull String key, @Nullable String contentType) {
+        throw new UnsupportedOperationException("Multipart uploads are not supported by this bucket");
+    }
+
+    /**
+     * Stores one multipart upload part.
+     *
+     * @param key the exposed object key
+     * @param uploadId the multipart upload identifier
+     * @param partNumber the S3 part number
+     * @param inputStream the part bytes
+     * @param contentLength the part length if known
+     * @return the uploaded part metadata
+     */
+    @NonNull
+    default S3MultipartPart uploadPart(@NonNull String key,
+                                       @NonNull String uploadId,
+                                       int partNumber,
+                                       @NonNull InputStream inputStream,
+                                       @Nullable Long contentLength) {
+        throw new UnsupportedOperationException("Multipart uploads are not supported by this bucket");
+    }
+
+    /**
+     * Lists the current uploaded multipart parts.
+     *
+     * @param key the exposed object key
+     * @param uploadId the multipart upload identifier
+     * @param partNumberMarker the optional part number cursor
+     * @param maxParts the page size
+     * @return the multipart listing response
+     */
+    @NonNull
+    default S3MultipartListPartsResponse listParts(@NonNull String key,
+                                                   @NonNull String uploadId,
+                                                   @Nullable Integer partNumberMarker,
+                                                   int maxParts) {
+        throw new UnsupportedOperationException("Multipart uploads are not supported by this bucket");
+    }
+
+    /**
+     * Completes a multipart upload.
+     *
+     * @param key the exposed object key
+     * @param uploadId the multipart upload identifier
+     * @param completedParts the uploaded parts in completion order
+     * @return the completion response
+     */
+    @NonNull
+    default S3MultipartCompletedUpload completeMultipartUpload(@NonNull String key,
+                                                               @NonNull String uploadId,
+                                                               @NonNull List<S3CompletedPart> completedParts) {
+        throw new UnsupportedOperationException("Multipart uploads are not supported by this bucket");
+    }
+
+    /**
+     * Aborts a multipart upload.
+     *
+     * @param key the exposed object key
+     * @param uploadId the multipart upload identifier
+     */
+    default void abortMultipartUpload(@NonNull String key, @NonNull String uploadId) {
+        throw new UnsupportedOperationException("Multipart uploads are not supported by this bucket");
+    }
 }

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibleOperations.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibleOperations.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.request.ListObjectsRequest;
+import io.micronaut.objectstorage.response.UploadResponse;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.io.InputStream;
+import java.util.Optional;
+
+/**
+ * Internal backend SPI for the S3-compatible transport layer.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Internal
+public interface S3CompatibleOperations {
+
+    /**
+     * @param key the exposed object key
+     * @return the object metadata and content if present
+     */
+    @NonNull
+    Optional<S3Object> getObject(@NonNull String key);
+
+    /**
+     * Stores an object behind the exposed S3-compatible bucket.
+     *
+     * @param key the exposed object key
+     * @param inputStream the object bytes
+     * @param contentLength the object length if known
+     * @param contentType the object content type if known
+     * @return the storage response
+     */
+    @NonNull
+    UploadResponse<?> putObject(@NonNull String key,
+                                @NonNull InputStream inputStream,
+                                @Nullable Long contentLength,
+                                @Nullable String contentType);
+
+    /**
+     * Deletes an object behind the exposed S3-compatible bucket.
+     *
+     * @param key the exposed object key
+     */
+    void deleteObject(@NonNull String key);
+
+    /**
+     * Lists exposed object keys.
+     *
+     * @param request the paging request
+     * @return the list response
+     */
+    @NonNull
+    S3ListResponse listObjects(@NonNull ListObjectsRequest request);
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibleOperationsFactory.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompatibleOperationsFactory.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.objectstorage.aws.AwsS3Configuration;
+import io.micronaut.objectstorage.aws.AwsS3Operations;
+import io.micronaut.objectstorage.local.LocalStorageOperations;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.util.Optional;
+
+/**
+ * Creates backend adapters for each configured S3-compatible bucket.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Factory
+@Internal
+public final class S3CompatibleOperationsFactory {
+
+    private final BeanContext beanContext;
+
+    public S3CompatibleOperationsFactory(BeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
+    @EachBean(S3CompatibilityConfiguration.class)
+    S3CompatibleOperations s3CompatibleOperations(S3CompatibilityConfiguration configuration) {
+        String bucket = configuration.getName();
+        String storage = configuration.getStorage();
+        Optional<LocalStorageOperations> localOperations = findBean(LocalStorageOperations.class, storage);
+        Optional<AwsS3Operations> awsOperations = findBean(AwsS3Operations.class, storage);
+
+        return configuration.getStorageProvider()
+            .<S3CompatibleOperations>map(provider -> switch (provider) {
+                case LOCAL -> localOperations
+                    .map(operations -> new LocalStorageS3CompatibleOperations(configuration, operations))
+                    .orElseThrow(() -> missingProvider(bucket, storage, provider));
+                case AWS -> awsOperations
+                    .map(operations -> new AwsS3CompatibleOperations(
+                        configuration,
+                        beanContext.getBean(AwsS3Configuration.class, Qualifiers.byName(storage)),
+                        operations,
+                        beanContext.getBean(S3Client.class)
+                    ))
+                    .orElseThrow(() -> missingProvider(bucket, storage, provider));
+            })
+            .orElseGet(() -> autoDetect(bucket, storage, localOperations, awsOperations, configuration));
+    }
+
+    private S3CompatibleOperations autoDetect(String bucket,
+                                              String storage,
+                                              Optional<LocalStorageOperations> localOperations,
+                                              Optional<AwsS3Operations> awsOperations,
+                                              S3CompatibilityConfiguration configuration) {
+        if (localOperations.isPresent() && awsOperations.isPresent()) {
+            throw new ConfigurationException("S3-compatible bucket [" + bucket + "] is ambiguous because both local and aws storage beans named ["
+                + storage + "] exist. Set [" + providerProperty(bucket) + "] to [local] or [aws].");
+        }
+        if (localOperations.isPresent()) {
+            return new LocalStorageS3CompatibleOperations(configuration, localOperations.orElseThrow());
+        }
+        if (awsOperations.isPresent()) {
+            return new AwsS3CompatibleOperations(
+                configuration,
+                beanContext.getBean(AwsS3Configuration.class, Qualifiers.byName(storage)),
+                awsOperations.orElseThrow(),
+                beanContext.getBean(S3Client.class)
+            );
+        }
+        throw new ConfigurationException("S3-compatible bucket [" + bucket + "] references storage bean [" + storage
+            + "] but no supported local or aws object storage bean with that name exists.");
+    }
+
+    private ConfigurationException missingProvider(String bucket,
+                                                   String storage,
+                                                   S3CompatibilityStorageProvider provider) {
+        return new ConfigurationException("S3-compatible bucket [" + bucket + "] requires backing provider [" + provider.name().toLowerCase()
+            + "] for storage bean [" + storage + "], but no matching bean was found.");
+    }
+
+    private static String providerProperty(String bucket) {
+        return S3CompatibilityConfiguration.PREFIX + '.' + bucket + ".storage-provider";
+    }
+
+    private <T> Optional<T> findBean(Class<T> beanType, String name) {
+        return beanContext.findBean(beanType, Qualifiers.byName(name));
+    }
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompletedPart.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3CompletedPart.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Completed multipart part descriptor.
+ *
+ * @param partNumber the S3 part number
+ * @param eTag the uploaded part entity tag
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Internal
+public record S3CompletedPart(
+    int partNumber,
+    @NonNull String eTag
+) {
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3ListResponse.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3ListResponse.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Internal paginated listing response for the S3-compatible transport layer.
+ *
+ * @param objects the objects in the current page
+ * @param continuationToken the opaque continuation token for the next page
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Internal
+public record S3ListResponse(
+    @NonNull List<S3ObjectSummary> objects,
+    @Nullable String continuationToken
+) {
+
+    public S3ListResponse(@NonNull List<S3ObjectSummary> objects, @Nullable String continuationToken) {
+        this.objects = List.copyOf(objects);
+        this.continuationToken = continuationToken == null || continuationToken.isEmpty() ? null : continuationToken;
+    }
+
+    /**
+     * @return the opaque continuation token for the next page if present
+     */
+    @NonNull
+    public Optional<String> getContinuationToken() {
+        return Optional.ofNullable(continuationToken);
+    }
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3MultipartCompletedUpload.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3MultipartCompletedUpload.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Completed multipart upload response.
+ *
+ * @param eTag the completed object entity tag
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Internal
+public record S3MultipartCompletedUpload(
+    @NonNull String eTag
+) {
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3MultipartListPartsResponse.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3MultipartListPartsResponse.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Multipart part listing response.
+ *
+ * @param parts the uploaded parts in the current page
+ * @param nextPartNumberMarker the next page cursor when truncated
+ * @param truncated whether more parts are available
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Internal
+public record S3MultipartListPartsResponse(
+    @NonNull List<S3MultipartPart> parts,
+    @Nullable Integer nextPartNumberMarker,
+    boolean truncated
+) {
+
+    public S3MultipartListPartsResponse(@NonNull List<S3MultipartPart> parts,
+                                        @Nullable Integer nextPartNumberMarker,
+                                        boolean truncated) {
+        this.parts = List.copyOf(parts);
+        this.nextPartNumberMarker = nextPartNumberMarker;
+        this.truncated = truncated;
+    }
+
+    /**
+     * @return the next page cursor if the response is truncated
+     */
+    @NonNull
+    public Optional<Integer> getNextPartNumberMarker() {
+        return Optional.ofNullable(nextPartNumberMarker);
+    }
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3MultipartPart.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3MultipartPart.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Uploaded multipart part descriptor.
+ *
+ * @param partNumber the S3 part number
+ * @param eTag the uploaded part entity tag
+ * @param size the part size if known
+ * @param lastModified the part timestamp if known
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Internal
+public record S3MultipartPart(
+    int partNumber,
+    @NonNull String eTag,
+    @Nullable Long size,
+    @Nullable Instant lastModified
+) {
+
+    /**
+     * @return the part size if known
+     */
+    @NonNull
+    public Optional<Long> getSize() {
+        return Optional.ofNullable(size);
+    }
+
+    /**
+     * @return the part timestamp if known
+     */
+    @NonNull
+    public Optional<Instant> getLastModified() {
+        return Optional.ofNullable(lastModified);
+    }
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3MultipartUpload.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3MultipartUpload.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * Initiated multipart upload descriptor.
+ *
+ * @param uploadId the opaque multipart upload identifier
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Internal
+public record S3MultipartUpload(
+    @NonNull String uploadId
+) {
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3Object.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3Object.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.objectstorage.ObjectStorageEntry;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Internal object representation for the S3-compatible transport layer.
+ *
+ * @param key the exposed object key
+ * @param entry the underlying object entry
+ * @param size the object length if known
+ * @param lastModified the object modification time if known
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Internal
+public record S3Object(
+    @NonNull String key,
+    @NonNull ObjectStorageEntry<?> entry,
+    @Nullable Long size,
+    @Nullable Instant lastModified
+) {
+
+    /**
+     * @return the object length if known
+     */
+    @NonNull
+    public Optional<Long> getSize() {
+        return Optional.ofNullable(size);
+    }
+
+    /**
+     * @return the last modification time if known
+     */
+    @NonNull
+    public Optional<Instant> getLastModified() {
+        return Optional.ofNullable(lastModified);
+    }
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3ObjectSummary.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/S3ObjectSummary.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Internal object summary for S3-compatible listings.
+ *
+ * @param key the exposed object key
+ * @param size the object length if known
+ * @param lastModified the last modification time if known
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Internal
+public record S3ObjectSummary(
+    @NonNull String key,
+    @Nullable Long size,
+    @Nullable Instant lastModified
+) {
+
+    /**
+     * @return the object length if known
+     */
+    @NonNull
+    public Optional<Long> getSize() {
+        return Optional.ofNullable(size);
+    }
+
+    /**
+     * @return the last modification time if known
+     */
+    @NonNull
+    public Optional<Instant> getLastModified() {
+        return Optional.ofNullable(lastModified);
+    }
+}

--- a/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/package-info.java
+++ b/object-storage-s3-compat/src/main/java/io/micronaut/objectstorage/s3compat/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Object Storage classes related to the S3-compatible API surface.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.0.0
+ */
+@Configuration
+@Requires(property = S3CompatibilityConfiguration.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
+package io.micronaut.objectstorage.s3compat;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;

--- a/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/LocalStorageS3CompatibleOperationsSpec.groovy
+++ b/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/LocalStorageS3CompatibleOperationsSpec.groovy
@@ -1,0 +1,41 @@
+package io.micronaut.objectstorage.s3compat
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.objectstorage.request.ListObjectsRequest
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class LocalStorageS3CompatibleOperationsSpec extends Specification {
+
+    @Inject
+    ApplicationContext context
+
+    void 'it strips the configured base path from listed keys and continuation tokens'() {
+        given:
+        ApplicationContext baseContext = ApplicationContext.run([
+            'micronaut.object-storage.local.default.enabled'          : true,
+            'micronaut.object-storage.s3-compat.assets.storage'       : 'default',
+            'micronaut.object-storage.s3-compat.assets.base-path'     : 'exports/public',
+            'micronaut.object-storage.s3-compat.assets.enabled'       : true,
+        ])
+        S3CompatibleOperations operations = baseContext.getBean(S3CompatibleOperations, Qualifiers.byName('assets'))
+
+        when:
+        operations.putObject('docs/a.txt', new ByteArrayInputStream('a'.bytes), 1L, 'text/plain')
+        operations.putObject('docs/b.txt', new ByteArrayInputStream('b'.bytes), 1L, 'text/plain')
+        def page = operations.listObjects(new ListObjectsRequest(1, 'docs/'))
+        def nextPage = operations.listObjects(new ListObjectsRequest(5, 'docs/', page.getContinuationToken().orElse(null)))
+
+        then:
+        page.objects()*.key == ['docs/a.txt']
+        page.getContinuationToken().orElse(null) == 'docs/a.txt'
+        nextPage.objects()*.key == ['docs/b.txt']
+        nextPage.getContinuationToken().empty
+
+        cleanup:
+        baseContext.close()
+    }
+}

--- a/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityAwsBackendSpec.groovy
+++ b/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityAwsBackendSpec.groovy
@@ -15,7 +15,9 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.GetObjectResponse
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
+import software.amazon.awssdk.services.s3.model.S3Exception
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.model.CompletedPart
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
@@ -83,6 +85,111 @@ class S3CompatibilityAwsBackendSpec extends Specification {
 
         then:
         emptyListing.contents().isEmpty()
+
+        cleanup:
+        client?.close()
+        server?.close()
+        backendClient?.close()
+    }
+
+    void 'aws-backed buckets support multipart upload routes through the compatibility endpoint'() {
+        given:
+        localstack.start()
+        String backingBucket = "mn-s3compat-multipart-${System.currentTimeMillis()}"
+        S3Client backendClient = localstackClient()
+        backendClient.createBucket { it.bucket(backingBucket) }
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+            'micronaut.object-storage.aws.default.enabled'                  : 'true',
+            'micronaut.object-storage.aws.default.bucket'                   : backingBucket,
+            'aws.accessKeyId'                                               : localstack.accessKey,
+            'aws.secretKey'                                                 : localstack.secretKey,
+            'aws.region'                                                    : localstack.region,
+            'aws.services.s3.endpoint-override'                             : localstack.getEndpoint().toString(),
+            'micronaut.object-storage.s3-compat.enabled'                    : 'true',
+            'micronaut.object-storage.s3-compat.auth-mode'                  : 'sigv4',
+            'micronaut.object-storage.s3-compat.access-key-id'              : 'test-access-key',
+            'micronaut.object-storage.s3-compat.secret-access-key'          : 'test-secret-key',
+            'micronaut.object-storage.s3-compat.region'                     : localstack.region,
+            'micronaut.object-storage.s3-compat.assets.enabled'             : 'true',
+            'micronaut.object-storage.s3-compat.assets.storage'             : 'default',
+            'micronaut.object-storage.s3-compat.assets.storage-provider'    : 'aws',
+            'micronaut.object-storage.s3-compat.assets.base-path'           : 'exports/public',
+        ])
+        S3Client client = s3Client(server.URI, 'test-access-key', 'test-secret-key', localstack.region)
+        byte[] partBytes = 'hello multipart world'.bytes
+
+        when:
+        def initiated = client.createMultipartUpload {
+            it.bucket('assets')
+                .key('docs/multipart.txt')
+                .contentType('text/plain')
+        }
+        def part = client.uploadPart(
+            {
+                it.bucket('assets')
+                    .key('docs/multipart.txt')
+                    .uploadId(initiated.uploadId())
+                    .partNumber(1)
+            },
+            RequestBody.fromBytes(partBytes)
+        )
+        def listedParts = client.listParts {
+            it.bucket('assets')
+                .key('docs/multipart.txt')
+                .uploadId(initiated.uploadId())
+        }
+        client.completeMultipartUpload {
+            it.bucket('assets')
+                .key('docs/multipart.txt')
+                .uploadId(initiated.uploadId())
+                .multipartUpload { upload ->
+                    upload.parts(
+                        CompletedPart.builder()
+                            .partNumber(1)
+                            .eTag(part.eTag())
+                            .build()
+                    )
+                }
+        }
+        ResponseBytes<GetObjectResponse> object = client.getObjectAsBytes(GetObjectRequest.builder().bucket('assets').key('docs/multipart.txt').build())
+        ResponseBytes<GetObjectResponse> backendObject = backendClient.getObjectAsBytes(GetObjectRequest.builder().bucket(backingBucket).key('exports/public/docs/multipart.txt').build())
+
+        then:
+        listedParts.parts().size() == 1
+        listedParts.parts().first().partNumber() == 1
+        listedParts.parts().first().size() == partBytes.length
+        object.asByteArray() == partBytes
+        backendObject.asByteArray() == partBytes
+
+        when:
+        def aborted = client.createMultipartUpload {
+            it.bucket('assets')
+                .key('docs/aborted.txt')
+        }
+        client.uploadPart(
+            {
+                it.bucket('assets')
+                    .key('docs/aborted.txt')
+                    .uploadId(aborted.uploadId())
+                    .partNumber(1)
+            },
+            RequestBody.fromBytes('bye'.bytes)
+        )
+        client.abortMultipartUpload {
+            it.bucket('assets')
+                .key('docs/aborted.txt')
+                .uploadId(aborted.uploadId())
+        }
+        client.listParts {
+            it.bucket('assets')
+                .key('docs/aborted.txt')
+                .uploadId(aborted.uploadId())
+        }
+
+        then:
+        def e = thrown(S3Exception)
+        e.statusCode() == 404
+        e.awsErrorDetails().errorCode() == 'NoSuchUpload'
 
         cleanup:
         client?.close()

--- a/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityAwsBackendSpec.groovy
+++ b/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityAwsBackendSpec.groovy
@@ -1,0 +1,114 @@
+package io.micronaut.objectstorage.s3compat
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import org.testcontainers.localstack.LocalStackContainer
+import org.testcontainers.utility.DockerImageName
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.core.ResponseBytes
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.S3Configuration
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.GetObjectResponse
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.net.URI
+
+import static io.micronaut.objectstorage.test.ObjectStorageTestConstants.LOCAL_STACK_DOCKER_IMAGE
+
+class S3CompatibilityAwsBackendSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
+        .withServices("s3")
+
+    void 'aws sdk can use sigv4 against the s3 compatibility endpoint backed by aws storage'() {
+        given:
+        localstack.start()
+        String backingBucket = "mn-s3compat-${System.currentTimeMillis()}"
+        S3Client backendClient = localstackClient()
+        backendClient.createBucket { it.bucket(backingBucket) }
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+            'micronaut.object-storage.aws.default.enabled'                  : 'true',
+            'micronaut.object-storage.aws.default.bucket'                   : backingBucket,
+            'aws.accessKeyId'                                               : localstack.accessKey,
+            'aws.secretKey'                                                 : localstack.secretKey,
+            'aws.region'                                                    : localstack.region,
+            'aws.services.s3.endpoint-override'                             : localstack.getEndpoint().toString(),
+            'micronaut.object-storage.s3-compat.enabled'                    : 'true',
+            'micronaut.object-storage.s3-compat.auth-mode'                  : 'sigv4',
+            'micronaut.object-storage.s3-compat.access-key-id'              : 'test-access-key',
+            'micronaut.object-storage.s3-compat.secret-access-key'          : 'test-secret-key',
+            'micronaut.object-storage.s3-compat.region'                     : localstack.region,
+            'micronaut.object-storage.s3-compat.assets.enabled'             : 'true',
+            'micronaut.object-storage.s3-compat.assets.storage'             : 'default',
+            'micronaut.object-storage.s3-compat.assets.storage-provider'    : 'aws',
+            'micronaut.object-storage.s3-compat.assets.base-path'           : 'exports/public',
+        ])
+        S3Client client = s3Client(server.URI, 'test-access-key', 'test-secret-key', localstack.region)
+
+        when:
+        client.putObject(
+            PutObjectRequest.builder()
+                .bucket('assets')
+                .key('docs/hello.txt')
+                .contentType('text/plain')
+                .build(),
+            RequestBody.fromString('hello world')
+        )
+        def head = client.headObject(HeadObjectRequest.builder().bucket('assets').key('docs/hello.txt').build())
+        ResponseBytes<GetObjectResponse> object = client.getObjectAsBytes(GetObjectRequest.builder().bucket('assets').key('docs/hello.txt').build())
+        def listing = client.listObjectsV2(ListObjectsV2Request.builder().bucket('assets').prefix('docs/').build())
+        def backingListing = backendClient.listObjectsV2(ListObjectsV2Request.builder().bucket(backingBucket).prefix('exports/public/docs/').build())
+
+        then:
+        head.contentLength() == 11L
+        head.contentType() == 'text/plain'
+        object.asUtf8String() == 'hello world'
+        listing.contents()*.key() == ['docs/hello.txt']
+        backingListing.contents()*.key() == ['exports/public/docs/hello.txt']
+
+        when:
+        client.deleteObject { it.bucket('assets').key('docs/hello.txt') }
+        def emptyListing = client.listObjectsV2(ListObjectsV2Request.builder().bucket('assets').prefix('docs/').build())
+
+        then:
+        emptyListing.contents().isEmpty()
+
+        cleanup:
+        client?.close()
+        server?.close()
+        backendClient?.close()
+    }
+
+    private S3Client localstackClient() {
+        s3Client(
+            localstack.getEndpoint(),
+            localstack.accessKey,
+            localstack.secretKey,
+            localstack.region
+        )
+    }
+
+    private static S3Client s3Client(URI endpoint, String accessKeyId, String secretAccessKey, String region) {
+        S3Client.builder()
+            .endpointOverride(endpoint)
+            .region(Region.of(region))
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKeyId, secretAccessKey)))
+            .serviceConfiguration(S3Configuration.builder()
+                .pathStyleAccessEnabled(true)
+                .chunkedEncodingEnabled(false)
+                .checksumValidationEnabled(false)
+                .build())
+            .build()
+    }
+}

--- a/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityAwsBackendSpec.groovy
+++ b/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityAwsBackendSpec.groovy
@@ -92,6 +92,67 @@ class S3CompatibilityAwsBackendSpec extends Specification {
         backendClient?.close()
     }
 
+    void 'aws-backed buckets preserve opaque continuation tokens across paginated listings'() {
+        given:
+        localstack.start()
+        String backingBucket = "mn-s3compat-listing-${System.currentTimeMillis()}"
+        S3Client backendClient = localstackClient()
+        backendClient.createBucket { it.bucket(backingBucket) }
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+            'micronaut.object-storage.aws.default.enabled'                  : 'true',
+            'micronaut.object-storage.aws.default.bucket'                   : backingBucket,
+            'aws.accessKeyId'                                               : localstack.accessKey,
+            'aws.secretKey'                                                 : localstack.secretKey,
+            'aws.region'                                                    : localstack.region,
+            'aws.services.s3.endpoint-override'                             : localstack.getEndpoint().toString(),
+            'micronaut.object-storage.s3-compat.enabled'                    : 'true',
+            'micronaut.object-storage.s3-compat.auth-mode'                  : 'sigv4',
+            'micronaut.object-storage.s3-compat.access-key-id'              : 'test-access-key',
+            'micronaut.object-storage.s3-compat.secret-access-key'          : 'test-secret-key',
+            'micronaut.object-storage.s3-compat.region'                     : localstack.region,
+            'micronaut.object-storage.s3-compat.assets.enabled'             : 'true',
+            'micronaut.object-storage.s3-compat.assets.storage'             : 'default',
+            'micronaut.object-storage.s3-compat.assets.storage-provider'    : 'aws',
+            'micronaut.object-storage.s3-compat.assets.base-path'           : 'exports/public',
+        ])
+        S3Client client = s3Client(server.URI, 'test-access-key', 'test-secret-key', localstack.region)
+
+        when:
+        client.putObject(
+            PutObjectRequest.builder().bucket('assets').key('docs/a.txt').build(),
+            RequestBody.fromString('a')
+        )
+        client.putObject(
+            PutObjectRequest.builder().bucket('assets').key('docs/b.txt').build(),
+            RequestBody.fromString('b')
+        )
+        def firstPage = client.listObjectsV2(
+            ListObjectsV2Request.builder()
+                .bucket('assets')
+                .prefix('docs/')
+                .maxKeys(1)
+                .build()
+        )
+        def secondPage = client.listObjectsV2(
+            ListObjectsV2Request.builder()
+                .bucket('assets')
+                .prefix('docs/')
+                .maxKeys(1)
+                .continuationToken(firstPage.nextContinuationToken())
+                .build()
+        )
+
+        then:
+        firstPage.contents()*.key() == ['docs/a.txt']
+        firstPage.nextContinuationToken()
+        secondPage.contents()*.key() == ['docs/b.txt']
+
+        cleanup:
+        client?.close()
+        server?.close()
+        backendClient?.close()
+    }
+
     void 'aws-backed buckets support multipart upload routes through the compatibility endpoint'() {
         given:
         localstack.start()

--- a/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityAwsSdkSpec.groovy
+++ b/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityAwsSdkSpec.groovy
@@ -1,0 +1,116 @@
+package io.micronaut.objectstorage.s3compat
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.core.ResponseBytes
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.S3Configuration
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.GetObjectResponse
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.model.S3Exception
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class S3CompatibilityAwsSdkSpec extends Specification {
+
+    void 'aws sdk can use sigv4 against the s3 compatibility endpoint'() {
+        given:
+        Path storagePath = Files.createTempDirectory('mn-object-storage-s3compat')
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+            'micronaut.object-storage.local.default.enabled'                  : 'true',
+            'micronaut.object-storage.local.default.path'                     : storagePath.toString(),
+            'micronaut.object-storage.s3-compat.enabled'                      : 'true',
+            'micronaut.object-storage.s3-compat.auth-mode'                    : 'sigv4',
+            'micronaut.object-storage.s3-compat.access-key-id'                : 'test-access-key',
+            'micronaut.object-storage.s3-compat.secret-access-key'            : 'test-secret-key',
+            'micronaut.object-storage.s3-compat.region'                       : 'us-east-1',
+            'micronaut.object-storage.s3-compat.assets.enabled'               : 'true',
+            'micronaut.object-storage.s3-compat.assets.storage'               : 'default',
+            'micronaut.object-storage.s3-compat.assets.base-path'             : 'exports/public',
+        ])
+        S3Client client = s3Client(server.URI, 'test-access-key', 'test-secret-key')
+
+        when:
+        client.putObject(
+            PutObjectRequest.builder()
+                .bucket('assets')
+                .key('docs/hello.txt')
+                .contentType('text/plain')
+                .build(),
+            RequestBody.fromString('hello world')
+        )
+        def head = client.headObject(HeadObjectRequest.builder().bucket('assets').key('docs/hello.txt').build())
+        ResponseBytes<GetObjectResponse> object = client.getObjectAsBytes(GetObjectRequest.builder().bucket('assets').key('docs/hello.txt').build())
+        def listing = client.listObjectsV2(ListObjectsV2Request.builder().bucket('assets').prefix('docs/').build())
+
+        then:
+        head.contentLength() == 11L
+        head.contentType() == 'text/plain'
+        object.asUtf8String() == 'hello world'
+        listing.contents()*.key() == ['docs/hello.txt']
+
+        when:
+        client.deleteObject { it.bucket('assets').key('docs/hello.txt') }
+        def emptyListing = client.listObjectsV2(ListObjectsV2Request.builder().bucket('assets').prefix('docs/').build())
+
+        then:
+        emptyListing.contents().isEmpty()
+
+        cleanup:
+        client?.close()
+        server?.close()
+        storagePath?.toFile()?.deleteDir()
+    }
+
+    void 'it rejects invalid sigv4 credentials'() {
+        given:
+        Path storagePath = Files.createTempDirectory('mn-object-storage-s3compat-invalid')
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+            'micronaut.object-storage.local.default.enabled'                  : 'true',
+            'micronaut.object-storage.local.default.path'                     : storagePath.toString(),
+            'micronaut.object-storage.s3-compat.enabled'                      : 'true',
+            'micronaut.object-storage.s3-compat.auth-mode'                    : 'sigv4',
+            'micronaut.object-storage.s3-compat.access-key-id'                : 'test-access-key',
+            'micronaut.object-storage.s3-compat.secret-access-key'            : 'test-secret-key',
+            'micronaut.object-storage.s3-compat.region'                       : 'us-east-1',
+            'micronaut.object-storage.s3-compat.assets.enabled'               : 'true',
+            'micronaut.object-storage.s3-compat.assets.storage'               : 'default',
+        ])
+        S3Client client = s3Client(server.URI, 'test-access-key', 'wrong-secret')
+
+        when:
+        client.listObjectsV2(ListObjectsV2Request.builder().bucket('assets').build())
+
+        then:
+        def e = thrown(S3Exception)
+        e.statusCode() == 403
+        e.awsErrorDetails().errorCode() == 'SignatureDoesNotMatch'
+
+        cleanup:
+        client?.close()
+        server?.close()
+        storagePath?.toFile()?.deleteDir()
+    }
+
+    private static S3Client s3Client(URI endpoint, String accessKeyId, String secretAccessKey) {
+        S3Client.builder()
+            .endpointOverride(endpoint)
+            .region(Region.of('us-east-1'))
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKeyId, secretAccessKey)))
+            .serviceConfiguration(S3Configuration.builder()
+                .pathStyleAccessEnabled(true)
+                .chunkedEncodingEnabled(false)
+                .checksumValidationEnabled(false)
+                .build())
+            .build()
+    }
+}

--- a/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityControllerSpec.groovy
+++ b/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityControllerSpec.groovy
@@ -26,11 +26,11 @@ class S3CompatibilityControllerSpec extends Specification {
             HttpRequest.PUT('/assets/docs/hello.txt', body).contentType(MediaType.TEXT_PLAIN_TYPE),
             new ByteArrayInputStream(body)
         )
-        def headResponse = controller.headObject('assets', 'docs/hello.txt')
-        def getResponse = controller.getObject('assets', 'docs/hello.txt')
-        def listResponse = controller.listObjectsV2('assets', 2, 'docs/', null, 1000)
-        def deleteResponse = controller.deleteObject('assets', 'docs/hello.txt')
-        def missingResponse = controller.getObject('assets', 'docs/hello.txt')
+        def headResponse = controller.headObject('assets', 'docs/hello.txt', HttpRequest.HEAD('/assets/docs/hello.txt'))
+        def getResponse = controller.getObject('assets', 'docs/hello.txt', HttpRequest.GET('/assets/docs/hello.txt'))
+        def listResponse = controller.listObjectsV2('assets', 2, 'docs/', null, 1000, HttpRequest.GET('/assets?list-type=2&prefix=docs/&max-keys=1000'))
+        def deleteResponse = controller.deleteObject('assets', 'docs/hello.txt', HttpRequest.DELETE('/assets/docs/hello.txt'))
+        def missingResponse = controller.getObject('assets', 'docs/hello.txt', HttpRequest.GET('/assets/docs/hello.txt'))
 
         then:
         putResponse.status() == HttpStatus.OK
@@ -68,8 +68,8 @@ class S3CompatibilityControllerSpec extends Specification {
         S3CompatibilityController controller = context.getBean(S3CompatibilityController)
 
         when:
-        def missingBucket = controller.getObject('missing', 'docs/hello.txt')
-        def missingKey = controller.getObject('assets', 'docs/hello.txt')
+        def missingBucket = controller.getObject('missing', 'docs/hello.txt', HttpRequest.GET('/missing/docs/hello.txt'))
+        def missingKey = controller.getObject('assets', 'docs/hello.txt', HttpRequest.GET('/assets/docs/hello.txt'))
 
         then:
         missingBucket.status() == HttpStatus.NOT_FOUND
@@ -97,7 +97,7 @@ class S3CompatibilityControllerSpec extends Specification {
         S3CompatibilityController controller = context.getBean(S3CompatibilityController)
 
         when:
-        def response = controller.listObjectsV2('assets', 1, null, null, 1000)
+        def response = controller.listObjectsV2('assets', 1, null, null, 1000, HttpRequest.GET('/assets?list-type=1&max-keys=1000'))
 
         then:
         response.status() == HttpStatus.BAD_REQUEST

--- a/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityControllerSpec.groovy
+++ b/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityControllerSpec.groovy
@@ -132,4 +132,28 @@ class S3CompatibilityControllerSpec extends Specification {
         cleanup:
         context.close()
     }
+
+    void 'it rejects complete-multipart xml bodies that declare a doctype'() {
+        given:
+        def method = S3CompatibilityController.getDeclaredMethod('parseCompletedParts', String)
+        method.accessible = true
+        String body = '''<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE CompleteMultipartUpload [
+<!ENTITY xxe SYSTEM "file:///etc/passwd">
+]>
+<CompleteMultipartUpload>
+  <Part>
+    <PartNumber>1</PartNumber>
+    <ETag>&xxe;</ETag>
+  </Part>
+</CompleteMultipartUpload>'''
+
+        when:
+        method.invoke(null, body)
+
+        then:
+        def e = thrown(java.lang.reflect.InvocationTargetException)
+        e.cause instanceof IllegalArgumentException
+        e.cause.message == 'Unable to parse the CompleteMultipartUpload request body'
+    }
 }

--- a/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityControllerSpec.groovy
+++ b/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityControllerSpec.groovy
@@ -23,14 +23,16 @@ class S3CompatibilityControllerSpec extends Specification {
         def putResponse = controller.putObject(
             'assets',
             'docs/hello.txt',
+            null,
+            null,
             HttpRequest.PUT('/assets/docs/hello.txt', body).contentType(MediaType.TEXT_PLAIN_TYPE),
             new ByteArrayInputStream(body)
         )
         def headResponse = controller.headObject('assets', 'docs/hello.txt', HttpRequest.HEAD('/assets/docs/hello.txt'))
-        def getResponse = controller.getObject('assets', 'docs/hello.txt', HttpRequest.GET('/assets/docs/hello.txt'))
+        def getResponse = controller.getObject('assets', 'docs/hello.txt', null, null, 1000, HttpRequest.GET('/assets/docs/hello.txt'))
         def listResponse = controller.listObjectsV2('assets', 2, 'docs/', null, 1000, HttpRequest.GET('/assets?list-type=2&prefix=docs/&max-keys=1000'))
-        def deleteResponse = controller.deleteObject('assets', 'docs/hello.txt', HttpRequest.DELETE('/assets/docs/hello.txt'))
-        def missingResponse = controller.getObject('assets', 'docs/hello.txt', HttpRequest.GET('/assets/docs/hello.txt'))
+        def deleteResponse = controller.deleteObject('assets', 'docs/hello.txt', null, HttpRequest.DELETE('/assets/docs/hello.txt'))
+        def missingResponse = controller.getObject('assets', 'docs/hello.txt', null, null, 1000, HttpRequest.GET('/assets/docs/hello.txt'))
 
         then:
         putResponse.status() == HttpStatus.OK
@@ -68,8 +70,8 @@ class S3CompatibilityControllerSpec extends Specification {
         S3CompatibilityController controller = context.getBean(S3CompatibilityController)
 
         when:
-        def missingBucket = controller.getObject('missing', 'docs/hello.txt', HttpRequest.GET('/missing/docs/hello.txt'))
-        def missingKey = controller.getObject('assets', 'docs/hello.txt', HttpRequest.GET('/assets/docs/hello.txt'))
+        def missingBucket = controller.getObject('missing', 'docs/hello.txt', null, null, 1000, HttpRequest.GET('/missing/docs/hello.txt'))
+        def missingKey = controller.getObject('assets', 'docs/hello.txt', null, null, 1000, HttpRequest.GET('/assets/docs/hello.txt'))
 
         then:
         missingBucket.status() == HttpStatus.NOT_FOUND
@@ -104,6 +106,28 @@ class S3CompatibilityControllerSpec extends Specification {
         response.contentType.get() == MediaType.APPLICATION_XML_TYPE
         response.body().contains('<Code>InvalidRequest</Code>')
         response.body().contains('list-type=2')
+
+        cleanup:
+        context.close()
+    }
+
+    void 'it reports multipart as not implemented for local-backed buckets'() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+            'micronaut.object-storage.local.default.enabled'    : 'true',
+            'micronaut.object-storage.s3-compat.assets.storage' : 'default',
+            'micronaut.object-storage.s3-compat.assets.enabled' : 'true',
+        ])
+        S3CompatibilityController controller = context.getBean(S3CompatibilityController)
+
+        when:
+        def response = controller.postObject('assets', 'docs/big.bin', null, HttpRequest.POST('/assets/docs/big.bin?uploads', ''), '')
+
+        then:
+        response.status() == HttpStatus.NOT_IMPLEMENTED
+        response.contentType.get() == MediaType.APPLICATION_XML_TYPE
+        response.body().contains('<Code>NotImplemented</Code>')
+        response.body().contains('Multipart uploads are only supported')
 
         cleanup:
         context.close()

--- a/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityControllerSpec.groovy
+++ b/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityControllerSpec.groovy
@@ -24,7 +24,7 @@ class S3CompatibilityControllerSpec extends Specification {
             'assets',
             'docs/hello.txt',
             HttpRequest.PUT('/assets/docs/hello.txt', body).contentType(MediaType.TEXT_PLAIN_TYPE),
-            body
+            new ByteArrayInputStream(body)
         )
         def headResponse = controller.headObject('assets', 'docs/hello.txt')
         def getResponse = controller.getObject('assets', 'docs/hello.txt')
@@ -53,6 +53,57 @@ class S3CompatibilityControllerSpec extends Specification {
         and:
         deleteResponse.status() == HttpStatus.NO_CONTENT
         missingResponse.status() == HttpStatus.NOT_FOUND
+
+        cleanup:
+        context.close()
+    }
+
+    void 'it returns s3 xml errors for missing buckets and keys'() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+            'micronaut.object-storage.local.default.enabled'    : 'true',
+            'micronaut.object-storage.s3-compat.assets.storage' : 'default',
+            'micronaut.object-storage.s3-compat.assets.enabled' : 'true',
+        ])
+        S3CompatibilityController controller = context.getBean(S3CompatibilityController)
+
+        when:
+        def missingBucket = controller.getObject('missing', 'docs/hello.txt')
+        def missingKey = controller.getObject('assets', 'docs/hello.txt')
+
+        then:
+        missingBucket.status() == HttpStatus.NOT_FOUND
+        missingBucket.contentType.get() == MediaType.APPLICATION_XML_TYPE
+        missingBucket.body().contains('<Code>NoSuchBucket</Code>')
+        missingBucket.body().contains('<BucketName>missing</BucketName>')
+
+        and:
+        missingKey.status() == HttpStatus.NOT_FOUND
+        missingKey.contentType.get() == MediaType.APPLICATION_XML_TYPE
+        missingKey.body().contains('<Code>NoSuchKey</Code>')
+        missingKey.body().contains('<Key>docs/hello.txt</Key>')
+
+        cleanup:
+        context.close()
+    }
+
+    void 'it returns an xml invalid request error for unsupported list variants'() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+            'micronaut.object-storage.local.default.enabled'    : 'true',
+            'micronaut.object-storage.s3-compat.assets.storage' : 'default',
+            'micronaut.object-storage.s3-compat.assets.enabled' : 'true',
+        ])
+        S3CompatibilityController controller = context.getBean(S3CompatibilityController)
+
+        when:
+        def response = controller.listObjectsV2('assets', 1, null, null, 1000)
+
+        then:
+        response.status() == HttpStatus.BAD_REQUEST
+        response.contentType.get() == MediaType.APPLICATION_XML_TYPE
+        response.body().contains('<Code>InvalidRequest</Code>')
+        response.body().contains('list-type=2')
 
         cleanup:
         context.close()

--- a/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityControllerSpec.groovy
+++ b/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityControllerSpec.groovy
@@ -1,0 +1,60 @@
+package io.micronaut.objectstorage.s3compat
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.server.types.files.StreamedFile
+import spock.lang.Specification
+
+class S3CompatibilityControllerSpec extends Specification {
+
+    void 'it exposes path-style CRUD and list-objects-v2 for a configured bucket'() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+            'micronaut.object-storage.local.default.enabled'    : 'true',
+            'micronaut.object-storage.s3-compat.assets.storage' : 'default',
+            'micronaut.object-storage.s3-compat.assets.enabled' : 'true',
+        ])
+        S3CompatibilityController controller = context.getBean(S3CompatibilityController)
+        byte[] body = 'hello world'.bytes
+
+        when:
+        def putResponse = controller.putObject(
+            'assets',
+            'docs/hello.txt',
+            HttpRequest.PUT('/assets/docs/hello.txt', body).contentType(MediaType.TEXT_PLAIN_TYPE),
+            body
+        )
+        def headResponse = controller.headObject('assets', 'docs/hello.txt')
+        def getResponse = controller.getObject('assets', 'docs/hello.txt')
+        def listResponse = controller.listObjectsV2('assets', 2, 'docs/', null, 1000)
+        def deleteResponse = controller.deleteObject('assets', 'docs/hello.txt')
+        def missingResponse = controller.getObject('assets', 'docs/hello.txt')
+
+        then:
+        putResponse.status() == HttpStatus.OK
+        putResponse.header('ETag')
+        headResponse.status() == HttpStatus.OK
+        headResponse.header('Content-Length') == '11'
+
+        and:
+        getResponse.status() == HttpStatus.OK
+        StreamedFile streamedFile = getResponse.body() as StreamedFile
+        streamedFile.inputStream.text == 'hello world'
+        getResponse.header('Content-Type') == 'text/plain'
+
+        and:
+        listResponse.status() == HttpStatus.OK
+        listResponse.body().contains('<Name>assets</Name>')
+        listResponse.body().contains('<Prefix>docs/</Prefix>')
+        listResponse.body().contains('<Key>docs/hello.txt</Key>')
+
+        and:
+        deleteResponse.status() == HttpStatus.NO_CONTENT
+        missingResponse.status() == HttpStatus.NOT_FOUND
+
+        cleanup:
+        context.close()
+    }
+}

--- a/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityRequestValidatorSpec.groovy
+++ b/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibilityRequestValidatorSpec.groovy
@@ -1,0 +1,80 @@
+package io.micronaut.objectstorage.s3compat
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import spock.lang.Specification
+
+class S3CompatibilityRequestValidatorSpec extends Specification {
+
+    void 'it rejects malformed x-amz-date values with an s3 auth error'() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+            'micronaut.object-storage.s3-compat.enabled'           : 'true',
+            'micronaut.object-storage.s3-compat.auth-mode'         : 'sigv4',
+            'micronaut.object-storage.s3-compat.access-key-id'     : 'test-access-key',
+            'micronaut.object-storage.s3-compat.secret-access-key' : 'test-secret-key',
+            'micronaut.object-storage.s3-compat.region'            : 'us-east-1',
+        ])
+        S3CompatibilityRequestValidator validator = context.getBean(S3CompatibilityRequestValidator)
+        HttpRequest<?> request = HttpRequest.GET('/assets')
+            .header(HttpHeaders.AUTHORIZATION, 'AWS4-HMAC-SHA256 Credential=test-access-key/20260410/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=deadbeef')
+            .header('x-amz-date', '2026041')
+            .header('x-amz-content-sha256', 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+            .header(HttpHeaders.HOST, 'localhost')
+
+        when:
+        def response = validator.validate(request).orElse(null)
+
+        then:
+        response.status() == HttpStatus.FORBIDDEN
+        response.body().contains('<Code>AccessDenied</Code>')
+        response.body().contains('Malformed x-amz-date header')
+
+        cleanup:
+        context.close()
+    }
+
+    void 'it rejects malformed percent-encoding in canonical query parsing'() {
+        given:
+        def method = S3CompatibilityRequestValidator.getDeclaredMethod('percentDecode', String)
+        method.accessible = true
+
+        when:
+        method.invoke(null, '%ZZ')
+
+        then:
+        def e = thrown(java.lang.reflect.InvocationTargetException)
+        e.cause instanceof IllegalArgumentException
+        e.cause.message == 'Malformed query parameter encoding'
+    }
+
+    void 'it verifies the received payload hash when sigv4 supplies one'() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+            'micronaut.object-storage.s3-compat.enabled'           : 'true',
+            'micronaut.object-storage.s3-compat.auth-mode'         : 'sigv4',
+            'micronaut.object-storage.s3-compat.access-key-id'     : 'test-access-key',
+            'micronaut.object-storage.s3-compat.secret-access-key' : 'test-secret-key',
+            'micronaut.object-storage.s3-compat.region'            : 'us-east-1',
+        ])
+        S3CompatibilityRequestValidator validator = context.getBean(S3CompatibilityRequestValidator)
+        HttpRequest<?> request = HttpRequest.PUT('/assets/docs/hello.txt', '')
+            .header(HttpHeaders.AUTHORIZATION, 'AWS4-HMAC-SHA256 Credential=test-access-key/20260410/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=deadbeef')
+            .header('x-amz-date', '20260410T010203Z')
+            .header('x-amz-content-sha256', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+            .header(HttpHeaders.HOST, 'localhost')
+
+        when:
+        def response = validator.validate(request, 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb').orElse(null)
+
+        then:
+        response.status() == HttpStatus.FORBIDDEN
+        response.body().contains('<Code>SignatureDoesNotMatch</Code>')
+        response.body().contains('x-amz-content-sha256')
+
+        cleanup:
+        context.close()
+    }
+}

--- a/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibleOperationsFactorySpec.groovy
+++ b/object-storage-s3-compat/src/test/groovy/io/micronaut/objectstorage/s3compat/S3CompatibleOperationsFactorySpec.groovy
@@ -1,0 +1,78 @@
+package io.micronaut.objectstorage.s3compat
+
+import io.micronaut.context.BeanContext
+import io.micronaut.context.exceptions.ConfigurationException
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.objectstorage.aws.AwsS3Configuration
+import io.micronaut.objectstorage.aws.AwsS3Operations
+import io.micronaut.objectstorage.local.LocalStorageOperations
+import software.amazon.awssdk.services.s3.S3Client
+import spock.lang.Specification
+
+class S3CompatibleOperationsFactorySpec extends Specification {
+
+    void 'it auto-detects the local adapter when that is the only matching provider'() {
+        given:
+        BeanContext beanContext = Mock()
+        LocalStorageOperations localStorageOperations = Mock()
+        def factory = new S3CompatibleOperationsFactory(beanContext)
+        def configuration = configuration('assets', 'default', null)
+
+        when:
+        def operations = factory.s3CompatibleOperations(configuration)
+
+        then:
+        operations instanceof LocalStorageS3CompatibleOperations
+        1 * beanContext.findBean(LocalStorageOperations, Qualifiers.byName('default')) >> Optional.of(localStorageOperations)
+        1 * beanContext.findBean(AwsS3Operations, Qualifiers.byName('default')) >> Optional.empty()
+        0 * _
+    }
+
+    void 'it uses the configured aws provider when requested explicitly'() {
+        given:
+        BeanContext beanContext = Mock()
+        AwsS3Operations awsOperations = Mock()
+        AwsS3Configuration awsConfiguration = new AwsS3Configuration('default')
+        awsConfiguration.setBucket('backing-bucket')
+        S3Client s3Client = Mock()
+        def factory = new S3CompatibleOperationsFactory(beanContext)
+        def configuration = configuration('assets', 'default', S3CompatibilityStorageProvider.AWS)
+
+        when:
+        def operations = factory.s3CompatibleOperations(configuration)
+
+        then:
+        operations instanceof AwsS3CompatibleOperations
+        1 * beanContext.findBean(LocalStorageOperations, Qualifiers.byName('default')) >> Optional.empty()
+        1 * beanContext.findBean(AwsS3Operations, Qualifiers.byName('default')) >> Optional.of(awsOperations)
+        1 * beanContext.getBean(AwsS3Configuration, Qualifiers.byName('default')) >> awsConfiguration
+        1 * beanContext.getBean(S3Client) >> s3Client
+        0 * _
+    }
+
+    void 'it requires a provider hint when local and aws storages share the same name'() {
+        given:
+        BeanContext beanContext = Mock()
+        def factory = new S3CompatibleOperationsFactory(beanContext)
+        def configuration = configuration('assets', 'default', null)
+
+        when:
+        factory.s3CompatibleOperations(configuration)
+
+        then:
+        def e = thrown(ConfigurationException)
+        e.message.contains('storage-provider')
+        1 * beanContext.findBean(LocalStorageOperations, Qualifiers.byName('default')) >> Optional.of(Mock(LocalStorageOperations))
+        1 * beanContext.findBean(AwsS3Operations, Qualifiers.byName('default')) >> Optional.of(Mock(AwsS3Operations))
+        0 * _
+    }
+
+    private static S3CompatibilityConfiguration configuration(String bucket,
+                                                              String storage,
+                                                              S3CompatibilityStorageProvider provider) {
+        def configuration = new S3CompatibilityConfiguration(bucket)
+        configuration.setStorage(storage)
+        configuration.setStorageProvider(provider)
+        configuration
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ include("object-storage-azure")
 include("object-storage-gcp")
 include("object-storage-oracle-cloud")
 include("object-storage-local")
+include("object-storage-s3-compat")
 include("test-suite-graal")
 
 include("doc-examples:example-java")

--- a/src/main/docs/guide/s3CompatibleApi.adoc
+++ b/src/main/docs/guide/s3CompatibleApi.adoc
@@ -34,14 +34,15 @@ The current implementation is intentionally narrow:
 * path-style routing only (`/{bucket}/{key}`)
 * one configured bucket mapping per entry under `micronaut.object-storage.s3-compat`
 * object upload, download, head, delete, and `ListObjectsV2`
+* multipart create/upload/list/complete/abort for AWS-backed buckets
 * SigV4 request validation for AWS SDK / CLI compatible clients
 * S3-style XML error payloads for missing buckets, missing keys, and invalid list requests
 
 Current limitations:
 
 * this is a focused compatibility subset, not a full Amazon S3 replacement
-* multipart upload routes are not exposed yet
-* the included bridge supports Micronaut Local Storage and AWS S3
+* multipart support is currently limited to buckets backed by Micronaut AWS S3 storage
+* the included bridges support Micronaut Local Storage and AWS S3
 
 If the same `storage` bean name exists in multiple providers, set `micronaut.object-storage.s3-compat.<bucket>.storage-provider` to `local` or `aws` to disambiguate the backing adapter explicitly.
 

--- a/src/main/docs/guide/s3CompatibleApi.adoc
+++ b/src/main/docs/guide/s3CompatibleApi.adoc
@@ -41,7 +41,9 @@ Current limitations:
 
 * this is a focused compatibility subset, not a full Amazon S3 replacement
 * multipart upload routes are not exposed yet
-* the included bridge targets Micronaut Local Storage; additional providers can add dedicated `S3CompatibleOperations` adapters later
+* the included bridge supports Micronaut Local Storage and AWS S3
+
+If the same `storage` bean name exists in multiple providers, set `micronaut.object-storage.s3-compat.<bucket>.storage-provider` to `local` or `aws` to disambiguate the backing adapter explicitly.
 
 For local development you can disable request signing entirely with `micronaut.object-storage.s3-compat.auth-mode=none`, but SigV4 should be the default compatibility story for real S3 client integrations.
 

--- a/src/main/docs/guide/s3CompatibleApi.adoc
+++ b/src/main/docs/guide/s3CompatibleApi.adoc
@@ -1,0 +1,46 @@
+== S3-Compatible API
+
+The `micronaut-object-storage-s3-compat` module adds an opt-in HTTP surface that exposes a focused, path-style subset of Amazon S3 semantics on top of Micronaut Object Storage.
+
+Add the dependency:
+
+dependency:io.micronaut.objectstorage:micronaut-object-storage-s3-compat[]
+
+Enable the module and map one exposed S3 bucket to one configured Micronaut object storage bean:
+
+[configuration]
+----
+micronaut:
+  object-storage:
+    local:
+      default:
+        enabled: true
+    s3-compat:
+      enabled: true
+      assets:
+        enabled: true
+        storage: default
+        base-path: exports/public
+----
+
+The configuration above exposes the logical S3 bucket `assets` while storing the actual objects under the `exports/public/` prefix in the backing Micronaut storage bean.
+
+The current implementation is intentionally narrow:
+
+* path-style routing only (`/{bucket}/{key}`)
+* one configured bucket mapping per entry under `micronaut.object-storage.s3-compat`
+* object upload, download, head, delete, and `ListObjectsV2`
+* S3-style XML error payloads for missing buckets, missing keys, and invalid list requests
+
+Current limitations:
+
+* this is a focused compatibility subset, not a full Amazon S3 replacement
+* SigV4 request verification is not implemented yet
+* multipart upload routes are not exposed yet
+* the included bridge targets Micronaut Local Storage; additional providers can add dedicated `S3CompatibleOperations` adapters later
+
+Configuration references:
+
+include::{includedir}configurationProperties/io.micronaut.objectstorage.s3compat.S3CompatibilityModuleConfiguration.adoc[]
+
+include::{includedir}configurationProperties/io.micronaut.objectstorage.s3compat.S3CompatibilityConfiguration.adoc[]

--- a/src/main/docs/guide/s3CompatibleApi.adoc
+++ b/src/main/docs/guide/s3CompatibleApi.adoc
@@ -17,6 +17,10 @@ micronaut:
         enabled: true
     s3-compat:
       enabled: true
+      auth-mode: sigv4
+      access-key-id: local-s3-access-key
+      secret-access-key: local-s3-secret-key
+      region: us-east-1
       assets:
         enabled: true
         storage: default
@@ -30,14 +34,16 @@ The current implementation is intentionally narrow:
 * path-style routing only (`/{bucket}/{key}`)
 * one configured bucket mapping per entry under `micronaut.object-storage.s3-compat`
 * object upload, download, head, delete, and `ListObjectsV2`
+* SigV4 request validation for AWS SDK / CLI compatible clients
 * S3-style XML error payloads for missing buckets, missing keys, and invalid list requests
 
 Current limitations:
 
 * this is a focused compatibility subset, not a full Amazon S3 replacement
-* SigV4 request verification is not implemented yet
 * multipart upload routes are not exposed yet
 * the included bridge targets Micronaut Local Storage; additional providers can add dedicated `S3CompatibleOperations` adapters later
+
+For local development you can disable request signing entirely with `micronaut.object-storage.s3-compat.auth-mode=none`, but SigV4 should be the default compatibility story for real S3 client integrations.
 
 Configuration references:
 

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -4,6 +4,7 @@ quickStart: Quick Start
 reactiveOperations: Reactive Operations
 preSignedUploads: Pre-Signed Uploads
 paginatedListing: Paginated Listing
+s3CompatibleApi: S3-Compatible API
 bucketManagement: Bucket and Container Management
 aws: Amazon S3
 azure: Azure Blob Storage


### PR DESCRIPTION
## Summary
- add a new `micronaut-object-storage-s3-compat` module that exposes a focused, path-style S3-compatible API surface without changing existing `ObjectStorageOperations` contracts
- support object CRUD, `ListObjectsV2`, SigV4 request validation, and multipart routes when the selected backend supports multipart workflows
- provide local and AWS-backed bridges, AWS SDK integration coverage, and guide documentation for the shipped subset and configuration

## Verification
- `source ~/.sdkman/bin/sdkman-init.sh && sdk env && ./gradlew --no-daemon :micronaut-object-storage-s3-compat:test --tests 'io.micronaut.objectstorage.s3compat.S3CompatibilityAwsSdkSpec'`
- `source ~/.sdkman/bin/sdkman-init.sh && sdk env && ./gradlew --no-daemon :micronaut-object-storage-s3-compat:check docs`
- `source ~/.sdkman/bin/sdkman-init.sh && sdk env && ./gradlew --no-daemon :micronaut-object-storage-s3-compat:test --rerun-tasks --tests 'io.micronaut.objectstorage.s3compat.S3CompatibilityControllerSpec' --tests 'io.micronaut.objectstorage.s3compat.S3CompatibilityAwsSdkSpec' --tests 'io.micronaut.objectstorage.s3compat.S3CompatibilityAwsBackendSpec'`

Closes #757
