### PR TITLE
fix: pin LocalStack test image

### DIFF
--- a/doc-examples/example-groovy/src/test/groovy/example/ProfileServiceSpec.groovy
+++ b/doc-examples/example-groovy/src/test/groovy/example/ProfileServiceSpec.groovy
@@ -27,7 +27,7 @@ class ProfileServiceSpec extends Specification implements TestPropertyProvider {
 
     @Shared
     @AutoCleanup
-    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
+    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE).asCompatibleSubstituteFor("localstack/localstack"))
             .withServices("s3")
 
     @Inject

--- a/doc-examples/example-groovy/src/test/groovy/example/UploadControllerSpec.groovy
+++ b/doc-examples/example-groovy/src/test/groovy/example/UploadControllerSpec.groovy
@@ -31,7 +31,7 @@ class UploadControllerSpec extends Specification implements TestPropertyProvider
 
     @Shared
     @AutoCleanup
-    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
+    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE).asCompatibleSubstituteFor("localstack/localstack"))
             .withServices("s3")
 
     @Inject

--- a/doc-examples/example-java/src/test/groovy/example/ProfileServiceSpec.groovy
+++ b/doc-examples/example-java/src/test/groovy/example/ProfileServiceSpec.groovy
@@ -27,7 +27,7 @@ class ProfileServiceSpec extends Specification implements TestPropertyProvider {
 
     @Shared
     @AutoCleanup
-    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
+    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE).asCompatibleSubstituteFor("localstack/localstack"))
             .withServices("s3")
 
     @Inject

--- a/doc-examples/example-java/src/test/groovy/example/UploadControllerSpec.groovy
+++ b/doc-examples/example-java/src/test/groovy/example/UploadControllerSpec.groovy
@@ -30,7 +30,7 @@ class UploadControllerSpec extends Specification implements TestPropertyProvider
 
     @Shared
     @AutoCleanup
-    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
+    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE).asCompatibleSubstituteFor("localstack/localstack"))
             .withServices("s3")
 
     @Inject

--- a/doc-examples/example-kotlin/src/test/groovy/example/ProfileServiceSpec.groovy
+++ b/doc-examples/example-kotlin/src/test/groovy/example/ProfileServiceSpec.groovy
@@ -27,7 +27,7 @@ class ProfileServiceSpec extends Specification implements TestPropertyProvider {
 
     @Shared
     @AutoCleanup
-    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
+    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE).asCompatibleSubstituteFor("localstack/localstack"))
             .withServices("s3")
 
     @Inject

--- a/doc-examples/example-kotlin/src/test/groovy/example/UploadControllerSpec.groovy
+++ b/doc-examples/example-kotlin/src/test/groovy/example/UploadControllerSpec.groovy
@@ -31,7 +31,7 @@ class UploadControllerSpec extends Specification implements TestPropertyProvider
 
     @Shared
     @AutoCleanup
-    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
+    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE).asCompatibleSubstituteFor("localstack/localstack"))
             .withServices("s3")
 
     @Inject

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3BucketLocalStackSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3BucketLocalStackSpec.groovy
@@ -14,7 +14,7 @@ import static io.micronaut.objectstorage.test.ObjectStorageTestConstants.LOCAL_S
 class AwsS3BucketLocalStackSpec extends AbstractAwsS3BucketSpec {
     @Shared
     @AutoCleanup
-    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
+    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE).asCompatibleSubstituteFor("localstack/localstack"))
             .withServices("s3")
 
     @Override

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3LegacyListObjectsSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3LegacyListObjectsSpec.groovy
@@ -16,7 +16,7 @@ class AwsS3LegacyListObjectsSpec extends AbstractAwsS3Spec implements TestProper
 
     @Shared
     @AutoCleanup
-    LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
+    LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE).asCompatibleSubstituteFor("localstack/localstack"))
         .withServices("s3")
 
     @Override

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3OperationsLocalstackSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3OperationsLocalstackSpec.groovy
@@ -14,7 +14,7 @@ class AwsS3OperationsLocalstackSpec extends AbstractAwsS3Spec implements TestPro
 
     @Shared
     @AutoCleanup
-    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
+    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE).asCompatibleSubstituteFor("localstack/localstack"))
             .withServices("s3")
 
     @Override

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3PaginationSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3PaginationSpec.groovy
@@ -16,7 +16,7 @@ class AwsS3PaginationSpec extends AbstractAwsS3Spec implements TestPropertyProvi
 
     @Shared
     @AutoCleanup
-    LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
+    LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE).asCompatibleSubstituteFor("localstack/localstack"))
         .withServices("s3")
 
     @Override

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3ReactiveOperationsLocalstackSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3ReactiveOperationsLocalstackSpec.groovy
@@ -14,7 +14,7 @@ class AwsS3ReactiveOperationsLocalstackSpec extends AbstractAwsS3ReactiveSpec im
 
     @Shared
     @AutoCleanup
-    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE))
+    public LocalStackContainer localstack = new LocalStackContainer(DockerImageName.parse(LOCAL_STACK_DOCKER_IMAGE).asCompatibleSubstituteFor("localstack/localstack"))
         .withServices("s3")
 
     @Override

--- a/test-suite-utils/src/main/java/io/micronaut/objectstorage/test/ObjectStorageTestConstants.java
+++ b/test-suite-utils/src/main/java/io/micronaut/objectstorage/test/ObjectStorageTestConstants.java
@@ -16,7 +16,7 @@
 package io.micronaut.objectstorage.test;
 
 public final class ObjectStorageTestConstants {
-    public static final String LOCAL_STACK_DOCKER_IMAGE = "localstack/localstack:4.14.0";
+    public static final String LOCAL_STACK_DOCKER_IMAGE = "localstack/localstack:4.14.0@sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a";
     private ObjectStorageTestConstants() {
 
     }


### PR DESCRIPTION
## Summary
- pin the shared LocalStack test image to an immutable digest in `test-suite-utils`
- update each `LocalStackContainer` site to treat the digest-pinned ref as a compatible substitute for `localstack/localstack`
- keep the AWS and doc-example LocalStack suites on one immutable image reference

## Verification
- ./gradlew :micronaut-object-storage-aws:test --tests 'io.micronaut.objectstorage.aws.AwsS3OperationsLocalstackSpec' --tests 'io.micronaut.objectstorage.aws.AwsS3ReactiveOperationsLocalstackSpec' --tests 'io.micronaut.objectstorage.aws.AwsS3PaginationSpec' --tests 'io.micronaut.objectstorage.aws.AwsS3LegacyListObjectsSpec' --tests 'io.micronaut.objectstorage.aws.AwsS3BucketLocalStackSpec' :micronaut-doc-examples:micronaut-example-java:test --tests 'example.ProfileServiceSpec' --tests 'example.UploadControllerSpec' :micronaut-doc-examples:micronaut-example-groovy:test --tests 'example.ProfileServiceSpec' --tests 'example.UploadControllerSpec' :micronaut-doc-examples:micronaut-example-kotlin:test --tests 'example.ProfileServiceSpec' --tests 'example.UploadControllerSpec'