### PR TITLE
Add local multipart upload support

### DIFF
--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalCompletedMultipartUploadRequest.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalCompletedMultipartUploadRequest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.local;
+
+import io.micronaut.objectstorage.ObjectStorageException;
+import io.micronaut.objectstorage.request.FileUploadRequest;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Map;
+
+final class LocalCompletedMultipartUploadRequest extends FileUploadRequest {
+
+    @NonNull
+    private final Path path;
+
+    LocalCompletedMultipartUploadRequest(@NonNull String keyName,
+                                         @Nullable String contentType,
+                                         @NonNull Path path,
+                                         @NonNull Map<String, String> metadata) {
+        super(keyName, contentType, path, metadata);
+        this.path = path;
+    }
+
+    @Override
+    @NonNull
+    public InputStream getInputStream() {
+        try {
+            return LocalStorageIoSupport.newInputStreamNoFollow(path);
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error reading completed multipart file: " + path, e);
+        }
+    }
+}

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageLayout.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageLayout.java
@@ -86,8 +86,7 @@ final class LocalStorageLayout {
     }
 
     Path objectMetadataBucketRoot(String name) {
-        LocalStorageIoSupport.resolveBucketPath(requireBucketRoot("object metadata cleanup"), name);
-        return objectMetadataRoot().resolve(name);
+        return providerManagedBucketDirectory(name, objectMetadataRoot(), "object metadata cleanup");
     }
 
     Path objectMetadataFile(String key) {
@@ -127,10 +126,11 @@ final class LocalStorageLayout {
     }
 
     Path snapshotBucketDirectory(String name) {
-        LocalStorageIoSupport.resolveBucketPath(requireBucketRoot("snapshot cleanup"), name);
-        return rootInternalDirectory()
-            .resolve(SNAPSHOT_DIRECTORY)
-            .resolve(name);
+        return providerManagedBucketDirectory(
+            name,
+            rootInternalDirectory().resolve(SNAPSHOT_DIRECTORY),
+            "snapshot cleanup"
+        );
     }
 
     Path multipartBucketDirectory() {
@@ -142,10 +142,11 @@ final class LocalStorageLayout {
     }
 
     Path multipartBucketDirectory(String name) {
-        LocalStorageIoSupport.resolveBucketPath(requireBucketRoot("multipart upload cleanup"), name);
-        return rootInternalDirectory()
-            .resolve(MULTIPART_DIRECTORY)
-            .resolve(name);
+        return providerManagedBucketDirectory(
+            name,
+            rootInternalDirectory().resolve(MULTIPART_DIRECTORY),
+            "multipart upload cleanup"
+        );
     }
 
     List<Path> multipartCleanupDirectories() {
@@ -178,6 +179,13 @@ final class LocalStorageLayout {
         Path metadataRoot = bucketPath.resolve(LEGACY_METADATA_DIRECTORY);
         LocalStorageIoSupport.rejectSymbolicLinks(bucketPath.normalize(), metadataRoot.normalize());
         return LocalStorageIoSupport.resolveSafe(metadataRoot, key);
+    }
+
+    private Path providerManagedBucketDirectory(String name, Path root, String component) {
+        requireBucketRoot(component);
+        Path bucketDirectory = LocalStorageIoSupport.resolveBucketPath(root, name);
+        LocalStorageIoSupport.rejectSymbolicLinks(storageRoot, bucketDirectory);
+        return bucketDirectory;
     }
 
     static Optional<String> reservedLocalStorageNamespace(String name) {

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageLayout.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageLayout.java
@@ -26,6 +26,7 @@ final class LocalStorageLayout {
     static final String METADATA_DIRECTORY = "metadata";
     static final String OBJECTS_DIRECTORY = "objects";
     static final String BUCKETS_DIRECTORY = "buckets";
+    static final String MULTIPART_DIRECTORY = "multipart";
     static final String SNAPSHOT_DIRECTORY = "snapshots";
 
     private final Path bucketPath;
@@ -132,9 +133,34 @@ final class LocalStorageLayout {
             .resolve(name);
     }
 
+    Path multipartBucketDirectory() {
+        Path multipartBucketDirectory = rootInternalDirectory()
+            .resolve(MULTIPART_DIRECTORY)
+            .resolve(bucketName);
+        LocalStorageIoSupport.rejectSymbolicLinks(storageRoot, multipartBucketDirectory);
+        return multipartBucketDirectory;
+    }
+
+    Path multipartBucketDirectory(String name) {
+        LocalStorageIoSupport.resolveBucketPath(requireBucketRoot("multipart upload cleanup"), name);
+        return rootInternalDirectory()
+            .resolve(MULTIPART_DIRECTORY)
+            .resolve(name);
+    }
+
+    List<Path> multipartCleanupDirectories() {
+        Path multipartBucketDirectory = multipartBucketDirectory();
+        return List.of(
+            multipartBucketDirectory,
+            multipartBucketDirectory.getParent(),
+            rootInternalDirectory()
+        );
+    }
+
     List<Path> providerManagedBucketDirectories(String name) {
         return List.of(
             objectMetadataBucketRoot(name),
+            multipartBucketDirectory(name),
             snapshotBucketDirectory(name)
         );
     }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartContinuationTokens.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartContinuationTokens.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.local;
+
+import io.micronaut.objectstorage.ObjectStorageException;
+import io.micronaut.objectstorage.multipart.ListMultipartPartsRequest;
+import io.micronaut.objectstorage.multipart.MultipartUploadHandle;
+import org.jspecify.annotations.NonNull;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.StringJoiner;
+
+final class LocalStorageMultipartContinuationTokens {
+
+    private static final String MULTIPART_CONTINUATION_TOKEN_PREFIX = "local-multipart:v1:";
+
+    private LocalStorageMultipartContinuationTokens() {
+    }
+
+    static Optional<Integer> decode(ListMultipartPartsRequest request) {
+        String continuationToken = request.getContinuationToken().orElse(null);
+        if (continuationToken == null || continuationToken.isEmpty()) {
+            return Optional.empty();
+        }
+        try {
+            Token decodedToken = Token.decode(continuationToken);
+            if (!decodedToken.matches(request)) {
+                throw new ObjectStorageException("Local multipart continuation token does not match the current request");
+            }
+            return Optional.of(decodedToken.partNumberMarker());
+        } catch (IllegalArgumentException e) {
+            throw new ObjectStorageException("Invalid local multipart continuation token", e);
+        }
+    }
+
+    static String encode(ListMultipartPartsRequest request, int partNumberMarker) {
+        MultipartUploadHandle upload = request.getUpload();
+        String payload = new StringJoiner("\n")
+            .add(encodeTokenPart(upload.getKey()))
+            .add(encodeTokenPart(upload.getUploadId()))
+            .add(encodeTokenPart(Integer.toString(request.getPageSize())))
+            .add(encodeTokenPart(Integer.toString(partNumberMarker)))
+            .toString();
+        return MULTIPART_CONTINUATION_TOKEN_PREFIX + Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String encodeTokenPart(String value) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String decodeTokenPart(String value) {
+        return new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8);
+    }
+
+    private static ObjectStorageException invalidMultipartContinuationToken() {
+        return new ObjectStorageException("Invalid local multipart continuation token");
+    }
+
+    private record Token(@NonNull String key,
+                         @NonNull String uploadId,
+                         int pageSize,
+                         int partNumberMarker) {
+
+        private static Token decode(String continuationToken) {
+            if (!continuationToken.startsWith(MULTIPART_CONTINUATION_TOKEN_PREFIX)) {
+                throw invalidMultipartContinuationToken();
+            }
+            String decodedToken = new String(
+                Base64.getUrlDecoder().decode(continuationToken.substring(MULTIPART_CONTINUATION_TOKEN_PREFIX.length())),
+                StandardCharsets.UTF_8
+            );
+            String[] parts = decodedToken.split("\n", -1);
+            if (parts.length != 4) {
+                throw invalidMultipartContinuationToken();
+            }
+            int partNumberMarker = Integer.parseInt(decodeTokenPart(parts[3]));
+            if (partNumberMarker <= 0) {
+                throw invalidMultipartContinuationToken();
+            }
+            return new Token(
+                decodeTokenPart(parts[0]),
+                decodeTokenPart(parts[1]),
+                Integer.parseInt(decodeTokenPart(parts[2])),
+                partNumberMarker
+            );
+        }
+
+        private boolean matches(ListMultipartPartsRequest request) {
+            MultipartUploadHandle upload = request.getUpload();
+            return upload.getKey().equals(key)
+                && upload.getUploadId().equals(uploadId)
+                && request.getPageSize() == pageSize;
+        }
+    }
+}

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartOperations.java
@@ -74,7 +74,7 @@ import java.util.stream.Stream;
 @Requires(beans = LocalStorageOperations.class)
 @Primary
 final class LocalStorageMultipartOperations implements MultipartObjectStorageOperations<
-    LocalStorageMultipartOperations.LocalMultipartUpload,
+    LocalStorageMultipartUpload,
     LocalStorageOperations.LocalStorageFile,
     LocalStorageOperations.LocalStorageFile> {
 
@@ -82,6 +82,7 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
 
     private static final String MULTIPART_PARTS_DIRECTORY = "parts";
     private static final String MULTIPART_UPLOAD_PROPERTIES = "upload.properties";
+    private static final String MULTIPART_COMPLETED_PROPERTIES = "completed.properties";
     private static final String MULTIPART_PART_EXTENSION = ".part";
     private static final String MULTIPART_PART_PROPERTIES_EXTENSION = ".properties";
     private static final String MULTIPART_COMPLETE_FILE_SUFFIX = ".complete";
@@ -106,7 +107,7 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
 
     @Override
     @NonNull
-    public CreateMultipartUploadResponse<LocalMultipartUpload> createMultipartUpload(@NonNull CreateMultipartUploadRequest request) {
+    public CreateMultipartUploadResponse<LocalStorageMultipartUpload> createMultipartUpload(@NonNull CreateMultipartUploadRequest request) {
         layout.objectPath(request.getKey());
         String uploadId = UUID.randomUUID().toString();
         Path uploadPath = multipartUploadPath(uploadId);
@@ -125,7 +126,7 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
         }
         return CreateMultipartUploadResponse.of(
             new MultipartUploadHandle(request.getKey(), uploadId),
-            new LocalMultipartUpload(uploadPath)
+            new LocalStorageMultipartUpload(uploadPath)
         );
     }
 
@@ -136,6 +137,7 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
         int partNumber = request.getPartNumber();
         Path partsPath = multipartPartsPath(session.path());
         Path partPropertiesFile = multipartPartPropertiesPath(session.path(), partNumber);
+        String previousPartFileName = retrieveCurrentPartFileName(session.path(), partPropertiesFile, partNumber).orElse(null);
         if (!mkdirs(partsPath)) {
             throw new ObjectStorageException("Error creating local multipart part directories: " + partsPath);
         }
@@ -156,7 +158,6 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
             properties.setProperty(MULTIPART_PART_SIZE_PROPERTY, Long.toString(partSize));
             properties.setProperty(MULTIPART_PART_FILE_PROPERTY, partFileName);
             storeRequiredProperties(temporaryPartPropertiesFile, properties);
-            String previousPartFileName = retrieveCurrentPartFileName(partPropertiesFile).orElse(null);
             moveReplacing(temporaryPartFile, partFile);
             partFileCommitted = true;
             moveReplacing(temporaryPartPropertiesFile, partPropertiesFile);
@@ -208,6 +209,7 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
                 session.metadata()
             );
             var uploadResponse = objectStorageOperations.upload(uploadRequest);
+            markMultipartUploadCompleted(session.path());
             deleteMultipartUploadAfterCompletion(session.path());
             return CompleteMultipartUploadResponse.of(upload, uploadResponse.getETag(), uploadResponse.getNativeResponse());
         } catch (RuntimeException e) {
@@ -220,16 +222,17 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
     public void abortMultipartUpload(@NonNull AbortMultipartUploadRequest request) {
         MultipartUploadHandle upload = request.getUpload();
         Path uploadPath = multipartUploadPath(upload.getUploadId());
-        Path propertiesPath = uploadPath.resolve(MULTIPART_UPLOAD_PROPERTIES);
-        if (Files.exists(propertiesPath, LinkOption.NOFOLLOW_LINKS)) {
-            validateUploadSessionKey(upload, retrieveRequiredProperties(propertiesPath));
-        }
+        retrieveAbortProperties(uploadPath).ifPresent(properties -> validateUploadSessionKey(upload, properties));
         deleteMultipartUpload(uploadPath);
     }
 
     @NonNull
     private UploadSession retrieveUploadSession(@NonNull MultipartUploadHandle upload) {
         Path uploadPath = multipartUploadPath(upload.getUploadId());
+        Path completedPropertiesPath = uploadPath.resolve(MULTIPART_COMPLETED_PROPERTIES);
+        if (Files.exists(completedPropertiesPath, LinkOption.NOFOLLOW_LINKS)) {
+            throw new ObjectStorageException("Local multipart upload is already completed: " + upload.getUploadId());
+        }
         Path propertiesPath = uploadPath.resolve(MULTIPART_UPLOAD_PROPERTIES);
         if (!Files.exists(propertiesPath, LinkOption.NOFOLLOW_LINKS)) {
             throw new ObjectStorageException("Local multipart upload does not exist: " + upload.getUploadId());
@@ -413,15 +416,16 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
         }
     }
 
-    private Optional<String> retrieveCurrentPartFileName(Path propertiesPath) {
+    private Optional<String> retrieveCurrentPartFileName(Path uploadPath, Path propertiesPath, int partNumber) {
         if (!Files.exists(propertiesPath, LinkOption.NOFOLLOW_LINKS)) {
             return Optional.empty();
         }
-        try {
-            return Optional.ofNullable(retrieveRequiredProperties(propertiesPath).getProperty(MULTIPART_PART_FILE_PROPERTY));
-        } catch (RuntimeException e) {
-            return Optional.empty();
+        String partFileName = retrieveRequiredProperties(propertiesPath).getProperty(MULTIPART_PART_FILE_PROPERTY);
+        if (partFileName == null) {
+            throw new ObjectStorageException("Local multipart part metadata is incomplete: " + partNumber);
         }
+        multipartPartDataPath(uploadPath, partFileName);
+        return Optional.of(partFileName);
     }
 
     private void deleteStalePartFile(Path uploadPath, @Nullable String previousPartFileName, String currentPartFileName) {
@@ -438,11 +442,13 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
     }
 
     private void storeFile(Path file, InputStream inputStream) {
-        if (!mkdirs(file.getParent())) {
-            throw new ObjectStorageException("Error creating local multipart part directories: " + file);
-        }
-        try (OutputStream fileOut = LocalStorageIoSupport.newOutputStreamNoFollow(file, supportsPosixPermissions)) {
-            inputStream.transferTo(fileOut);
+        try (InputStream in = inputStream) {
+            if (!mkdirs(file.getParent())) {
+                throw new ObjectStorageException("Error creating local multipart part directories: " + file);
+            }
+            try (OutputStream fileOut = LocalStorageIoSupport.newOutputStreamNoFollow(file, supportsPosixPermissions)) {
+                in.transferTo(fileOut);
+            }
         } catch (IOException e) {
             throw new ObjectStorageException("Error copying multipart part to: " + file, e);
         }
@@ -483,6 +489,33 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
         }
     }
 
+    private Optional<Properties> retrieveAbortProperties(Path uploadPath) {
+        Optional<Properties> activeProperties = retrievePropertiesIfExists(uploadPath.resolve(MULTIPART_UPLOAD_PROPERTIES));
+        if (activeProperties.isPresent()) {
+            return activeProperties;
+        }
+        return retrievePropertiesIfExists(uploadPath.resolve(MULTIPART_COMPLETED_PROPERTIES));
+    }
+
+    private Optional<Properties> retrievePropertiesIfExists(Path propertiesPath) {
+        Properties properties = new Properties();
+        try (InputStream in = LocalStorageIoSupport.newInputStreamNoFollow(propertiesPath)) {
+            properties.load(in);
+            return Optional.of(properties);
+        } catch (NoSuchFileException e) {
+            return Optional.empty();
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error reading local multipart metadata: " + propertiesPath, e);
+        }
+    }
+
+    private void markMultipartUploadCompleted(Path uploadPath) {
+        moveReplacing(
+            uploadPath.resolve(MULTIPART_UPLOAD_PROPERTIES),
+            uploadPath.resolve(MULTIPART_COMPLETED_PROPERTIES)
+        );
+    }
+
     private Path createTempFile(Path directory, String prefix, String suffix) {
         try {
             return LocalStorageIoSupport.createTempFile(directory, prefix, suffix, supportsPosixPermissions);
@@ -516,11 +549,37 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
 
     private void deleteMultipartUploadAfterCompletion(Path uploadPath) {
         try {
-            deleteMultipartUpload(uploadPath);
+            deleteCompletedMultipartUpload(uploadPath);
         } catch (RuntimeException e) {
             if (LOG.isWarnEnabled()) {
                 LOG.warn("Error deleting completed local multipart upload: {}", uploadPath, e);
             }
+        }
+    }
+
+    private void deleteCompletedMultipartUpload(Path uploadPath) {
+        try {
+            Path completedPropertiesPath = uploadPath.resolve(MULTIPART_COMPLETED_PROPERTIES);
+            try (Stream<Path> stream = Files.list(uploadPath)) {
+                for (Path path : stream.filter(path -> !path.equals(completedPropertiesPath)).toList()) {
+                    deleteRecursivelyOrFile(path);
+                }
+            }
+            Files.deleteIfExists(completedPropertiesPath);
+            Files.deleteIfExists(uploadPath);
+        } catch (NoSuchFileException ignored) {
+            // A concurrent abort or cleanup may have already removed the completed session.
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error deleting local multipart upload: " + uploadPath, e);
+        }
+        deleteEmptyMultipartDirectories(null);
+    }
+
+    private void deleteRecursivelyOrFile(Path path) throws IOException {
+        if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+            LocalStorageBucketOperations.deleteRecursively(path);
+        } else {
+            Files.delete(path);
         }
     }
 
@@ -563,9 +622,6 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
     @Nullable
     private static String nullIfEmpty(@Nullable String value) {
         return value == null || value.isEmpty() ? null : value;
-    }
-
-    record LocalMultipartUpload(@NonNull Path path) {
     }
 
     private record UploadSession(@NonNull Path path,

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartOperations.java
@@ -33,7 +33,7 @@ import io.micronaut.objectstorage.multipart.MultipartPart;
 import io.micronaut.objectstorage.multipart.MultipartUploadHandle;
 import io.micronaut.objectstorage.multipart.UploadPartRequest;
 import io.micronaut.objectstorage.multipart.UploadPartResponse;
-import io.micronaut.objectstorage.request.UploadRequest;
+import io.micronaut.objectstorage.request.FileUploadRequest;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -201,11 +201,11 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
         UploadSession session = retrieveUploadSession(upload);
         Path completedFile = buildCompletedMultipartFile(session.path(), request.getParts(), upload.getUploadId());
         try {
-            LocalMultipartUploadRequest uploadRequest = new LocalMultipartUploadRequest(
+            var uploadRequest = new LocalCompletedMultipartUploadRequest(
                 upload.getKey(),
+                session.contentType(),
                 completedFile,
-                session.metadata(),
-                session.contentType()
+                session.metadata()
             );
             var uploadResponse = objectStorageOperations.upload(uploadRequest);
             deleteMultipartUploadAfterCompletion(session.path());
@@ -327,32 +327,11 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
             return Optional.empty();
         }
         try {
-            if (!continuationToken.startsWith(MULTIPART_CONTINUATION_TOKEN_PREFIX)) {
-                throw new ObjectStorageException("Invalid local multipart continuation token");
-            }
-            String decodedToken = new String(
-                Base64.getUrlDecoder().decode(continuationToken.substring(MULTIPART_CONTINUATION_TOKEN_PREFIX.length())),
-                StandardCharsets.UTF_8
-            );
-            String[] parts = decodedToken.split("\n", -1);
-            if (parts.length != 4) {
-                throw new ObjectStorageException("Invalid local multipart continuation token");
-            }
-            MultipartUploadHandle upload = request.getUpload();
-            String key = decodeTokenPart(parts[0]);
-            String uploadId = decodeTokenPart(parts[1]);
-            String pageSize = decodeTokenPart(parts[2]);
-            String partNumberMarker = decodeTokenPart(parts[3]);
-            if (!upload.getKey().equals(key)
-                || !upload.getUploadId().equals(uploadId)
-                || !Integer.toString(request.getPageSize()).equals(pageSize)) {
+            LocalMultipartContinuationToken decodedToken = LocalMultipartContinuationToken.decode(continuationToken);
+            if (!decodedToken.matches(request)) {
                 throw new ObjectStorageException("Local multipart continuation token does not match the current request");
             }
-            int marker = Integer.parseInt(partNumberMarker);
-            if (marker <= 0) {
-                throw new ObjectStorageException("Invalid local multipart continuation token");
-            }
-            return Optional.of(marker);
+            return Optional.of(decodedToken.partNumberMarker());
         } catch (IllegalArgumentException e) {
             throw new ObjectStorageException("Invalid local multipart continuation token", e);
         }
@@ -370,12 +349,16 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
             .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
     }
 
-    private String encodeTokenPart(String value) {
+    private static String encodeTokenPart(String value) {
         return Base64.getUrlEncoder().withoutPadding().encodeToString(value.getBytes(StandardCharsets.UTF_8));
     }
 
-    private String decodeTokenPart(String value) {
+    private static String decodeTokenPart(String value) {
         return new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8);
+    }
+
+    private static ObjectStorageException invalidMultipartContinuationToken() {
+        return new ObjectStorageException("Invalid local multipart continuation token");
     }
 
     private Path multipartUploadPath(String uploadId) {
@@ -594,31 +577,54 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
                                        @NonNull Path path) {
     }
 
-    private record LocalMultipartUploadRequest(@NonNull String key,
-                                               @NonNull Path path,
-                                               @NonNull Map<String, String> metadata,
-                                               @Nullable String contentType) implements UploadRequest {
+    private record LocalMultipartContinuationToken(@NonNull String key,
+                                                   @NonNull String uploadId,
+                                                   int pageSize,
+                                                   int partNumberMarker) {
 
-        @Override
-        @NonNull
-        public Optional<String> getContentType() {
-            return Optional.ofNullable(contentType);
-        }
-
-        @Override
-        @NonNull
-        public String getKey() {
-            return key;
-        }
-
-        @Override
-        @NonNull
-        public Optional<Long> getContentSize() {
-            try {
-                return Optional.of(Files.size(path));
-            } catch (IOException e) {
-                throw new ObjectStorageException("Error reading completed multipart file size: " + path, e);
+        private static LocalMultipartContinuationToken decode(String continuationToken) {
+            if (!continuationToken.startsWith(MULTIPART_CONTINUATION_TOKEN_PREFIX)) {
+                throw invalidMultipartContinuationToken();
             }
+            String decodedToken = new String(
+                Base64.getUrlDecoder().decode(continuationToken.substring(MULTIPART_CONTINUATION_TOKEN_PREFIX.length())),
+                StandardCharsets.UTF_8
+            );
+            String[] parts = decodedToken.split("\n", -1);
+            if (parts.length != 4) {
+                throw invalidMultipartContinuationToken();
+            }
+            int partNumberMarker = Integer.parseInt(decodeTokenPart(parts[3]));
+            if (partNumberMarker <= 0) {
+                throw invalidMultipartContinuationToken();
+            }
+            return new LocalMultipartContinuationToken(
+                decodeTokenPart(parts[0]),
+                decodeTokenPart(parts[1]),
+                Integer.parseInt(decodeTokenPart(parts[2])),
+                partNumberMarker
+            );
+        }
+
+        private boolean matches(ListMultipartPartsRequest request) {
+            MultipartUploadHandle upload = request.getUpload();
+            return upload.getKey().equals(key)
+                && upload.getUploadId().equals(uploadId)
+                && request.getPageSize() == pageSize;
+        }
+    }
+
+    private static final class LocalCompletedMultipartUploadRequest extends FileUploadRequest {
+
+        @NonNull
+        private final Path path;
+
+        private LocalCompletedMultipartUploadRequest(@NonNull String keyName,
+                                                     @Nullable String contentType,
+                                                     @NonNull Path path,
+                                                     @NonNull Map<String, String> metadata) {
+            super(keyName, contentType, path, metadata);
+            this.path = path;
         }
 
         @Override
@@ -629,12 +635,6 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
             } catch (IOException e) {
                 throw new ObjectStorageException("Error reading completed multipart file: " + path, e);
             }
-        }
-
-        @Override
-        @NonNull
-        public Map<String, String> getMetadata() {
-            return metadata;
         }
     }
 }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartOperations.java
@@ -19,7 +19,6 @@ import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.objectstorage.ObjectStorageException;
 import io.micronaut.objectstorage.configuration.ToggeableCondition;
 import io.micronaut.objectstorage.multipart.AbortMultipartUploadRequest;
 import io.micronaut.objectstorage.multipart.CompleteMultipartUploadRequest;
@@ -33,39 +32,16 @@ import io.micronaut.objectstorage.multipart.MultipartPart;
 import io.micronaut.objectstorage.multipart.MultipartUploadHandle;
 import io.micronaut.objectstorage.multipart.UploadPartRequest;
 import io.micronaut.objectstorage.multipart.UploadPartResponse;
-import io.micronaut.objectstorage.request.FileUploadRequest;
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.AtomicMoveNotSupportedException;
-import java.nio.file.DirectoryNotEmptyException;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.StringJoiner;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 /**
  * Local multipart upload operations.
  *
- * @author Álvaro Sánchez-Mariscal
+ * @author Ayoub Ait Abdellah
  * @since 3.1.0
  */
 @EachBean(LocalStorageConfiguration.class)
@@ -78,52 +54,21 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
     LocalStorageOperations.LocalStorageFile,
     LocalStorageOperations.LocalStorageFile> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(LocalStorageMultipartOperations.class);
-
-    private static final String MULTIPART_PARTS_DIRECTORY = "parts";
-    private static final String MULTIPART_UPLOAD_PROPERTIES = "upload.properties";
-    private static final String MULTIPART_COMPLETED_PROPERTIES = "completed.properties";
-    private static final String MULTIPART_PART_EXTENSION = ".part";
-    private static final String MULTIPART_PART_PROPERTIES_EXTENSION = ".properties";
-    private static final String MULTIPART_COMPLETE_FILE_SUFFIX = ".complete";
-    private static final String MULTIPART_CONTINUATION_TOKEN_PREFIX = "local-multipart:v1:";
-    private static final String MULTIPART_KEY_PROPERTY = "key";
-    private static final String MULTIPART_CONTENT_TYPE_PROPERTY = "contentType";
-    private static final String MULTIPART_METADATA_PREFIX = "metadata.";
-    private static final String MULTIPART_PART_ETAG_PROPERTY = "eTag";
-    private static final String MULTIPART_PART_SIZE_PROPERTY = "size";
-    private static final String MULTIPART_PART_FILE_PROPERTY = "file";
-
-    private final LocalStorageLayout layout;
     private final LocalStorageOperations objectStorageOperations;
-    private final boolean supportsPosixPermissions;
+    private final LocalStorageMultipartUploadState uploadState;
 
     LocalStorageMultipartOperations(@Parameter LocalStorageConfiguration configuration,
                                     LocalStorageOperations objectStorageOperations) {
-        this.layout = new LocalStorageLayout(configuration);
+        LocalStorageLayout layout = new LocalStorageLayout(configuration);
         this.objectStorageOperations = objectStorageOperations;
-        this.supportsPosixPermissions = layout.storageRoot().getFileSystem().supportedFileAttributeViews().contains("posix");
+        this.uploadState = new LocalStorageMultipartUploadState(layout);
     }
 
     @Override
     @NonNull
     public CreateMultipartUploadResponse<LocalStorageMultipartUpload> createMultipartUpload(@NonNull CreateMultipartUploadRequest request) {
-        layout.objectPath(request.getKey());
         String uploadId = UUID.randomUUID().toString();
-        Path uploadPath = multipartUploadPath(uploadId);
-        if (!mkdirs(uploadPath)) {
-            throw new ObjectStorageException("Error creating local multipart upload: " + uploadId);
-        }
-        Properties properties = new Properties();
-        properties.setProperty(MULTIPART_KEY_PROPERTY, request.getKey());
-        request.getContentType().ifPresent(contentType -> properties.setProperty(MULTIPART_CONTENT_TYPE_PROPERTY, contentType));
-        request.getMetadata().forEach((key, value) -> properties.setProperty(MULTIPART_METADATA_PREFIX + key, value));
-        try {
-            storeRequiredProperties(uploadPath.resolve(MULTIPART_UPLOAD_PROPERTIES), properties);
-        } catch (RuntimeException e) {
-            deleteRecursively(uploadPath, e);
-            throw e;
-        }
+        Path uploadPath = uploadState.createUpload(request, uploadId);
         return CreateMultipartUploadResponse.of(
             new MultipartUploadHandle(request.getKey(), uploadId),
             new LocalStorageMultipartUpload(uploadPath)
@@ -133,56 +78,24 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
     @Override
     @NonNull
     public UploadPartResponse<LocalStorageOperations.LocalStorageFile> uploadPart(@NonNull UploadPartRequest request) {
-        UploadSession session = retrieveUploadSession(request.getUpload());
-        int partNumber = request.getPartNumber();
-        Path partsPath = multipartPartsPath(session.path());
-        Path partPropertiesFile = multipartPartPropertiesPath(session.path(), partNumber);
-        String previousPartFileName = retrieveCurrentPartFileName(session.path(), partPropertiesFile, partNumber).orElse(null);
-        if (!mkdirs(partsPath)) {
-            throw new ObjectStorageException("Error creating local multipart part directories: " + partsPath);
-        }
-        String eTag = UUID.randomUUID().toString();
-        String partFileName = partNumber + "-" + eTag + MULTIPART_PART_EXTENSION;
-        Path partFile = multipartPartDataPath(session.path(), partFileName);
-        Path temporaryPartFile = null;
-        Path temporaryPartPropertiesFile = null;
-        boolean partFileCommitted = false;
-        boolean propertiesCommitted = false;
-        try {
-            temporaryPartFile = createTempFile(partsPath, partNumber + "-", MULTIPART_PART_EXTENSION + ".tmp");
-            temporaryPartPropertiesFile = createTempFile(partsPath, partNumber + "-", MULTIPART_PART_PROPERTIES_EXTENSION + ".tmp");
-            storeFile(temporaryPartFile, request.getUploadRequest().getInputStream());
-            long partSize = size(temporaryPartFile);
-            Properties properties = new Properties();
-            properties.setProperty(MULTIPART_PART_ETAG_PROPERTY, eTag);
-            properties.setProperty(MULTIPART_PART_SIZE_PROPERTY, Long.toString(partSize));
-            properties.setProperty(MULTIPART_PART_FILE_PROPERTY, partFileName);
-            storeRequiredProperties(temporaryPartPropertiesFile, properties);
-            moveReplacing(temporaryPartFile, partFile);
-            partFileCommitted = true;
-            moveReplacing(temporaryPartPropertiesFile, partPropertiesFile);
-            propertiesCommitted = true;
-            deleteStalePartFile(session.path(), previousPartFileName, partFileName);
-            return UploadPartResponse.of(
-                new MultipartPart(partNumber, eTag, partSize),
-                new LocalStorageOperations.LocalStorageFile(partFile)
-            );
-        } catch (RuntimeException e) {
-            deleteIfExists(temporaryPartFile, e);
-            deleteIfExists(temporaryPartPropertiesFile, e);
-            if (partFileCommitted && !propertiesCommitted) {
-                deleteIfExists(partFile, e);
-            }
-            throw e;
-        }
+        LocalStorageMultipartUploadState.UploadSession session = uploadState.retrieveUploadSession(request.getUpload());
+        LocalStorageMultipartUploadState.StoredMultipartPart storedPart = uploadState.storePart(
+            session.path(),
+            request.getPartNumber(),
+            request.getUploadRequest().getInputStream()
+        );
+        return UploadPartResponse.of(
+            storedPart.part(),
+            new LocalStorageOperations.LocalStorageFile(storedPart.path())
+        );
     }
 
     @Override
     @NonNull
     public ListMultipartPartsResponse listParts(@NonNull ListMultipartPartsRequest request) {
-        UploadSession session = retrieveUploadSession(request.getUpload());
-        int partNumberMarker = decodeMultipartContinuationToken(request).orElse(0);
-        List<MultipartPart> parts = retrieveMultipartParts(session.path()).stream()
+        LocalStorageMultipartUploadState.UploadSession session = uploadState.retrieveUploadSession(request.getUpload());
+        int partNumberMarker = LocalStorageMultipartContinuationTokens.decode(request).orElse(0);
+        List<MultipartPart> parts = uploadState.retrieveMultipartParts(session.path()).stream()
             .filter(part -> part.getPartNumber() > partNumberMarker)
             .limit((long) request.getPageSize() + 1)
             .toList();
@@ -191,7 +104,7 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
         }
         List<MultipartPart> page = parts.subList(0, request.getPageSize());
         MultipartPart lastPart = page.get(page.size() - 1);
-        return new ListMultipartPartsResponse(page, encodeMultipartContinuationToken(request, lastPart.getPartNumber()));
+        return new ListMultipartPartsResponse(page, LocalStorageMultipartContinuationTokens.encode(request, lastPart.getPartNumber()));
     }
 
     @Override
@@ -199,8 +112,8 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
     public CompleteMultipartUploadResponse<LocalStorageOperations.LocalStorageFile> completeMultipartUpload(
         @NonNull CompleteMultipartUploadRequest request) {
         MultipartUploadHandle upload = request.getUpload();
-        UploadSession session = retrieveUploadSession(upload);
-        Path completedFile = buildCompletedMultipartFile(session.path(), request.getParts(), upload.getUploadId());
+        LocalStorageMultipartUploadState.UploadSession session = uploadState.retrieveUploadSession(upload);
+        Path completedFile = uploadState.buildCompletedMultipartFile(session.path(), request.getParts(), upload.getUploadId());
         try {
             var uploadRequest = new LocalCompletedMultipartUploadRequest(
                 upload.getKey(),
@@ -209,11 +122,11 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
                 session.metadata()
             );
             var uploadResponse = objectStorageOperations.upload(uploadRequest);
-            markMultipartUploadCompleted(session.path());
-            deleteMultipartUploadAfterCompletion(session.path());
+            uploadState.markMultipartUploadCompleted(session.path());
+            uploadState.deleteMultipartUploadAfterCompletion(session.path());
             return CompleteMultipartUploadResponse.of(upload, uploadResponse.getETag(), uploadResponse.getNativeResponse());
         } catch (RuntimeException e) {
-            deleteIfExists(completedFile, e);
+            uploadState.deleteIfExists(completedFile, e);
             throw e;
         }
     }
@@ -221,476 +134,8 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
     @Override
     public void abortMultipartUpload(@NonNull AbortMultipartUploadRequest request) {
         MultipartUploadHandle upload = request.getUpload();
-        Path uploadPath = multipartUploadPath(upload.getUploadId());
-        retrieveAbortProperties(uploadPath).ifPresent(properties -> validateUploadSessionKey(upload, properties));
-        deleteMultipartUpload(uploadPath);
-    }
-
-    @NonNull
-    private UploadSession retrieveUploadSession(@NonNull MultipartUploadHandle upload) {
-        Path uploadPath = multipartUploadPath(upload.getUploadId());
-        Path completedPropertiesPath = uploadPath.resolve(MULTIPART_COMPLETED_PROPERTIES);
-        if (Files.exists(completedPropertiesPath, LinkOption.NOFOLLOW_LINKS)) {
-            throw new ObjectStorageException("Local multipart upload is already completed: " + upload.getUploadId());
-        }
-        Path propertiesPath = uploadPath.resolve(MULTIPART_UPLOAD_PROPERTIES);
-        if (!Files.exists(propertiesPath, LinkOption.NOFOLLOW_LINKS)) {
-            throw new ObjectStorageException("Local multipart upload does not exist: " + upload.getUploadId());
-        }
-        Properties properties = retrieveRequiredProperties(propertiesPath);
-        validateUploadSessionKey(upload, properties);
-        Map<String, String> metadata = new HashMap<>();
-        for (String name : properties.stringPropertyNames()) {
-            if (name.startsWith(MULTIPART_METADATA_PREFIX)) {
-                metadata.put(name.substring(MULTIPART_METADATA_PREFIX.length()), properties.getProperty(name));
-            }
-        }
-        return new UploadSession(uploadPath, Map.copyOf(metadata), nullIfEmpty(properties.getProperty(MULTIPART_CONTENT_TYPE_PROPERTY)));
-    }
-
-    @NonNull
-    private List<MultipartPart> retrieveMultipartParts(@NonNull Path uploadPath) {
-        Path partsPath = multipartPartsPath(uploadPath);
-        if (!Files.exists(partsPath, LinkOption.NOFOLLOW_LINKS)) {
-            return Collections.emptyList();
-        }
-        try (Stream<Path> stream = Files.list(partsPath)) {
-            return stream
-                .filter(path -> path.getFileName().toString().endsWith(MULTIPART_PART_PROPERTIES_EXTENSION))
-                .map(path -> retrieveMultipartPart(uploadPath, parsePartNumber(path, MULTIPART_PART_PROPERTIES_EXTENSION)))
-                .sorted(Comparator.comparingInt(MultipartPart::getPartNumber))
-                .toList();
-        } catch (IOException e) {
-            throw new ObjectStorageException("Error listing local multipart parts", e);
-        }
-    }
-
-    @NonNull
-    private MultipartPart retrieveMultipartPart(@NonNull Path uploadPath, int partNumber) {
-        return retrieveStoredMultipartPart(uploadPath, partNumber).part();
-    }
-
-    @NonNull
-    private StoredMultipartPart retrieveStoredMultipartPart(@NonNull Path uploadPath, int partNumber) {
-        Path propertiesPath = multipartPartPropertiesPath(uploadPath, partNumber);
-        if (!Files.exists(propertiesPath, LinkOption.NOFOLLOW_LINKS)) {
-            throw new ObjectStorageException("Local multipart part does not exist: " + partNumber);
-        }
-        Properties properties = retrieveRequiredProperties(propertiesPath);
-        String eTag = properties.getProperty(MULTIPART_PART_ETAG_PROPERTY);
-        String size = properties.getProperty(MULTIPART_PART_SIZE_PROPERTY);
-        String partFileName = properties.getProperty(MULTIPART_PART_FILE_PROPERTY);
-        if (eTag == null || size == null || partFileName == null) {
-            throw new ObjectStorageException("Local multipart part metadata is incomplete: " + partNumber);
-        }
-        Path partFile = multipartPartDataPath(uploadPath, partFileName);
-        if (!Files.exists(partFile, LinkOption.NOFOLLOW_LINKS)) {
-            throw new ObjectStorageException("Local multipart part does not exist: " + partNumber);
-        }
-        try {
-            long partSize = Long.parseLong(size);
-            if (size(partFile) != partSize) {
-                throw new ObjectStorageException("Local multipart part size does not match metadata: " + partNumber);
-            }
-            return new StoredMultipartPart(new MultipartPart(partNumber, eTag, partSize), partFile);
-        } catch (NumberFormatException e) {
-            throw new ObjectStorageException("Local multipart part size is invalid: " + partNumber, e);
-        }
-    }
-
-    @NonNull
-    private Path buildCompletedMultipartFile(@NonNull Path uploadPath,
-                                             @NonNull List<MultipartPart> parts,
-                                             @NonNull String uploadId) {
-        Path completedFile = createTempFile(uploadPath, "micronaut-object-storage-local-" + uploadId + "-", MULTIPART_COMPLETE_FILE_SUFFIX);
-        try (OutputStream out = LocalStorageIoSupport.newOutputStreamNoFollow(completedFile, supportsPosixPermissions)) {
-            for (MultipartPart part : parts) {
-                StoredMultipartPart storedPart = retrieveStoredMultipartPart(uploadPath, part.getPartNumber());
-                if (!storedPart.part().getETag().equals(part.getETag())) {
-                    throw new ObjectStorageException("Local multipart part ETag does not match: " + part.getPartNumber());
-                }
-                try (InputStream in = LocalStorageIoSupport.newInputStreamNoFollow(storedPart.path())) {
-                    in.transferTo(out);
-                }
-            }
-            return completedFile;
-        } catch (IOException e) {
-            ObjectStorageException objectStorageException = new ObjectStorageException("Error assembling local multipart upload: " + uploadId, e);
-            deleteIfExists(completedFile, objectStorageException);
-            throw objectStorageException;
-        } catch (RuntimeException e) {
-            deleteIfExists(completedFile, e);
-            throw e;
-        }
-    }
-
-    private Optional<Integer> decodeMultipartContinuationToken(ListMultipartPartsRequest request) {
-        String continuationToken = request.getContinuationToken().orElse(null);
-        if (continuationToken == null || continuationToken.isEmpty()) {
-            return Optional.empty();
-        }
-        try {
-            LocalMultipartContinuationToken decodedToken = LocalMultipartContinuationToken.decode(continuationToken);
-            if (!decodedToken.matches(request)) {
-                throw new ObjectStorageException("Local multipart continuation token does not match the current request");
-            }
-            return Optional.of(decodedToken.partNumberMarker());
-        } catch (IllegalArgumentException e) {
-            throw new ObjectStorageException("Invalid local multipart continuation token", e);
-        }
-    }
-
-    private String encodeMultipartContinuationToken(ListMultipartPartsRequest request, int partNumberMarker) {
-        MultipartUploadHandle upload = request.getUpload();
-        String payload = new StringJoiner("\n")
-            .add(encodeTokenPart(upload.getKey()))
-            .add(encodeTokenPart(upload.getUploadId()))
-            .add(encodeTokenPart(Integer.toString(request.getPageSize())))
-            .add(encodeTokenPart(Integer.toString(partNumberMarker)))
-            .toString();
-        return MULTIPART_CONTINUATION_TOKEN_PREFIX + Base64.getUrlEncoder().withoutPadding()
-            .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
-    }
-
-    private static String encodeTokenPart(String value) {
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(value.getBytes(StandardCharsets.UTF_8));
-    }
-
-    private static String decodeTokenPart(String value) {
-        return new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8);
-    }
-
-    private static ObjectStorageException invalidMultipartContinuationToken() {
-        return new ObjectStorageException("Invalid local multipart continuation token");
-    }
-
-    private Path multipartUploadPath(String uploadId) {
-        try {
-            UUID.fromString(uploadId);
-        } catch (IllegalArgumentException e) {
-            throw new ObjectStorageException("Invalid local multipart upload id: " + uploadId, e);
-        }
-        Path uploadPath = layout.multipartBucketDirectory().resolve(uploadId);
-        LocalStorageIoSupport.rejectSymbolicLinks(layout.storageRoot(), uploadPath);
-        return uploadPath;
-    }
-
-    private Path multipartPartsPath(Path uploadPath) {
-        Path partsPath = uploadPath.resolve(MULTIPART_PARTS_DIRECTORY);
-        LocalStorageIoSupport.rejectSymbolicLinks(layout.storageRoot(), partsPath);
-        return partsPath;
-    }
-
-    private Path multipartPartDataPath(Path uploadPath, String fileName) {
-        if (!fileName.endsWith(MULTIPART_PART_EXTENSION)) {
-            throw new ObjectStorageException("Invalid local multipart part file: " + fileName);
-        }
-        Path partsPath = multipartPartsPath(uploadPath);
-        Path partPath = partsPath.resolve(fileName).normalize();
-        if (!partPath.getParent().equals(partsPath.normalize()) || !partPath.getFileName().toString().equals(fileName)) {
-            throw new ObjectStorageException("Invalid local multipart part file: " + fileName);
-        }
-        LocalStorageIoSupport.rejectSymbolicLinks(layout.storageRoot(), partPath);
-        return partPath;
-    }
-
-    private Path multipartPartPropertiesPath(Path uploadPath, int partNumber) {
-        Path propertiesPath = multipartPartsPath(uploadPath).resolve(partNumber + MULTIPART_PART_PROPERTIES_EXTENSION);
-        LocalStorageIoSupport.rejectSymbolicLinks(layout.storageRoot(), propertiesPath);
-        return propertiesPath;
-    }
-
-    private int parsePartNumber(Path partFile, String extension) {
-        String fileName = partFile.getFileName().toString();
-        try {
-            return Integer.parseInt(fileName.substring(0, fileName.length() - extension.length()));
-        } catch (NumberFormatException e) {
-            throw new ObjectStorageException("Invalid local multipart part file: " + fileName, e);
-        }
-    }
-
-    private void validateUploadSessionKey(MultipartUploadHandle upload, Properties properties) {
-        String key = properties.getProperty(MULTIPART_KEY_PROPERTY);
-        if (!upload.getKey().equals(key)) {
-            throw new ObjectStorageException("Multipart upload key does not match local upload session");
-        }
-    }
-
-    private Optional<String> retrieveCurrentPartFileName(Path uploadPath, Path propertiesPath, int partNumber) {
-        if (!Files.exists(propertiesPath, LinkOption.NOFOLLOW_LINKS)) {
-            return Optional.empty();
-        }
-        String partFileName = retrieveRequiredProperties(propertiesPath).getProperty(MULTIPART_PART_FILE_PROPERTY);
-        if (partFileName == null) {
-            throw new ObjectStorageException("Local multipart part metadata is incomplete: " + partNumber);
-        }
-        multipartPartDataPath(uploadPath, partFileName);
-        return Optional.of(partFileName);
-    }
-
-    private void deleteStalePartFile(Path uploadPath, @Nullable String previousPartFileName, String currentPartFileName) {
-        if (previousPartFileName == null || previousPartFileName.equals(currentPartFileName)) {
-            return;
-        }
-        try {
-            Files.deleteIfExists(multipartPartDataPath(uploadPath, previousPartFileName));
-        } catch (IOException | RuntimeException e) {
-            if (LOG.isWarnEnabled()) {
-                LOG.warn("Error deleting stale local multipart part file: {}", previousPartFileName, e);
-            }
-        }
-    }
-
-    private void storeFile(Path file, InputStream inputStream) {
-        try (InputStream in = inputStream) {
-            if (!mkdirs(file.getParent())) {
-                throw new ObjectStorageException("Error creating local multipart part directories: " + file);
-            }
-            try (OutputStream fileOut = LocalStorageIoSupport.newOutputStreamNoFollow(file, supportsPosixPermissions)) {
-                in.transferTo(fileOut);
-            }
-        } catch (IOException e) {
-            throw new ObjectStorageException("Error copying multipart part to: " + file, e);
-        }
-    }
-
-    private void storeRequiredProperties(Path propertiesPath, Properties properties) {
-        if (!mkdirs(propertiesPath.getParent())) {
-            throw new ObjectStorageException("Error creating local multipart metadata directories: " + propertiesPath);
-        }
-        try (OutputStream out = LocalStorageIoSupport.newOutputStreamNoFollow(propertiesPath, supportsPosixPermissions)) {
-            properties.store(out, "Local multipart upload state");
-        } catch (IOException e) {
-            throw new ObjectStorageException("Error storing local multipart metadata: " + propertiesPath, e);
-        }
-    }
-
-    private void moveReplacing(Path source, Path target) {
-        try {
-            Files.move(source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
-        } catch (AtomicMoveNotSupportedException e) {
-            try {
-                Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
-            } catch (IOException moveException) {
-                throw new ObjectStorageException("Error committing local multipart file: " + target, moveException);
-            }
-        } catch (IOException e) {
-            throw new ObjectStorageException("Error committing local multipart file: " + target, e);
-        }
-    }
-
-    private Properties retrieveRequiredProperties(Path propertiesPath) {
-        Properties properties = new Properties();
-        try (InputStream in = LocalStorageIoSupport.newInputStreamNoFollow(propertiesPath)) {
-            properties.load(in);
-            return properties;
-        } catch (IOException e) {
-            throw new ObjectStorageException("Error reading local multipart metadata: " + propertiesPath, e);
-        }
-    }
-
-    private Optional<Properties> retrieveAbortProperties(Path uploadPath) {
-        Optional<Properties> activeProperties = retrievePropertiesIfExists(uploadPath.resolve(MULTIPART_UPLOAD_PROPERTIES));
-        if (activeProperties.isPresent()) {
-            return activeProperties;
-        }
-        return retrievePropertiesIfExists(uploadPath.resolve(MULTIPART_COMPLETED_PROPERTIES));
-    }
-
-    private Optional<Properties> retrievePropertiesIfExists(Path propertiesPath) {
-        Properties properties = new Properties();
-        try (InputStream in = LocalStorageIoSupport.newInputStreamNoFollow(propertiesPath)) {
-            properties.load(in);
-            return Optional.of(properties);
-        } catch (NoSuchFileException e) {
-            return Optional.empty();
-        } catch (IOException e) {
-            throw new ObjectStorageException("Error reading local multipart metadata: " + propertiesPath, e);
-        }
-    }
-
-    private void markMultipartUploadCompleted(Path uploadPath) {
-        moveReplacing(
-            uploadPath.resolve(MULTIPART_UPLOAD_PROPERTIES),
-            uploadPath.resolve(MULTIPART_COMPLETED_PROPERTIES)
-        );
-    }
-
-    private Path createTempFile(Path directory, String prefix, String suffix) {
-        try {
-            return LocalStorageIoSupport.createTempFile(directory, prefix, suffix, supportsPosixPermissions);
-        } catch (IOException e) {
-            throw new ObjectStorageException("Error creating local multipart temporary file", e);
-        }
-    }
-
-    private long size(Path path) {
-        try {
-            return Files.size(path);
-        } catch (IOException e) {
-            throw new ObjectStorageException("Error reading local multipart part size: " + path, e);
-        }
-    }
-
-    private boolean mkdirs(Path path) {
-        return LocalStorageIoSupport.mkdirs(layout.rootInternalDirectory(), path, supportsPosixPermissions);
-    }
-
-    private void deleteMultipartUpload(Path uploadPath) {
-        try {
-            LocalStorageBucketOperations.deleteRecursively(uploadPath);
-        } catch (NoSuchFileException ignored) {
-            // Abort must be safe to retry, and completed uploads have already removed their local session.
-        } catch (IOException e) {
-            throw new ObjectStorageException("Error deleting local multipart upload: " + uploadPath, e);
-        }
-        deleteEmptyMultipartDirectories(null);
-    }
-
-    private void deleteMultipartUploadAfterCompletion(Path uploadPath) {
-        try {
-            deleteCompletedMultipartUpload(uploadPath);
-        } catch (RuntimeException e) {
-            if (LOG.isWarnEnabled()) {
-                LOG.warn("Error deleting completed local multipart upload: {}", uploadPath, e);
-            }
-        }
-    }
-
-    private void deleteCompletedMultipartUpload(Path uploadPath) {
-        try {
-            Path completedPropertiesPath = uploadPath.resolve(MULTIPART_COMPLETED_PROPERTIES);
-            try (Stream<Path> stream = Files.list(uploadPath)) {
-                for (Path path : stream.filter(path -> !path.equals(completedPropertiesPath)).toList()) {
-                    deleteRecursivelyOrFile(path);
-                }
-            }
-            Files.deleteIfExists(completedPropertiesPath);
-            Files.deleteIfExists(uploadPath);
-        } catch (NoSuchFileException ignored) {
-            // A concurrent abort or cleanup may have already removed the completed session.
-        } catch (IOException e) {
-            throw new ObjectStorageException("Error deleting local multipart upload: " + uploadPath, e);
-        }
-        deleteEmptyMultipartDirectories(null);
-    }
-
-    private void deleteRecursivelyOrFile(Path path) throws IOException {
-        if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
-            LocalStorageBucketOperations.deleteRecursively(path);
-        } else {
-            Files.delete(path);
-        }
-    }
-
-    private void deleteRecursively(Path path, Throwable failure) {
-        try {
-            LocalStorageBucketOperations.deleteRecursively(path);
-        } catch (IOException | RuntimeException e) {
-            failure.addSuppressed(e);
-        }
-        deleteEmptyMultipartDirectories(failure);
-    }
-
-    private void deleteIfExists(@Nullable Path path, Throwable failure) {
-        if (path == null) {
-            return;
-        }
-        try {
-            Files.deleteIfExists(path);
-        } catch (IOException e) {
-            failure.addSuppressed(e);
-        }
-    }
-
-    private void deleteEmptyMultipartDirectories(@Nullable Throwable failure) {
-        for (Path directory : layout.multipartCleanupDirectories()) {
-            try {
-                Files.deleteIfExists(directory);
-            } catch (DirectoryNotEmptyException ignored) {
-                // Other local provider state still uses this directory.
-            } catch (IOException e) {
-                if (failure != null) {
-                    failure.addSuppressed(e);
-                } else {
-                    throw new ObjectStorageException("Error deleting local multipart directory: " + directory, e);
-                }
-            }
-        }
-    }
-
-    @Nullable
-    private static String nullIfEmpty(@Nullable String value) {
-        return value == null || value.isEmpty() ? null : value;
-    }
-
-    private record UploadSession(@NonNull Path path,
-                                 @NonNull Map<String, String> metadata,
-                                 @Nullable String contentType) {
-    }
-
-    private record StoredMultipartPart(@NonNull MultipartPart part,
-                                       @NonNull Path path) {
-    }
-
-    private record LocalMultipartContinuationToken(@NonNull String key,
-                                                   @NonNull String uploadId,
-                                                   int pageSize,
-                                                   int partNumberMarker) {
-
-        private static LocalMultipartContinuationToken decode(String continuationToken) {
-            if (!continuationToken.startsWith(MULTIPART_CONTINUATION_TOKEN_PREFIX)) {
-                throw invalidMultipartContinuationToken();
-            }
-            String decodedToken = new String(
-                Base64.getUrlDecoder().decode(continuationToken.substring(MULTIPART_CONTINUATION_TOKEN_PREFIX.length())),
-                StandardCharsets.UTF_8
-            );
-            String[] parts = decodedToken.split("\n", -1);
-            if (parts.length != 4) {
-                throw invalidMultipartContinuationToken();
-            }
-            int partNumberMarker = Integer.parseInt(decodeTokenPart(parts[3]));
-            if (partNumberMarker <= 0) {
-                throw invalidMultipartContinuationToken();
-            }
-            return new LocalMultipartContinuationToken(
-                decodeTokenPart(parts[0]),
-                decodeTokenPart(parts[1]),
-                Integer.parseInt(decodeTokenPart(parts[2])),
-                partNumberMarker
-            );
-        }
-
-        private boolean matches(ListMultipartPartsRequest request) {
-            MultipartUploadHandle upload = request.getUpload();
-            return upload.getKey().equals(key)
-                && upload.getUploadId().equals(uploadId)
-                && request.getPageSize() == pageSize;
-        }
-    }
-
-    private static final class LocalCompletedMultipartUploadRequest extends FileUploadRequest {
-
-        @NonNull
-        private final Path path;
-
-        private LocalCompletedMultipartUploadRequest(@NonNull String keyName,
-                                                     @Nullable String contentType,
-                                                     @NonNull Path path,
-                                                     @NonNull Map<String, String> metadata) {
-            super(keyName, contentType, path, metadata);
-            this.path = path;
-        }
-
-        @Override
-        @NonNull
-        public InputStream getInputStream() {
-            try {
-                return LocalStorageIoSupport.newInputStreamNoFollow(path);
-            } catch (IOException e) {
-                throw new ObjectStorageException("Error reading completed multipart file: " + path, e);
-            }
-        }
+        Path uploadPath = uploadState.multipartUploadPath(upload.getUploadId());
+        uploadState.retrieveAbortProperties(uploadPath).ifPresent(properties -> uploadState.validateUploadSessionKey(upload, properties));
+        uploadState.deleteMultipartUpload(uploadPath);
     }
 }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartOperations.java
@@ -1,0 +1,640 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.local;
+
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.objectstorage.ObjectStorageException;
+import io.micronaut.objectstorage.configuration.ToggeableCondition;
+import io.micronaut.objectstorage.multipart.AbortMultipartUploadRequest;
+import io.micronaut.objectstorage.multipart.CompleteMultipartUploadRequest;
+import io.micronaut.objectstorage.multipart.CompleteMultipartUploadResponse;
+import io.micronaut.objectstorage.multipart.CreateMultipartUploadRequest;
+import io.micronaut.objectstorage.multipart.CreateMultipartUploadResponse;
+import io.micronaut.objectstorage.multipart.ListMultipartPartsRequest;
+import io.micronaut.objectstorage.multipart.ListMultipartPartsResponse;
+import io.micronaut.objectstorage.multipart.MultipartObjectStorageOperations;
+import io.micronaut.objectstorage.multipart.MultipartPart;
+import io.micronaut.objectstorage.multipart.MultipartUploadHandle;
+import io.micronaut.objectstorage.multipart.UploadPartRequest;
+import io.micronaut.objectstorage.multipart.UploadPartResponse;
+import io.micronaut.objectstorage.request.UploadRequest;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.StringJoiner;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+/**
+ * Local multipart upload operations.
+ *
+ * @author Álvaro Sánchez-Mariscal
+ * @since 3.1.0
+ */
+@EachBean(LocalStorageConfiguration.class)
+@Requires(condition = ToggeableCondition.class)
+@Requires(beans = LocalStorageConfiguration.class)
+@Requires(beans = LocalStorageOperations.class)
+@Primary
+final class LocalStorageMultipartOperations implements MultipartObjectStorageOperations<
+    LocalStorageMultipartOperations.LocalMultipartUpload,
+    LocalStorageOperations.LocalStorageFile,
+    LocalStorageOperations.LocalStorageFile> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LocalStorageMultipartOperations.class);
+
+    private static final String MULTIPART_PARTS_DIRECTORY = "parts";
+    private static final String MULTIPART_UPLOAD_PROPERTIES = "upload.properties";
+    private static final String MULTIPART_PART_EXTENSION = ".part";
+    private static final String MULTIPART_PART_PROPERTIES_EXTENSION = ".properties";
+    private static final String MULTIPART_COMPLETE_FILE_SUFFIX = ".complete";
+    private static final String MULTIPART_CONTINUATION_TOKEN_PREFIX = "local-multipart:v1:";
+    private static final String MULTIPART_KEY_PROPERTY = "key";
+    private static final String MULTIPART_CONTENT_TYPE_PROPERTY = "contentType";
+    private static final String MULTIPART_METADATA_PREFIX = "metadata.";
+    private static final String MULTIPART_PART_ETAG_PROPERTY = "eTag";
+    private static final String MULTIPART_PART_SIZE_PROPERTY = "size";
+    private static final String MULTIPART_PART_FILE_PROPERTY = "file";
+
+    private final LocalStorageLayout layout;
+    private final LocalStorageOperations objectStorageOperations;
+    private final boolean supportsPosixPermissions;
+
+    LocalStorageMultipartOperations(@Parameter LocalStorageConfiguration configuration,
+                                    LocalStorageOperations objectStorageOperations) {
+        this.layout = new LocalStorageLayout(configuration);
+        this.objectStorageOperations = objectStorageOperations;
+        this.supportsPosixPermissions = layout.storageRoot().getFileSystem().supportedFileAttributeViews().contains("posix");
+    }
+
+    @Override
+    @NonNull
+    public CreateMultipartUploadResponse<LocalMultipartUpload> createMultipartUpload(@NonNull CreateMultipartUploadRequest request) {
+        layout.objectPath(request.getKey());
+        String uploadId = UUID.randomUUID().toString();
+        Path uploadPath = multipartUploadPath(uploadId);
+        if (!mkdirs(uploadPath)) {
+            throw new ObjectStorageException("Error creating local multipart upload: " + uploadId);
+        }
+        Properties properties = new Properties();
+        properties.setProperty(MULTIPART_KEY_PROPERTY, request.getKey());
+        request.getContentType().ifPresent(contentType -> properties.setProperty(MULTIPART_CONTENT_TYPE_PROPERTY, contentType));
+        request.getMetadata().forEach((key, value) -> properties.setProperty(MULTIPART_METADATA_PREFIX + key, value));
+        try {
+            storeRequiredProperties(uploadPath.resolve(MULTIPART_UPLOAD_PROPERTIES), properties);
+        } catch (RuntimeException e) {
+            deleteRecursively(uploadPath, e);
+            throw e;
+        }
+        return CreateMultipartUploadResponse.of(
+            new MultipartUploadHandle(request.getKey(), uploadId),
+            new LocalMultipartUpload(uploadPath)
+        );
+    }
+
+    @Override
+    @NonNull
+    public UploadPartResponse<LocalStorageOperations.LocalStorageFile> uploadPart(@NonNull UploadPartRequest request) {
+        UploadSession session = retrieveUploadSession(request.getUpload());
+        int partNumber = request.getPartNumber();
+        Path partsPath = multipartPartsPath(session.path());
+        Path partPropertiesFile = multipartPartPropertiesPath(session.path(), partNumber);
+        if (!mkdirs(partsPath)) {
+            throw new ObjectStorageException("Error creating local multipart part directories: " + partsPath);
+        }
+        String eTag = UUID.randomUUID().toString();
+        String partFileName = partNumber + "-" + eTag + MULTIPART_PART_EXTENSION;
+        Path partFile = multipartPartDataPath(session.path(), partFileName);
+        Path temporaryPartFile = null;
+        Path temporaryPartPropertiesFile = null;
+        boolean partFileCommitted = false;
+        boolean propertiesCommitted = false;
+        try {
+            temporaryPartFile = createTempFile(partsPath, partNumber + "-", MULTIPART_PART_EXTENSION + ".tmp");
+            temporaryPartPropertiesFile = createTempFile(partsPath, partNumber + "-", MULTIPART_PART_PROPERTIES_EXTENSION + ".tmp");
+            storeFile(temporaryPartFile, request.getUploadRequest().getInputStream());
+            long partSize = size(temporaryPartFile);
+            Properties properties = new Properties();
+            properties.setProperty(MULTIPART_PART_ETAG_PROPERTY, eTag);
+            properties.setProperty(MULTIPART_PART_SIZE_PROPERTY, Long.toString(partSize));
+            properties.setProperty(MULTIPART_PART_FILE_PROPERTY, partFileName);
+            storeRequiredProperties(temporaryPartPropertiesFile, properties);
+            String previousPartFileName = retrieveCurrentPartFileName(partPropertiesFile).orElse(null);
+            moveReplacing(temporaryPartFile, partFile);
+            partFileCommitted = true;
+            moveReplacing(temporaryPartPropertiesFile, partPropertiesFile);
+            propertiesCommitted = true;
+            deleteStalePartFile(session.path(), previousPartFileName, partFileName);
+            return UploadPartResponse.of(
+                new MultipartPart(partNumber, eTag, partSize),
+                new LocalStorageOperations.LocalStorageFile(partFile)
+            );
+        } catch (RuntimeException e) {
+            deleteIfExists(temporaryPartFile, e);
+            deleteIfExists(temporaryPartPropertiesFile, e);
+            if (partFileCommitted && !propertiesCommitted) {
+                deleteIfExists(partFile, e);
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    @NonNull
+    public ListMultipartPartsResponse listParts(@NonNull ListMultipartPartsRequest request) {
+        UploadSession session = retrieveUploadSession(request.getUpload());
+        int partNumberMarker = decodeMultipartContinuationToken(request).orElse(0);
+        List<MultipartPart> parts = retrieveMultipartParts(session.path()).stream()
+            .filter(part -> part.getPartNumber() > partNumberMarker)
+            .limit((long) request.getPageSize() + 1)
+            .toList();
+        if (parts.size() <= request.getPageSize()) {
+            return new ListMultipartPartsResponse(parts);
+        }
+        List<MultipartPart> page = parts.subList(0, request.getPageSize());
+        MultipartPart lastPart = page.get(page.size() - 1);
+        return new ListMultipartPartsResponse(page, encodeMultipartContinuationToken(request, lastPart.getPartNumber()));
+    }
+
+    @Override
+    @NonNull
+    public CompleteMultipartUploadResponse<LocalStorageOperations.LocalStorageFile> completeMultipartUpload(
+        @NonNull CompleteMultipartUploadRequest request) {
+        MultipartUploadHandle upload = request.getUpload();
+        UploadSession session = retrieveUploadSession(upload);
+        Path completedFile = buildCompletedMultipartFile(session.path(), request.getParts(), upload.getUploadId());
+        try {
+            LocalMultipartUploadRequest uploadRequest = new LocalMultipartUploadRequest(
+                upload.getKey(),
+                completedFile,
+                session.metadata(),
+                session.contentType()
+            );
+            var uploadResponse = objectStorageOperations.upload(uploadRequest);
+            deleteMultipartUploadAfterCompletion(session.path());
+            return CompleteMultipartUploadResponse.of(upload, uploadResponse.getETag(), uploadResponse.getNativeResponse());
+        } catch (RuntimeException e) {
+            deleteIfExists(completedFile, e);
+            throw e;
+        }
+    }
+
+    @Override
+    public void abortMultipartUpload(@NonNull AbortMultipartUploadRequest request) {
+        MultipartUploadHandle upload = request.getUpload();
+        Path uploadPath = multipartUploadPath(upload.getUploadId());
+        Path propertiesPath = uploadPath.resolve(MULTIPART_UPLOAD_PROPERTIES);
+        if (Files.exists(propertiesPath, LinkOption.NOFOLLOW_LINKS)) {
+            validateUploadSessionKey(upload, retrieveRequiredProperties(propertiesPath));
+        }
+        deleteMultipartUpload(uploadPath);
+    }
+
+    @NonNull
+    private UploadSession retrieveUploadSession(@NonNull MultipartUploadHandle upload) {
+        Path uploadPath = multipartUploadPath(upload.getUploadId());
+        Path propertiesPath = uploadPath.resolve(MULTIPART_UPLOAD_PROPERTIES);
+        if (!Files.exists(propertiesPath, LinkOption.NOFOLLOW_LINKS)) {
+            throw new ObjectStorageException("Local multipart upload does not exist: " + upload.getUploadId());
+        }
+        Properties properties = retrieveRequiredProperties(propertiesPath);
+        validateUploadSessionKey(upload, properties);
+        Map<String, String> metadata = new HashMap<>();
+        for (String name : properties.stringPropertyNames()) {
+            if (name.startsWith(MULTIPART_METADATA_PREFIX)) {
+                metadata.put(name.substring(MULTIPART_METADATA_PREFIX.length()), properties.getProperty(name));
+            }
+        }
+        return new UploadSession(uploadPath, Map.copyOf(metadata), nullIfEmpty(properties.getProperty(MULTIPART_CONTENT_TYPE_PROPERTY)));
+    }
+
+    @NonNull
+    private List<MultipartPart> retrieveMultipartParts(@NonNull Path uploadPath) {
+        Path partsPath = multipartPartsPath(uploadPath);
+        if (!Files.exists(partsPath, LinkOption.NOFOLLOW_LINKS)) {
+            return Collections.emptyList();
+        }
+        try (Stream<Path> stream = Files.list(partsPath)) {
+            return stream
+                .filter(path -> path.getFileName().toString().endsWith(MULTIPART_PART_PROPERTIES_EXTENSION))
+                .map(path -> retrieveMultipartPart(uploadPath, parsePartNumber(path, MULTIPART_PART_PROPERTIES_EXTENSION)))
+                .sorted(Comparator.comparingInt(MultipartPart::getPartNumber))
+                .toList();
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error listing local multipart parts", e);
+        }
+    }
+
+    @NonNull
+    private MultipartPart retrieveMultipartPart(@NonNull Path uploadPath, int partNumber) {
+        return retrieveStoredMultipartPart(uploadPath, partNumber).part();
+    }
+
+    @NonNull
+    private StoredMultipartPart retrieveStoredMultipartPart(@NonNull Path uploadPath, int partNumber) {
+        Path propertiesPath = multipartPartPropertiesPath(uploadPath, partNumber);
+        if (!Files.exists(propertiesPath, LinkOption.NOFOLLOW_LINKS)) {
+            throw new ObjectStorageException("Local multipart part does not exist: " + partNumber);
+        }
+        Properties properties = retrieveRequiredProperties(propertiesPath);
+        String eTag = properties.getProperty(MULTIPART_PART_ETAG_PROPERTY);
+        String size = properties.getProperty(MULTIPART_PART_SIZE_PROPERTY);
+        String partFileName = properties.getProperty(MULTIPART_PART_FILE_PROPERTY);
+        if (eTag == null || size == null || partFileName == null) {
+            throw new ObjectStorageException("Local multipart part metadata is incomplete: " + partNumber);
+        }
+        Path partFile = multipartPartDataPath(uploadPath, partFileName);
+        if (!Files.exists(partFile, LinkOption.NOFOLLOW_LINKS)) {
+            throw new ObjectStorageException("Local multipart part does not exist: " + partNumber);
+        }
+        try {
+            long partSize = Long.parseLong(size);
+            if (size(partFile) != partSize) {
+                throw new ObjectStorageException("Local multipart part size does not match metadata: " + partNumber);
+            }
+            return new StoredMultipartPart(new MultipartPart(partNumber, eTag, partSize), partFile);
+        } catch (NumberFormatException e) {
+            throw new ObjectStorageException("Local multipart part size is invalid: " + partNumber, e);
+        }
+    }
+
+    @NonNull
+    private Path buildCompletedMultipartFile(@NonNull Path uploadPath,
+                                             @NonNull List<MultipartPart> parts,
+                                             @NonNull String uploadId) {
+        Path completedFile = createTempFile(uploadPath, "micronaut-object-storage-local-" + uploadId + "-", MULTIPART_COMPLETE_FILE_SUFFIX);
+        try (OutputStream out = LocalStorageIoSupport.newOutputStreamNoFollow(completedFile, supportsPosixPermissions)) {
+            for (MultipartPart part : parts) {
+                StoredMultipartPart storedPart = retrieveStoredMultipartPart(uploadPath, part.getPartNumber());
+                if (!storedPart.part().getETag().equals(part.getETag())) {
+                    throw new ObjectStorageException("Local multipart part ETag does not match: " + part.getPartNumber());
+                }
+                try (InputStream in = LocalStorageIoSupport.newInputStreamNoFollow(storedPart.path())) {
+                    in.transferTo(out);
+                }
+            }
+            return completedFile;
+        } catch (IOException e) {
+            ObjectStorageException objectStorageException = new ObjectStorageException("Error assembling local multipart upload: " + uploadId, e);
+            deleteIfExists(completedFile, objectStorageException);
+            throw objectStorageException;
+        } catch (RuntimeException e) {
+            deleteIfExists(completedFile, e);
+            throw e;
+        }
+    }
+
+    private Optional<Integer> decodeMultipartContinuationToken(ListMultipartPartsRequest request) {
+        String continuationToken = request.getContinuationToken().orElse(null);
+        if (continuationToken == null || continuationToken.isEmpty()) {
+            return Optional.empty();
+        }
+        try {
+            if (!continuationToken.startsWith(MULTIPART_CONTINUATION_TOKEN_PREFIX)) {
+                throw new ObjectStorageException("Invalid local multipart continuation token");
+            }
+            String decodedToken = new String(
+                Base64.getUrlDecoder().decode(continuationToken.substring(MULTIPART_CONTINUATION_TOKEN_PREFIX.length())),
+                StandardCharsets.UTF_8
+            );
+            String[] parts = decodedToken.split("\n", -1);
+            if (parts.length != 4) {
+                throw new ObjectStorageException("Invalid local multipart continuation token");
+            }
+            MultipartUploadHandle upload = request.getUpload();
+            String key = decodeTokenPart(parts[0]);
+            String uploadId = decodeTokenPart(parts[1]);
+            String pageSize = decodeTokenPart(parts[2]);
+            String partNumberMarker = decodeTokenPart(parts[3]);
+            if (!upload.getKey().equals(key)
+                || !upload.getUploadId().equals(uploadId)
+                || !Integer.toString(request.getPageSize()).equals(pageSize)) {
+                throw new ObjectStorageException("Local multipart continuation token does not match the current request");
+            }
+            int marker = Integer.parseInt(partNumberMarker);
+            if (marker <= 0) {
+                throw new ObjectStorageException("Invalid local multipart continuation token");
+            }
+            return Optional.of(marker);
+        } catch (IllegalArgumentException e) {
+            throw new ObjectStorageException("Invalid local multipart continuation token", e);
+        }
+    }
+
+    private String encodeMultipartContinuationToken(ListMultipartPartsRequest request, int partNumberMarker) {
+        MultipartUploadHandle upload = request.getUpload();
+        String payload = new StringJoiner("\n")
+            .add(encodeTokenPart(upload.getKey()))
+            .add(encodeTokenPart(upload.getUploadId()))
+            .add(encodeTokenPart(Integer.toString(request.getPageSize())))
+            .add(encodeTokenPart(Integer.toString(partNumberMarker)))
+            .toString();
+        return MULTIPART_CONTINUATION_TOKEN_PREFIX + Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String encodeTokenPart(String value) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String decodeTokenPart(String value) {
+        return new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8);
+    }
+
+    private Path multipartUploadPath(String uploadId) {
+        try {
+            UUID.fromString(uploadId);
+        } catch (IllegalArgumentException e) {
+            throw new ObjectStorageException("Invalid local multipart upload id: " + uploadId, e);
+        }
+        Path uploadPath = layout.multipartBucketDirectory().resolve(uploadId);
+        LocalStorageIoSupport.rejectSymbolicLinks(layout.storageRoot(), uploadPath);
+        return uploadPath;
+    }
+
+    private Path multipartPartsPath(Path uploadPath) {
+        Path partsPath = uploadPath.resolve(MULTIPART_PARTS_DIRECTORY);
+        LocalStorageIoSupport.rejectSymbolicLinks(layout.storageRoot(), partsPath);
+        return partsPath;
+    }
+
+    private Path multipartPartDataPath(Path uploadPath, String fileName) {
+        if (!fileName.endsWith(MULTIPART_PART_EXTENSION)) {
+            throw new ObjectStorageException("Invalid local multipart part file: " + fileName);
+        }
+        Path partsPath = multipartPartsPath(uploadPath);
+        Path partPath = partsPath.resolve(fileName).normalize();
+        if (!partPath.getParent().equals(partsPath.normalize()) || !partPath.getFileName().toString().equals(fileName)) {
+            throw new ObjectStorageException("Invalid local multipart part file: " + fileName);
+        }
+        LocalStorageIoSupport.rejectSymbolicLinks(layout.storageRoot(), partPath);
+        return partPath;
+    }
+
+    private Path multipartPartPropertiesPath(Path uploadPath, int partNumber) {
+        Path propertiesPath = multipartPartsPath(uploadPath).resolve(partNumber + MULTIPART_PART_PROPERTIES_EXTENSION);
+        LocalStorageIoSupport.rejectSymbolicLinks(layout.storageRoot(), propertiesPath);
+        return propertiesPath;
+    }
+
+    private int parsePartNumber(Path partFile, String extension) {
+        String fileName = partFile.getFileName().toString();
+        try {
+            return Integer.parseInt(fileName.substring(0, fileName.length() - extension.length()));
+        } catch (NumberFormatException e) {
+            throw new ObjectStorageException("Invalid local multipart part file: " + fileName, e);
+        }
+    }
+
+    private void validateUploadSessionKey(MultipartUploadHandle upload, Properties properties) {
+        String key = properties.getProperty(MULTIPART_KEY_PROPERTY);
+        if (!upload.getKey().equals(key)) {
+            throw new ObjectStorageException("Multipart upload key does not match local upload session");
+        }
+    }
+
+    private Optional<String> retrieveCurrentPartFileName(Path propertiesPath) {
+        if (!Files.exists(propertiesPath, LinkOption.NOFOLLOW_LINKS)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.ofNullable(retrieveRequiredProperties(propertiesPath).getProperty(MULTIPART_PART_FILE_PROPERTY));
+        } catch (RuntimeException e) {
+            return Optional.empty();
+        }
+    }
+
+    private void deleteStalePartFile(Path uploadPath, @Nullable String previousPartFileName, String currentPartFileName) {
+        if (previousPartFileName == null || previousPartFileName.equals(currentPartFileName)) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(multipartPartDataPath(uploadPath, previousPartFileName));
+        } catch (IOException | RuntimeException e) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("Error deleting stale local multipart part file: {}", previousPartFileName, e);
+            }
+        }
+    }
+
+    private void storeFile(Path file, InputStream inputStream) {
+        if (!mkdirs(file.getParent())) {
+            throw new ObjectStorageException("Error creating local multipart part directories: " + file);
+        }
+        try (OutputStream fileOut = LocalStorageIoSupport.newOutputStreamNoFollow(file, supportsPosixPermissions)) {
+            inputStream.transferTo(fileOut);
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error copying multipart part to: " + file, e);
+        }
+    }
+
+    private void storeRequiredProperties(Path propertiesPath, Properties properties) {
+        if (!mkdirs(propertiesPath.getParent())) {
+            throw new ObjectStorageException("Error creating local multipart metadata directories: " + propertiesPath);
+        }
+        try (OutputStream out = LocalStorageIoSupport.newOutputStreamNoFollow(propertiesPath, supportsPosixPermissions)) {
+            properties.store(out, "Local multipart upload state");
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error storing local multipart metadata: " + propertiesPath, e);
+        }
+    }
+
+    private void moveReplacing(Path source, Path target) {
+        try {
+            Files.move(source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException e) {
+            try {
+                Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException moveException) {
+                throw new ObjectStorageException("Error committing local multipart file: " + target, moveException);
+            }
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error committing local multipart file: " + target, e);
+        }
+    }
+
+    private Properties retrieveRequiredProperties(Path propertiesPath) {
+        Properties properties = new Properties();
+        try (InputStream in = LocalStorageIoSupport.newInputStreamNoFollow(propertiesPath)) {
+            properties.load(in);
+            return properties;
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error reading local multipart metadata: " + propertiesPath, e);
+        }
+    }
+
+    private Path createTempFile(Path directory, String prefix, String suffix) {
+        try {
+            return LocalStorageIoSupport.createTempFile(directory, prefix, suffix, supportsPosixPermissions);
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error creating local multipart temporary file", e);
+        }
+    }
+
+    private long size(Path path) {
+        try {
+            return Files.size(path);
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error reading local multipart part size: " + path, e);
+        }
+    }
+
+    private boolean mkdirs(Path path) {
+        return LocalStorageIoSupport.mkdirs(layout.rootInternalDirectory(), path, supportsPosixPermissions);
+    }
+
+    private void deleteMultipartUpload(Path uploadPath) {
+        try {
+            LocalStorageBucketOperations.deleteRecursively(uploadPath);
+        } catch (NoSuchFileException ignored) {
+            // Abort must be safe to retry, and completed uploads have already removed their local session.
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error deleting local multipart upload: " + uploadPath, e);
+        }
+        deleteEmptyMultipartDirectories(null);
+    }
+
+    private void deleteMultipartUploadAfterCompletion(Path uploadPath) {
+        try {
+            deleteMultipartUpload(uploadPath);
+        } catch (RuntimeException e) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("Error deleting completed local multipart upload: {}", uploadPath, e);
+            }
+        }
+    }
+
+    private void deleteRecursively(Path path, Throwable failure) {
+        try {
+            LocalStorageBucketOperations.deleteRecursively(path);
+        } catch (IOException | RuntimeException e) {
+            failure.addSuppressed(e);
+        }
+        deleteEmptyMultipartDirectories(failure);
+    }
+
+    private void deleteIfExists(@Nullable Path path, Throwable failure) {
+        if (path == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException e) {
+            failure.addSuppressed(e);
+        }
+    }
+
+    private void deleteEmptyMultipartDirectories(@Nullable Throwable failure) {
+        for (Path directory : layout.multipartCleanupDirectories()) {
+            try {
+                Files.deleteIfExists(directory);
+            } catch (DirectoryNotEmptyException ignored) {
+                // Other local provider state still uses this directory.
+            } catch (IOException e) {
+                if (failure != null) {
+                    failure.addSuppressed(e);
+                } else {
+                    throw new ObjectStorageException("Error deleting local multipart directory: " + directory, e);
+                }
+            }
+        }
+    }
+
+    @Nullable
+    private static String nullIfEmpty(@Nullable String value) {
+        return value == null || value.isEmpty() ? null : value;
+    }
+
+    record LocalMultipartUpload(@NonNull Path path) {
+    }
+
+    private record UploadSession(@NonNull Path path,
+                                 @NonNull Map<String, String> metadata,
+                                 @Nullable String contentType) {
+    }
+
+    private record StoredMultipartPart(@NonNull MultipartPart part,
+                                       @NonNull Path path) {
+    }
+
+    private record LocalMultipartUploadRequest(@NonNull String key,
+                                               @NonNull Path path,
+                                               @NonNull Map<String, String> metadata,
+                                               @Nullable String contentType) implements UploadRequest {
+
+        @Override
+        @NonNull
+        public Optional<String> getContentType() {
+            return Optional.ofNullable(contentType);
+        }
+
+        @Override
+        @NonNull
+        public String getKey() {
+            return key;
+        }
+
+        @Override
+        @NonNull
+        public Optional<Long> getContentSize() {
+            try {
+                return Optional.of(Files.size(path));
+            } catch (IOException e) {
+                throw new ObjectStorageException("Error reading completed multipart file size: " + path, e);
+            }
+        }
+
+        @Override
+        @NonNull
+        public InputStream getInputStream() {
+            try {
+                return LocalStorageIoSupport.newInputStreamNoFollow(path);
+            } catch (IOException e) {
+                throw new ObjectStorageException("Error reading completed multipart file: " + path, e);
+            }
+        }
+
+        @Override
+        @NonNull
+        public Map<String, String> getMetadata() {
+            return metadata;
+        }
+    }
+}

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartUpload.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartUpload.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.local;
+
+import org.jspecify.annotations.NonNull;
+
+import java.nio.file.Path;
+
+/**
+ * Native local multipart upload state.
+ *
+ * @param path The directory where local storage stores the multipart upload session state
+ * @since 3.1.0
+ */
+public record LocalStorageMultipartUpload(@NonNull Path path) {
+}

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartUploadState.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartUploadState.java
@@ -1,0 +1,499 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.local;
+
+import io.micronaut.objectstorage.ObjectStorageException;
+import io.micronaut.objectstorage.multipart.CreateMultipartUploadRequest;
+import io.micronaut.objectstorage.multipart.MultipartPart;
+import io.micronaut.objectstorage.multipart.MultipartUploadHandle;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+final class LocalStorageMultipartUploadState {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LocalStorageMultipartUploadState.class);
+
+    private static final String MULTIPART_PARTS_DIRECTORY = "parts";
+    private static final String MULTIPART_UPLOAD_PROPERTIES = "upload.properties";
+    private static final String MULTIPART_COMPLETED_PROPERTIES = "completed.properties";
+    private static final String MULTIPART_PART_EXTENSION = ".part";
+    private static final String MULTIPART_PART_PROPERTIES_EXTENSION = ".properties";
+    private static final String MULTIPART_COMPLETE_FILE_SUFFIX = ".complete";
+    private static final String MULTIPART_KEY_PROPERTY = "key";
+    private static final String MULTIPART_CONTENT_TYPE_PROPERTY = "contentType";
+    private static final String MULTIPART_METADATA_PREFIX = "metadata.";
+    private static final String MULTIPART_PART_ETAG_PROPERTY = "eTag";
+    private static final String MULTIPART_PART_SIZE_PROPERTY = "size";
+    private static final String MULTIPART_PART_FILE_PROPERTY = "file";
+
+    private final LocalStorageLayout layout;
+    private final boolean supportsPosixPermissions;
+
+    LocalStorageMultipartUploadState(LocalStorageLayout layout) {
+        this.layout = layout;
+        this.supportsPosixPermissions = layout.storageRoot().getFileSystem().supportedFileAttributeViews().contains("posix");
+    }
+
+    @NonNull
+    Path createUpload(@NonNull CreateMultipartUploadRequest request, @NonNull String uploadId) {
+        layout.objectPath(request.getKey());
+        Path uploadPath = multipartUploadPath(uploadId);
+        if (!mkdirs(uploadPath)) {
+            throw new ObjectStorageException("Error creating local multipart upload: " + uploadId);
+        }
+        Properties properties = new Properties();
+        properties.setProperty(MULTIPART_KEY_PROPERTY, request.getKey());
+        request.getContentType().ifPresent(contentType -> properties.setProperty(MULTIPART_CONTENT_TYPE_PROPERTY, contentType));
+        request.getMetadata().forEach((key, value) -> properties.setProperty(MULTIPART_METADATA_PREFIX + key, value));
+        try {
+            storeRequiredProperties(uploadPath.resolve(MULTIPART_UPLOAD_PROPERTIES), properties);
+            return uploadPath;
+        } catch (RuntimeException e) {
+            deleteRecursively(uploadPath, e);
+            throw e;
+        }
+    }
+
+    @NonNull
+    UploadSession retrieveUploadSession(@NonNull MultipartUploadHandle upload) {
+        Path uploadPath = multipartUploadPath(upload.getUploadId());
+        Path completedPropertiesPath = uploadPath.resolve(MULTIPART_COMPLETED_PROPERTIES);
+        if (Files.exists(completedPropertiesPath, LinkOption.NOFOLLOW_LINKS)) {
+            throw new ObjectStorageException("Local multipart upload is already completed: " + upload.getUploadId());
+        }
+        Path propertiesPath = uploadPath.resolve(MULTIPART_UPLOAD_PROPERTIES);
+        if (!Files.exists(propertiesPath, LinkOption.NOFOLLOW_LINKS)) {
+            throw new ObjectStorageException("Local multipart upload does not exist: " + upload.getUploadId());
+        }
+        Properties properties = retrieveRequiredProperties(propertiesPath);
+        validateUploadSessionKey(upload, properties);
+        Map<String, String> metadata = new HashMap<>();
+        for (String name : properties.stringPropertyNames()) {
+            if (name.startsWith(MULTIPART_METADATA_PREFIX)) {
+                metadata.put(name.substring(MULTIPART_METADATA_PREFIX.length()), properties.getProperty(name));
+            }
+        }
+        return new UploadSession(uploadPath, Map.copyOf(metadata), nullIfEmpty(properties.getProperty(MULTIPART_CONTENT_TYPE_PROPERTY)));
+    }
+
+    @NonNull
+    StoredMultipartPart storePart(@NonNull Path uploadPath, int partNumber, @NonNull InputStream inputStream) {
+        Path partsPath = multipartPartsPath(uploadPath);
+        Path partPropertiesFile = multipartPartPropertiesPath(uploadPath, partNumber);
+        String previousPartFileName = retrieveCurrentPartFileName(uploadPath, partPropertiesFile, partNumber).orElse(null);
+        if (!mkdirs(partsPath)) {
+            throw new ObjectStorageException("Error creating local multipart part directories: " + partsPath);
+        }
+        String eTag = UUID.randomUUID().toString();
+        String partFileName = partNumber + "-" + eTag + MULTIPART_PART_EXTENSION;
+        Path partFile = multipartPartDataPath(uploadPath, partFileName);
+        Path temporaryPartFile = null;
+        Path temporaryPartPropertiesFile = null;
+        boolean partFileCommitted = false;
+        boolean propertiesCommitted = false;
+        try {
+            temporaryPartFile = createTempFile(partsPath, partNumber + "-", MULTIPART_PART_EXTENSION + ".tmp");
+            temporaryPartPropertiesFile = createTempFile(partsPath, partNumber + "-", MULTIPART_PART_PROPERTIES_EXTENSION + ".tmp");
+            storeFile(temporaryPartFile, inputStream);
+            long partSize = size(temporaryPartFile);
+            Properties properties = new Properties();
+            properties.setProperty(MULTIPART_PART_ETAG_PROPERTY, eTag);
+            properties.setProperty(MULTIPART_PART_SIZE_PROPERTY, Long.toString(partSize));
+            properties.setProperty(MULTIPART_PART_FILE_PROPERTY, partFileName);
+            storeRequiredProperties(temporaryPartPropertiesFile, properties);
+            moveReplacing(temporaryPartFile, partFile);
+            partFileCommitted = true;
+            moveReplacing(temporaryPartPropertiesFile, partPropertiesFile);
+            propertiesCommitted = true;
+            deleteStalePartFile(uploadPath, previousPartFileName, partFileName);
+            return new StoredMultipartPart(new MultipartPart(partNumber, eTag, partSize), partFile);
+        } catch (RuntimeException e) {
+            deleteIfExists(temporaryPartFile, e);
+            deleteIfExists(temporaryPartPropertiesFile, e);
+            if (partFileCommitted && !propertiesCommitted) {
+                deleteIfExists(partFile, e);
+            }
+            throw e;
+        }
+    }
+
+    @NonNull
+    List<MultipartPart> retrieveMultipartParts(@NonNull Path uploadPath) {
+        Path partsPath = multipartPartsPath(uploadPath);
+        if (!Files.exists(partsPath, LinkOption.NOFOLLOW_LINKS)) {
+            return Collections.emptyList();
+        }
+        try (Stream<Path> stream = Files.list(partsPath)) {
+            return stream
+                .filter(path -> path.getFileName().toString().endsWith(MULTIPART_PART_PROPERTIES_EXTENSION))
+                .map(path -> retrieveMultipartPart(uploadPath, parsePartNumber(path, MULTIPART_PART_PROPERTIES_EXTENSION)))
+                .sorted(Comparator.comparingInt(MultipartPart::getPartNumber))
+                .toList();
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error listing local multipart parts", e);
+        }
+    }
+
+    @NonNull
+    Path buildCompletedMultipartFile(@NonNull Path uploadPath,
+                                     @NonNull List<MultipartPart> parts,
+                                     @NonNull String uploadId) {
+        Path completedFile = createTempFile(uploadPath, "micronaut-object-storage-local-" + uploadId + "-", MULTIPART_COMPLETE_FILE_SUFFIX);
+        try (OutputStream out = LocalStorageIoSupport.newOutputStreamNoFollow(completedFile, supportsPosixPermissions)) {
+            for (MultipartPart part : parts) {
+                StoredMultipartPart storedPart = retrieveStoredMultipartPart(uploadPath, part.getPartNumber());
+                if (!storedPart.part().getETag().equals(part.getETag())) {
+                    throw new ObjectStorageException("Local multipart part ETag does not match: " + part.getPartNumber());
+                }
+                try (InputStream in = LocalStorageIoSupport.newInputStreamNoFollow(storedPart.path())) {
+                    in.transferTo(out);
+                }
+            }
+            return completedFile;
+        } catch (IOException e) {
+            ObjectStorageException objectStorageException = new ObjectStorageException("Error assembling local multipart upload: " + uploadId, e);
+            deleteIfExists(completedFile, objectStorageException);
+            throw objectStorageException;
+        } catch (RuntimeException e) {
+            deleteIfExists(completedFile, e);
+            throw e;
+        }
+    }
+
+    Path multipartUploadPath(String uploadId) {
+        try {
+            UUID.fromString(uploadId);
+        } catch (IllegalArgumentException e) {
+            throw new ObjectStorageException("Invalid local multipart upload id: " + uploadId, e);
+        }
+        Path uploadPath = layout.multipartBucketDirectory().resolve(uploadId);
+        LocalStorageIoSupport.rejectSymbolicLinks(layout.storageRoot(), uploadPath);
+        return uploadPath;
+    }
+
+    Optional<Properties> retrieveAbortProperties(Path uploadPath) {
+        Optional<Properties> activeProperties = retrievePropertiesIfExists(uploadPath.resolve(MULTIPART_UPLOAD_PROPERTIES));
+        if (activeProperties.isPresent()) {
+            return activeProperties;
+        }
+        return retrievePropertiesIfExists(uploadPath.resolve(MULTIPART_COMPLETED_PROPERTIES));
+    }
+
+    void validateUploadSessionKey(MultipartUploadHandle upload, Properties properties) {
+        String key = properties.getProperty(MULTIPART_KEY_PROPERTY);
+        if (!upload.getKey().equals(key)) {
+            throw new ObjectStorageException("Multipart upload key does not match local upload session");
+        }
+    }
+
+    void markMultipartUploadCompleted(Path uploadPath) {
+        moveReplacing(
+            uploadPath.resolve(MULTIPART_UPLOAD_PROPERTIES),
+            uploadPath.resolve(MULTIPART_COMPLETED_PROPERTIES)
+        );
+    }
+
+    void deleteMultipartUpload(Path uploadPath) {
+        try {
+            LocalStorageBucketOperations.deleteRecursively(uploadPath);
+        } catch (NoSuchFileException ignored) {
+            // Abort must be safe to retry, and completed uploads have already removed their local session.
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error deleting local multipart upload: " + uploadPath, e);
+        }
+        deleteEmptyMultipartDirectories(null);
+    }
+
+    void deleteMultipartUploadAfterCompletion(Path uploadPath) {
+        try {
+            deleteCompletedMultipartUpload(uploadPath);
+        } catch (RuntimeException e) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("Error deleting completed local multipart upload: {}", uploadPath, e);
+            }
+        }
+    }
+
+    void deleteIfExists(@Nullable Path path, Throwable failure) {
+        if (path == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException e) {
+            failure.addSuppressed(e);
+        }
+    }
+
+    @NonNull
+    private MultipartPart retrieveMultipartPart(@NonNull Path uploadPath, int partNumber) {
+        return retrieveStoredMultipartPart(uploadPath, partNumber).part();
+    }
+
+    @NonNull
+    private StoredMultipartPart retrieveStoredMultipartPart(@NonNull Path uploadPath, int partNumber) {
+        Path propertiesPath = multipartPartPropertiesPath(uploadPath, partNumber);
+        if (!Files.exists(propertiesPath, LinkOption.NOFOLLOW_LINKS)) {
+            throw new ObjectStorageException("Local multipart part does not exist: " + partNumber);
+        }
+        Properties properties = retrieveRequiredProperties(propertiesPath);
+        String eTag = properties.getProperty(MULTIPART_PART_ETAG_PROPERTY);
+        String size = properties.getProperty(MULTIPART_PART_SIZE_PROPERTY);
+        String partFileName = properties.getProperty(MULTIPART_PART_FILE_PROPERTY);
+        if (eTag == null || size == null || partFileName == null) {
+            throw new ObjectStorageException("Local multipart part metadata is incomplete: " + partNumber);
+        }
+        Path partFile = multipartPartDataPath(uploadPath, partFileName);
+        if (!Files.exists(partFile, LinkOption.NOFOLLOW_LINKS)) {
+            throw new ObjectStorageException("Local multipart part does not exist: " + partNumber);
+        }
+        try {
+            long partSize = Long.parseLong(size);
+            if (size(partFile) != partSize) {
+                throw new ObjectStorageException("Local multipart part size does not match metadata: " + partNumber);
+            }
+            return new StoredMultipartPart(new MultipartPart(partNumber, eTag, partSize), partFile);
+        } catch (NumberFormatException e) {
+            throw new ObjectStorageException("Local multipart part size is invalid: " + partNumber, e);
+        }
+    }
+
+    private Path multipartPartsPath(Path uploadPath) {
+        Path partsPath = uploadPath.resolve(MULTIPART_PARTS_DIRECTORY);
+        LocalStorageIoSupport.rejectSymbolicLinks(layout.storageRoot(), partsPath);
+        return partsPath;
+    }
+
+    private Path multipartPartDataPath(Path uploadPath, String fileName) {
+        if (!fileName.endsWith(MULTIPART_PART_EXTENSION)) {
+            throw new ObjectStorageException("Invalid local multipart part file: " + fileName);
+        }
+        Path partsPath = multipartPartsPath(uploadPath);
+        Path partPath = partsPath.resolve(fileName).normalize();
+        if (!partPath.getParent().equals(partsPath.normalize()) || !partPath.getFileName().toString().equals(fileName)) {
+            throw new ObjectStorageException("Invalid local multipart part file: " + fileName);
+        }
+        LocalStorageIoSupport.rejectSymbolicLinks(layout.storageRoot(), partPath);
+        return partPath;
+    }
+
+    private Path multipartPartPropertiesPath(Path uploadPath, int partNumber) {
+        Path propertiesPath = multipartPartsPath(uploadPath).resolve(partNumber + MULTIPART_PART_PROPERTIES_EXTENSION);
+        LocalStorageIoSupport.rejectSymbolicLinks(layout.storageRoot(), propertiesPath);
+        return propertiesPath;
+    }
+
+    private int parsePartNumber(Path partFile, String extension) {
+        String fileName = partFile.getFileName().toString();
+        try {
+            return Integer.parseInt(fileName.substring(0, fileName.length() - extension.length()));
+        } catch (NumberFormatException e) {
+            throw new ObjectStorageException("Invalid local multipart part file: " + fileName, e);
+        }
+    }
+
+    private Optional<String> retrieveCurrentPartFileName(Path uploadPath, Path propertiesPath, int partNumber) {
+        if (!Files.exists(propertiesPath, LinkOption.NOFOLLOW_LINKS)) {
+            return Optional.empty();
+        }
+        String partFileName = retrieveRequiredProperties(propertiesPath).getProperty(MULTIPART_PART_FILE_PROPERTY);
+        if (partFileName == null) {
+            throw new ObjectStorageException("Local multipart part metadata is incomplete: " + partNumber);
+        }
+        multipartPartDataPath(uploadPath, partFileName);
+        return Optional.of(partFileName);
+    }
+
+    private void deleteStalePartFile(Path uploadPath, @Nullable String previousPartFileName, String currentPartFileName) {
+        if (previousPartFileName == null || previousPartFileName.equals(currentPartFileName)) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(multipartPartDataPath(uploadPath, previousPartFileName));
+        } catch (IOException | RuntimeException e) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("Error deleting stale local multipart part file: {}", previousPartFileName, e);
+            }
+        }
+    }
+
+    private void storeFile(Path file, InputStream inputStream) {
+        try (InputStream in = inputStream) {
+            if (!mkdirs(file.getParent())) {
+                throw new ObjectStorageException("Error creating local multipart part directories: " + file);
+            }
+            try (OutputStream fileOut = LocalStorageIoSupport.newOutputStreamNoFollow(file, supportsPosixPermissions)) {
+                in.transferTo(fileOut);
+            }
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error copying multipart part to: " + file, e);
+        }
+    }
+
+    private void storeRequiredProperties(Path propertiesPath, Properties properties) {
+        if (!mkdirs(propertiesPath.getParent())) {
+            throw new ObjectStorageException("Error creating local multipart metadata directories: " + propertiesPath);
+        }
+        try (OutputStream out = LocalStorageIoSupport.newOutputStreamNoFollow(propertiesPath, supportsPosixPermissions)) {
+            properties.store(out, "Local multipart upload state");
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error storing local multipart metadata: " + propertiesPath, e);
+        }
+    }
+
+    private void moveReplacing(Path source, Path target) {
+        try {
+            Files.move(source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException e) {
+            try {
+                Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException moveException) {
+                throw new ObjectStorageException("Error committing local multipart file: " + target, moveException);
+            }
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error committing local multipart file: " + target, e);
+        }
+    }
+
+    private Properties retrieveRequiredProperties(Path propertiesPath) {
+        Properties properties = new Properties();
+        try (InputStream in = LocalStorageIoSupport.newInputStreamNoFollow(propertiesPath)) {
+            properties.load(in);
+            return properties;
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error reading local multipart metadata: " + propertiesPath, e);
+        }
+    }
+
+    private Optional<Properties> retrievePropertiesIfExists(Path propertiesPath) {
+        Properties properties = new Properties();
+        try (InputStream in = LocalStorageIoSupport.newInputStreamNoFollow(propertiesPath)) {
+            properties.load(in);
+            return Optional.of(properties);
+        } catch (NoSuchFileException e) {
+            return Optional.empty();
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error reading local multipart metadata: " + propertiesPath, e);
+        }
+    }
+
+    private Path createTempFile(Path directory, String prefix, String suffix) {
+        try {
+            return LocalStorageIoSupport.createTempFile(directory, prefix, suffix, supportsPosixPermissions);
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error creating local multipart temporary file", e);
+        }
+    }
+
+    private long size(Path path) {
+        try {
+            return Files.size(path);
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error reading local multipart part size: " + path, e);
+        }
+    }
+
+    private boolean mkdirs(Path path) {
+        return LocalStorageIoSupport.mkdirs(layout.rootInternalDirectory(), path, supportsPosixPermissions);
+    }
+
+    private void deleteCompletedMultipartUpload(Path uploadPath) {
+        try {
+            Path completedPropertiesPath = uploadPath.resolve(MULTIPART_COMPLETED_PROPERTIES);
+            try (Stream<Path> stream = Files.list(uploadPath)) {
+                for (Path path : stream.filter(path -> !path.equals(completedPropertiesPath)).toList()) {
+                    deleteRecursivelyOrFile(path);
+                }
+            }
+            Files.deleteIfExists(completedPropertiesPath);
+            Files.deleteIfExists(uploadPath);
+        } catch (NoSuchFileException ignored) {
+            // A concurrent abort or cleanup may have already removed the completed session.
+        } catch (IOException e) {
+            throw new ObjectStorageException("Error deleting local multipart upload: " + uploadPath, e);
+        }
+        deleteEmptyMultipartDirectories(null);
+    }
+
+    private void deleteRecursivelyOrFile(Path path) throws IOException {
+        if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+            LocalStorageBucketOperations.deleteRecursively(path);
+        } else {
+            Files.delete(path);
+        }
+    }
+
+    private void deleteRecursively(Path path, Throwable failure) {
+        try {
+            LocalStorageBucketOperations.deleteRecursively(path);
+        } catch (IOException | RuntimeException e) {
+            failure.addSuppressed(e);
+        }
+        deleteEmptyMultipartDirectories(failure);
+    }
+
+    private void deleteEmptyMultipartDirectories(@Nullable Throwable failure) {
+        for (Path directory : layout.multipartCleanupDirectories()) {
+            try {
+                Files.deleteIfExists(directory);
+            } catch (DirectoryNotEmptyException ignored) {
+                // Other local provider state still uses this directory.
+            } catch (IOException e) {
+                if (failure != null) {
+                    failure.addSuppressed(e);
+                } else {
+                    throw new ObjectStorageException("Error deleting local multipart directory: " + directory, e);
+                }
+            }
+        }
+    }
+
+    @Nullable
+    private static String nullIfEmpty(@Nullable String value) {
+        return value == null || value.isEmpty() ? null : value;
+    }
+
+    record UploadSession(@NonNull Path path,
+                         @NonNull Map<String, String> metadata,
+                         @Nullable String contentType) {
+    }
+
+    record StoredMultipartPart(@NonNull MultipartPart part,
+                               @NonNull Path path) {
+    }
+}

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -77,6 +77,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     static final String INTERNAL_DIRECTORY = LocalStorageLayout.INTERNAL_DIRECTORY;
     static final String LEGACY_METADATA_DIRECTORY = LocalStorageLayout.LEGACY_METADATA_DIRECTORY;
     static final String OBJECTS_DIRECTORY = LocalStorageLayout.OBJECTS_DIRECTORY;
+    static final String MULTIPART_DIRECTORY = LocalStorageLayout.MULTIPART_DIRECTORY;
     static final String SNAPSHOT_DIRECTORY = LocalStorageLayout.SNAPSHOT_DIRECTORY;
     private static final int DEFAULT_LIST_PAGE_SIZE = 1_000;
 

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -432,10 +432,12 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     }
 
     private Path storeFile(Path file, InputStream inputStream) {
-        mkdirs(configuration.getPath(), file.getParent());
-        try (OutputStream fileOut = newOutputStreamNoFollow(file)) {
-            inputStream.transferTo(fileOut);
-            return file;
+        try (InputStream in = inputStream) {
+            mkdirs(configuration.getPath(), file.getParent());
+            try (OutputStream fileOut = newOutputStreamNoFollow(file)) {
+                in.transferTo(fileOut);
+                return file;
+            }
         } catch (IOException e) {
             throw new ObjectStorageException("Error copying file to: " + file, e);
         }

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageBucketOperationsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageBucketOperationsSpec.groovy
@@ -4,6 +4,8 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.objectstorage.BucketOperationsSpecification
 import io.micronaut.objectstorage.ObjectStorageOperations
 import io.micronaut.objectstorage.bucket.BucketOperations
+import io.micronaut.objectstorage.multipart.CreateMultipartUploadRequest
+import io.micronaut.objectstorage.multipart.UploadPartRequest
 import io.micronaut.objectstorage.request.UploadRequest
 
 import java.nio.file.Files
@@ -94,21 +96,28 @@ class LocalStorageBucketOperationsSpec extends BucketOperationsSpecification {
         Files.exists(metadataFile)
     }
 
-    void 'bucket delete removes provider managed object metadata and snapshots'() {
+    void 'bucket delete removes provider managed object metadata multipart state and snapshots'() {
         given:
         Path objectMetadataDirectory = rootDirectory.resolve(LocalStorageOperations.INTERNAL_DIRECTORY)
             .resolve(LocalStorageLayout.METADATA_DIRECTORY)
             .resolve(LocalStorageOperations.OBJECTS_DIRECTORY)
             .resolve('default')
+        Path multipartDirectory = rootDirectory.resolve(LocalStorageOperations.INTERNAL_DIRECTORY)
+            .resolve(LocalStorageOperations.MULTIPART_DIRECTORY)
+            .resolve('default')
         Path snapshotDirectory = rootDirectory.resolve(LocalStorageOperations.INTERNAL_DIRECTORY)
             .resolve(LocalStorageOperations.SNAPSHOT_DIRECTORY)
             .resolve('default')
         getObjectStorage().upload(UploadRequest.fromBytes('hello'.bytes, 'delete-me.txt', 'text/plain'))
+        def multipartOperations = ctx.getBean(LocalStorageMultipartOperations)
+        def multipartUpload = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest('multipart/delete-me.txt', 'text/plain')).upload
+        multipartOperations.uploadPart(new UploadPartRequest(multipartUpload, 1, UploadRequest.fromBytes('part'.bytes, 'multipart/delete-me.txt', 'text/plain')))
         Files.createDirectories(snapshotDirectory)
         Files.writeString(snapshotDirectory.resolve('temporary'), 'snapshot')
 
         expect:
         Files.exists(objectMetadataDirectory.resolve('delete-me.txt'))
+        Files.exists(multipartDirectory.resolve(multipartUpload.uploadId))
         Files.exists(snapshotDirectory.resolve('temporary'))
 
         when:
@@ -117,6 +126,7 @@ class LocalStorageBucketOperationsSpec extends BucketOperationsSpecification {
         then:
         !Files.exists(defaultBucketPath)
         !Files.exists(objectMetadataDirectory)
+        !Files.exists(multipartDirectory)
         !Files.exists(snapshotDirectory)
         !ctx.getBean(LocalStorageObjectMetadataOperations).retrieve('delete-me.txt').present
     }

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageFilePermissionsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageFilePermissionsSpec.groovy
@@ -2,6 +2,8 @@ package io.micronaut.objectstorage.local
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.objectstorage.metadata.BucketMetadataWrite
+import io.micronaut.objectstorage.multipart.CreateMultipartUploadRequest
+import io.micronaut.objectstorage.multipart.UploadPartRequest
 import io.micronaut.objectstorage.request.UploadRequest
 import spock.lang.Requires
 import spock.lang.Specification
@@ -25,6 +27,7 @@ class LocalStorageFilePermissionsSpec extends Specification {
         Path bucket = root.resolve("bucket")
         ApplicationContext ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
         LocalStorageOperations operations = ctx.getBean(LocalStorageOperations)
+        LocalStorageMultipartOperations multipartOperations = ctx.getBean(LocalStorageMultipartOperations)
         LocalStorageBucketOperations bucketOperations = ctx.getBean(LocalStorageBucketOperations)
         LocalStorageBucketMetadataOperations bucketMetadataOperations = ctx.getBean(LocalStorageBucketMetadataOperations)
         UploadRequest request = UploadRequest.fromBytes('secret'.getBytes(StandardCharsets.UTF_8), 'nested/deeper/object.txt', 'text/plain')
@@ -34,6 +37,12 @@ class LocalStorageFilePermissionsSpec extends Specification {
         bucketOperations.create('reports')
         bucketMetadataOperations.save(new BucketMetadataWrite('reports', [region: 'internal'], [:]))
         operations.upload(request)
+        def multipartUpload = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest('multipart/secret.txt', 'text/plain')).upload
+        def multipartPart = multipartOperations.uploadPart(new UploadPartRequest(multipartUpload, 1, UploadRequest.fromBytes('part'.bytes, 'multipart/secret.txt', 'text/plain')))
+        Path multipartUploadDirectory = root.resolve(LocalStorageOperations.INTERNAL_DIRECTORY)
+            .resolve(LocalStorageOperations.MULTIPART_DIRECTORY)
+            .resolve('bucket')
+            .resolve(multipartUpload.uploadId)
 
         then:
         Files.getPosixFilePermissions(bucket) == ownerOnlyDirectoryPermissions()
@@ -46,6 +55,13 @@ class LocalStorageFilePermissionsSpec extends Specification {
         Files.getPosixFilePermissions(root.resolve(LocalStorageOperations.INTERNAL_DIRECTORY).resolve(LocalStorageLayout.METADATA_DIRECTORY).resolve(LocalStorageOperations.OBJECTS_DIRECTORY).resolve('bucket/nested/deeper/object.txt')) == ownerOnlyFilePermissions()
         Files.getPosixFilePermissions(root.resolve(LocalStorageOperations.INTERNAL_DIRECTORY).resolve(LocalStorageLayout.METADATA_DIRECTORY).resolve('buckets')) == ownerOnlyDirectoryPermissions()
         Files.getPosixFilePermissions(root.resolve(LocalStorageOperations.INTERNAL_DIRECTORY).resolve(LocalStorageLayout.METADATA_DIRECTORY).resolve('buckets/reports')) == ownerOnlyFilePermissions()
+        Files.getPosixFilePermissions(root.resolve(LocalStorageOperations.INTERNAL_DIRECTORY).resolve(LocalStorageOperations.MULTIPART_DIRECTORY)) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(root.resolve(LocalStorageOperations.INTERNAL_DIRECTORY).resolve(LocalStorageOperations.MULTIPART_DIRECTORY).resolve('bucket')) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(multipartUploadDirectory) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(multipartUploadDirectory.resolve('upload.properties')) == ownerOnlyFilePermissions()
+        Files.getPosixFilePermissions(multipartUploadDirectory.resolve('parts')) == ownerOnlyDirectoryPermissions()
+        Files.getPosixFilePermissions(multipartPart.nativeResponse.path) == ownerOnlyFilePermissions()
+        Files.getPosixFilePermissions(multipartUploadDirectory.resolve('parts/1.properties')) == ownerOnlyFilePermissions()
         Files.getPosixFilePermissions(bucket.resolve('nested')) == ownerOnlyDirectoryPermissions()
         Files.getPosixFilePermissions(bucket.resolve('nested/deeper')) == ownerOnlyDirectoryPermissions()
         Files.getPosixFilePermissions(bucket.resolve('nested/deeper/object.txt')) == ownerOnlyFilePermissions()

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMultipartOperationsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMultipartOperationsSpec.groovy
@@ -70,6 +70,23 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
         operations.listObjects().each { operations.delete(it) }
     }
 
+    void 'local multipart lists no parts for a new upload'() {
+        given:
+        String key = 'multipart-local/new-upload.txt'
+        def createResponse = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE))
+        def upload = createResponse.upload
+
+        when:
+        def response = multipartOperations.listParts(new ListMultipartPartsRequest(upload, 10, ''))
+
+        then:
+        response.parts.empty
+        !response.getContinuationToken().present
+
+        cleanup:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+    }
+
     void 'local multipart scratch state is hidden until completion and cleaned up after completion'() {
         given:
         String key = 'multipart-local/demo.txt'
@@ -121,6 +138,25 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
         listedParts*.ETag == [originalPart.part.ETag]
         response.ETag
         entry.inputStream.text == 'original'
+    }
+
+    void 'successful local multipart part replacement commits the latest part'() {
+        given:
+        String key = 'multipart-local/successful-replacement.txt'
+        def createResponse = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE))
+        def upload = createResponse.upload
+        multipartOperations.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes('old'.bytes, key, CONTENT_TYPE)))
+        String stalePartFileName = loadProperties(partPropertiesPath(createResponse.nativeResponse.path, 1)).getProperty('file')
+
+        when:
+        def replacementPart = multipartOperations.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes('new'.bytes, key, CONTENT_TYPE)))
+        def response = multipartOperations.completeMultipartUpload(new CompleteMultipartUploadRequest(upload, [replacementPart.part]))
+        def entry = operations.retrieve(key).get()
+
+        then:
+        response.ETag
+        entry.inputStream.text == 'new'
+        !Files.exists(partDataPath(createResponse.nativeResponse.path, stalePartFileName))
     }
 
     void 'failed local multipart complete removes assembled temporary file and leaves upload abortable'() {
@@ -179,6 +215,138 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
 
         then:
         !Files.exists(createResponse.nativeResponse.path)
+    }
+
+    void 'local multipart complete rejects ETag mismatches'() {
+        given:
+        def fixture = createUploadWithSinglePart('multipart-local/wrong-etag.txt')
+        MultipartPart wrongPart = new MultipartPart(fixture.part.partNumber, 'wrong-etag', fixture.part.size)
+
+        when:
+        multipartOperations.completeMultipartUpload(new CompleteMultipartUploadRequest(fixture.upload, [wrongPart]))
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message == 'Local multipart part ETag does not match: 1'
+        !containsCompletedMultipartFile(fixture.uploadPath)
+
+        cleanup:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(fixture.upload))
+    }
+
+    void 'local multipart tolerates empty stored content type'() {
+        given:
+        def fixture = createUploadWithSinglePart('multipart-local/empty-content-type.txt')
+        Path uploadPropertiesPath = fixture.uploadPath.resolve('upload.properties')
+        Properties properties = loadProperties(uploadPropertiesPath)
+        properties.setProperty('contentType', '')
+        storeProperties(uploadPropertiesPath, properties)
+
+        when:
+        def response = multipartOperations.completeMultipartUpload(new CompleteMultipartUploadRequest(fixture.upload, [fixture.part]))
+
+        then:
+        response.ETag
+    }
+
+    void 'local multipart rejects incomplete part metadata'() {
+        given:
+        def fixture = createUploadWithSinglePart("multipart-local/incomplete-${propertyName}.txt")
+        Properties properties = loadProperties(partPropertiesPath(fixture.uploadPath, 1))
+        properties.remove(propertyName)
+        storeProperties(partPropertiesPath(fixture.uploadPath, 1), properties)
+
+        when:
+        multipartOperations.listParts(new ListMultipartPartsRequest(fixture.upload, 10))
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message == 'Local multipart part metadata is incomplete: 1'
+
+        cleanup:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(fixture.upload))
+
+        where:
+        propertyName << ['eTag', 'size', 'file']
+    }
+
+    void 'local multipart rejects missing part data'() {
+        given:
+        def fixture = createUploadWithSinglePart('multipart-local/missing-part-data.txt')
+        Properties properties = loadProperties(partPropertiesPath(fixture.uploadPath, 1))
+        Files.delete(partDataPath(fixture.uploadPath, properties.getProperty('file')))
+
+        when:
+        multipartOperations.listParts(new ListMultipartPartsRequest(fixture.upload, 10))
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message == 'Local multipart part does not exist: 1'
+
+        cleanup:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(fixture.upload))
+    }
+
+    void 'local multipart rejects part size metadata mismatches'() {
+        given:
+        def fixture = createUploadWithSinglePart("multipart-local/${sizeValue}.txt")
+        Properties properties = loadProperties(partPropertiesPath(fixture.uploadPath, 1))
+        properties.setProperty('size', sizeValue)
+        storeProperties(partPropertiesPath(fixture.uploadPath, 1), properties)
+
+        when:
+        multipartOperations.listParts(new ListMultipartPartsRequest(fixture.upload, 10))
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message == expectedMessage
+
+        cleanup:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(fixture.upload))
+
+        where:
+        sizeValue      | expectedMessage
+        '999'          | 'Local multipart part size does not match metadata: 1'
+        'not-a-number' | 'Local multipart part size is invalid: 1'
+    }
+
+    void 'local multipart rejects invalid stored part file names'() {
+        given:
+        def fixture = createUploadWithSinglePart("multipart-local/invalid-part-file-${index}.txt")
+        Properties properties = loadProperties(partPropertiesPath(fixture.uploadPath, 1))
+        properties.setProperty('file', fileName)
+        storeProperties(partPropertiesPath(fixture.uploadPath, 1), properties)
+
+        when:
+        multipartOperations.listParts(new ListMultipartPartsRequest(fixture.upload, 10))
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message == "Invalid local multipart part file: ${fileName}"
+
+        cleanup:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(fixture.upload))
+
+        where:
+        index | fileName
+        1     | 'part.txt'
+        2     | '../escape.part'
+    }
+
+    void 'local multipart rejects malformed part metadata file names'() {
+        given:
+        def fixture = createUploadWithSinglePart('multipart-local/malformed-part-metadata.txt')
+        Files.writeString(fixture.uploadPath.resolve('parts').resolve('broken.properties'), '')
+
+        when:
+        multipartOperations.listParts(new ListMultipartPartsRequest(fixture.upload, 10))
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message == 'Invalid local multipart part file: broken.properties'
+
+        cleanup:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(fixture.upload))
     }
 
     void 'local multipart abort validates the upload key before deleting an existing upload'() {
@@ -254,6 +422,26 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
         ]
     }
 
+    void 'local multipart rejects malformed continuation token page sizes'() {
+        given:
+        String key = 'multipart-local/malformed-page-size-token.txt'
+        def upload = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE)).upload
+
+        when:
+        multipartOperations.listParts(new ListMultipartPartsRequest(
+            upload,
+            2,
+            continuationToken(key, upload.uploadId, 'two', '1')
+        ))
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message == 'Invalid local multipart continuation token'
+
+        cleanup:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+    }
+
     void 'local multipart rejects non-positive continuation markers before listing parts'() {
         given:
         String key = 'multipart-local/non-positive-token-marker.txt'
@@ -289,6 +477,52 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
         !Files.exists(multipartBucketDirectory)
     }
 
+    void 'local multipart rejects invalid upload ids'() {
+        when:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(new MultipartUploadHandle('multipart-local/object.txt', 'not-a-uuid')))
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message == 'Invalid local multipart upload id: not-a-uuid'
+    }
+
+    private MultipartUploadFixture createUploadWithSinglePart(String key) {
+        def createResponse = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE))
+        def upload = createResponse.upload
+        def part = multipartOperations.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes('part'.bytes, key, CONTENT_TYPE))).part
+        new MultipartUploadFixture(upload, createResponse.nativeResponse.path, part)
+    }
+
+    private static Path partPropertiesPath(Path uploadPath, int partNumber) {
+        uploadPath.resolve('parts').resolve(partNumber + '.properties')
+    }
+
+    private static Path partDataPath(Path uploadPath, String fileName) {
+        uploadPath.resolve('parts').resolve(fileName)
+    }
+
+    private static Properties loadProperties(Path path) {
+        Properties properties = new Properties()
+        Files.newInputStream(path).withCloseable { properties.load(it) }
+        properties
+    }
+
+    private static void storeProperties(Path path, Properties properties) {
+        Files.newOutputStream(path).withCloseable { properties.store(it, 'test') }
+    }
+
+    private static final class MultipartUploadFixture {
+        private final MultipartUploadHandle upload
+        private final Path uploadPath
+        private final MultipartPart part
+
+        private MultipartUploadFixture(MultipartUploadHandle upload, Path uploadPath, MultipartPart part) {
+            this.upload = upload
+            this.uploadPath = uploadPath
+            this.part = part
+        }
+    }
+
     private static boolean containsCompletedMultipartFile(Path uploadPath) {
         Files.list(uploadPath).withCloseable { stream ->
             stream.anyMatch { path -> path.fileName.toString().endsWith('.complete') }
@@ -296,11 +530,15 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
     }
 
     private static String continuationToken(String key, String uploadId, int pageSize, int marker) {
+        continuationToken(key, uploadId, Integer.toString(pageSize), Integer.toString(marker))
+    }
+
+    private static String continuationToken(String key, String uploadId, String pageSize, String marker) {
         String payload = new StringJoiner('\n')
             .add(encodeTokenPart(key))
             .add(encodeTokenPart(uploadId))
-            .add(encodeTokenPart(Integer.toString(pageSize)))
-            .add(encodeTokenPart(Integer.toString(marker)))
+            .add(encodeTokenPart(pageSize))
+            .add(encodeTokenPart(marker))
             .toString()
         'local-multipart:v1:' + Base64.getUrlEncoder().withoutPadding()
             .encodeToString(payload.getBytes(StandardCharsets.UTF_8))

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMultipartOperationsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMultipartOperationsSpec.groovy
@@ -1,0 +1,387 @@
+package io.micronaut.objectstorage.local
+
+import io.micronaut.objectstorage.MultipartObjectStorageOperationsSpecification
+import io.micronaut.objectstorage.ObjectStorageException
+import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.bucket.BucketOperations
+import io.micronaut.objectstorage.metadata.ObjectMetadataOperations
+import io.micronaut.objectstorage.multipart.AbortMultipartUploadRequest
+import io.micronaut.objectstorage.multipart.CompleteMultipartUploadRequest
+import io.micronaut.objectstorage.multipart.CreateMultipartUploadRequest
+import io.micronaut.objectstorage.multipart.ListMultipartPartsRequest
+import io.micronaut.objectstorage.multipart.MultipartObjectStorageOperations
+import io.micronaut.objectstorage.multipart.MultipartPart
+import io.micronaut.objectstorage.multipart.MultipartUploadHandle
+import io.micronaut.objectstorage.multipart.UploadPartRequest
+import io.micronaut.objectstorage.request.UploadRequest
+import io.micronaut.objectstorage.response.UploadResponse
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Base64
+
+@MicronautTest
+class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperationsSpecification implements TestPropertyProvider {
+
+    private static final int LOCAL_NON_FINAL_MULTIPART_PART_SIZE_BYTES = 32
+
+    @Inject
+    LocalStorageOperations operations
+
+    @Inject
+    LocalStorageBucketOperations bucketOperations
+
+    @Inject
+    LocalStorageMultipartOperations multipartOperations
+
+    @Inject
+    LocalStorageConfiguration configuration
+
+    @Override
+    ObjectStorageOperations<?, ?, ?> getObjectStorage() {
+        operations
+    }
+
+    @Override
+    BucketOperations<?> getBucketOperations() {
+        bucketOperations
+    }
+
+    @Override
+    MultipartObjectStorageOperations<?, ?, ?> getMultipartObjectStorage() {
+        multipartOperations
+    }
+
+    @Override
+    protected int nonFinalMultipartPartSizeBytes() {
+        LOCAL_NON_FINAL_MULTIPART_PART_SIZE_BYTES
+    }
+
+    @Override
+    Map<String, String> getProperties() {
+        [(LocalStorageConfiguration.PREFIX + '.default.enabled'): 'true']
+    }
+
+    void cleanup() {
+        operations.listObjects().each { operations.delete(it) }
+    }
+
+    void 'local multipart scratch state is hidden until completion and cleaned up after completion'() {
+        given:
+        String key = 'multipart-local/demo.txt'
+        Map<String, String> metadata = [owner: 'local']
+        def createResponse = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE, metadata))
+        def upload = createResponse.upload
+
+        when:
+        def firstPart = multipartOperations.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes('micro'.bytes, key, CONTENT_TYPE)))
+        def secondPart = multipartOperations.uploadPart(new UploadPartRequest(upload, 2, UploadRequest.fromBytes('naut'.bytes, key, CONTENT_TYPE)))
+
+        then:
+        Files.exists(createResponse.nativeResponse.path)
+        operations.listObjects().empty
+
+        when:
+        def response = multipartOperations.completeMultipartUpload(new CompleteMultipartUploadRequest(upload, [firstPart.part, secondPart.part]))
+        def entry = operations.retrieve(key).get()
+
+        then:
+        response.ETag
+        operations.listObjects() == [key] as Set
+        entry.inputStream.text == 'micronaut'
+        entry.metadata == metadata
+        entry.contentType.get() == CONTENT_TYPE
+        !Files.exists(createResponse.nativeResponse.path)
+    }
+
+    void 'failed local multipart part replacement preserves the previously uploaded part'() {
+        given:
+        String key = 'multipart-local/replacement.txt'
+        def createResponse = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE))
+        def upload = createResponse.upload
+        def originalPart = multipartOperations.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes('original'.bytes, key, CONTENT_TYPE)))
+
+        when:
+        multipartOperations.uploadPart(new UploadPartRequest(upload, 1, new FailingUploadRequest(key, CONTENT_TYPE, 'replacement'.bytes, 4)))
+
+        then:
+        thrown(ObjectStorageException)
+
+        when:
+        def listedParts = multipartOperations.listParts(new ListMultipartPartsRequest(upload, 10)).parts
+        def response = multipartOperations.completeMultipartUpload(new CompleteMultipartUploadRequest(upload, [originalPart.part]))
+        def entry = operations.retrieve(key).get()
+
+        then:
+        listedParts*.partNumber == [1]
+        listedParts*.ETag == [originalPart.part.ETag]
+        response.ETag
+        entry.inputStream.text == 'original'
+    }
+
+    void 'failed local multipart complete removes assembled temporary file and leaves upload abortable'() {
+        given:
+        String key = 'multipart-local/failed-complete.txt'
+        def createResponse = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE))
+        def upload = createResponse.upload
+        def uploadedPart = multipartOperations.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes('micro'.bytes, key, CONTENT_TYPE)))
+        MultipartPart missingPart = new MultipartPart(2, 'missing-etag', 4)
+
+        when:
+        multipartOperations.completeMultipartUpload(new CompleteMultipartUploadRequest(upload, [uploadedPart.part, missingPart]))
+
+        then:
+        thrown(ObjectStorageException)
+        !operations.exists(key)
+        Files.exists(createResponse.nativeResponse.path)
+        !containsCompletedMultipartFile(createResponse.nativeResponse.path)
+
+        when:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+
+        then:
+        !Files.exists(createResponse.nativeResponse.path)
+    }
+
+    void 'failed local multipart final upload removes assembled temporary file and leaves upload abortable'() {
+        given:
+        String key = 'multipart-local/failed-final-upload.txt'
+        ObjectMetadataOperations<Path> metadataOperations = Mock()
+        LocalStorageOperations failingOperations = new LocalStorageOperations(configuration, metadataOperations) {
+            @Override
+            UploadResponse<LocalStorageFile> upload(UploadRequest request) {
+                throw new ObjectStorageException('final upload failed')
+            }
+        }
+        LocalStorageMultipartOperations failingMultipartOperations = new LocalStorageMultipartOperations(configuration, failingOperations)
+        def createResponse = failingMultipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE))
+        def upload = createResponse.upload
+        def firstPart = failingMultipartOperations.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes('micro'.bytes, key, CONTENT_TYPE)))
+        def secondPart = failingMultipartOperations.uploadPart(new UploadPartRequest(upload, 2, UploadRequest.fromBytes('naut'.bytes, key, CONTENT_TYPE)))
+
+        when:
+        failingMultipartOperations.completeMultipartUpload(new CompleteMultipartUploadRequest(upload, [firstPart.part, secondPart.part]))
+
+        then:
+        thrown(ObjectStorageException)
+        !operations.exists(key)
+        Files.exists(createResponse.nativeResponse.path)
+        !containsCompletedMultipartFile(createResponse.nativeResponse.path)
+
+        when:
+        failingMultipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+        failingMultipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+
+        then:
+        !Files.exists(createResponse.nativeResponse.path)
+    }
+
+    void 'local multipart abort validates the upload key before deleting an existing upload'() {
+        given:
+        String key = 'multipart-local/abort-key.txt'
+        def createResponse = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE))
+        def upload = createResponse.upload
+        def wrongKeyUpload = new MultipartUploadHandle('multipart-local/other.txt', upload.uploadId)
+
+        when:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(wrongKeyUpload))
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message == 'Multipart upload key does not match local upload session'
+        Files.exists(createResponse.nativeResponse.path)
+
+        cleanup:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+    }
+
+    void 'local multipart continuation tokens are bound to the upload and page size'() {
+        given:
+        String firstKey = 'multipart-local/first.txt'
+        String secondKey = 'multipart-local/second.txt'
+        def firstUpload = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(firstKey, CONTENT_TYPE)).upload
+        def secondUpload = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(secondKey, CONTENT_TYPE)).upload
+        multipartOperations.uploadPart(new UploadPartRequest(firstUpload, 1, UploadRequest.fromBytes('one'.bytes, firstKey, CONTENT_TYPE)))
+        multipartOperations.uploadPart(new UploadPartRequest(firstUpload, 2, UploadRequest.fromBytes('two'.bytes, firstKey, CONTENT_TYPE)))
+        multipartOperations.uploadPart(new UploadPartRequest(secondUpload, 1, UploadRequest.fromBytes('one'.bytes, secondKey, CONTENT_TYPE)))
+        multipartOperations.uploadPart(new UploadPartRequest(secondUpload, 2, UploadRequest.fromBytes('two'.bytes, secondKey, CONTENT_TYPE)))
+        String token = multipartOperations.listParts(new ListMultipartPartsRequest(firstUpload, 1)).getContinuationToken().get()
+
+        when:
+        multipartOperations.listParts(new ListMultipartPartsRequest(secondUpload, 1, token))
+
+        then:
+        ObjectStorageException uploadException = thrown()
+        uploadException.message == 'Local multipart continuation token does not match the current request'
+
+        when:
+        multipartOperations.listParts(new ListMultipartPartsRequest(firstUpload, 2, token))
+
+        then:
+        ObjectStorageException pageSizeException = thrown()
+        pageSizeException.message == 'Local multipart continuation token does not match the current request'
+
+        cleanup:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(firstUpload))
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(secondUpload))
+    }
+
+    void 'local multipart rejects invalid continuation tokens before listing parts'() {
+        given:
+        String key = 'multipart-local/invalid-token.txt'
+        def upload = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE)).upload
+
+        when:
+        multipartOperations.listParts(new ListMultipartPartsRequest(upload, 2, token))
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message == 'Invalid local multipart continuation token'
+
+        cleanup:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+
+        where:
+        token << [
+            'part-2',
+            'local-multipart:v1:not-base64',
+            'local-multipart:v1:' + Base64.getUrlEncoder().withoutPadding().encodeToString('too-short'.getBytes(StandardCharsets.UTF_8))
+        ]
+    }
+
+    void 'local multipart rejects non-positive continuation markers before listing parts'() {
+        given:
+        String key = 'multipart-local/non-positive-token-marker.txt'
+        def upload = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE)).upload
+
+        when:
+        multipartOperations.listParts(new ListMultipartPartsRequest(
+            upload,
+            2,
+            continuationToken(key, upload.uploadId, 2, marker)
+        ))
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message == 'Invalid local multipart continuation token'
+
+        cleanup:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+
+        where:
+        marker << [0, -1]
+    }
+
+    void 'local multipart rejects reserved keys before creating scratch state'() {
+        given:
+        Path multipartBucketDirectory = new LocalStorageLayout(configuration).multipartBucketDirectory()
+
+        when:
+        multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest('.mn-storage/multipart.txt', CONTENT_TYPE))
+
+        then:
+        thrown(IllegalArgumentException)
+        !Files.exists(multipartBucketDirectory)
+    }
+
+    private static boolean containsCompletedMultipartFile(Path uploadPath) {
+        Files.list(uploadPath).withCloseable { stream ->
+            stream.anyMatch { path -> path.fileName.toString().endsWith('.complete') }
+        }
+    }
+
+    private static String continuationToken(String key, String uploadId, int pageSize, int marker) {
+        String payload = new StringJoiner('\n')
+            .add(encodeTokenPart(key))
+            .add(encodeTokenPart(uploadId))
+            .add(encodeTokenPart(Integer.toString(pageSize)))
+            .add(encodeTokenPart(Integer.toString(marker)))
+            .toString()
+        'local-multipart:v1:' + Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(payload.getBytes(StandardCharsets.UTF_8))
+    }
+
+    private static String encodeTokenPart(String value) {
+        Base64.getUrlEncoder().withoutPadding().encodeToString(value.getBytes(StandardCharsets.UTF_8))
+    }
+
+    private static final class FailingUploadRequest implements UploadRequest {
+        private final String key
+        private final String contentType
+        private final byte[] bytes
+        private final int failureAfterBytes
+
+        private FailingUploadRequest(String key, String contentType, byte[] bytes, int failureAfterBytes) {
+            this.key = key
+            this.contentType = contentType
+            this.bytes = bytes
+            this.failureAfterBytes = failureAfterBytes
+        }
+
+        @Override
+        Optional<String> getContentType() {
+            Optional.of(contentType)
+        }
+
+        @Override
+        String getKey() {
+            key
+        }
+
+        @Override
+        Optional<Long> getContentSize() {
+            Optional.of((long) bytes.length)
+        }
+
+        @Override
+        InputStream getInputStream() {
+            new FailingInputStream(bytes, failureAfterBytes)
+        }
+
+        @Override
+        Map<String, String> getMetadata() {
+            [:]
+        }
+    }
+
+    private static final class FailingInputStream extends InputStream {
+        private final byte[] bytes
+        private final int failureAfterBytes
+        private int index
+
+        private FailingInputStream(byte[] bytes, int failureAfterBytes) {
+            this.bytes = bytes
+            this.failureAfterBytes = failureAfterBytes
+        }
+
+        @Override
+        int read() throws IOException {
+            if (index >= failureAfterBytes) {
+                throw new IOException('simulated upload failure')
+            }
+            if (index >= bytes.length) {
+                return -1
+            }
+            bytes[index++] & 0xff
+        }
+
+        @Override
+        int read(byte[] buffer, int offset, int length) throws IOException {
+            if (index >= failureAfterBytes) {
+                throw new IOException('simulated upload failure')
+            }
+            if (index >= bytes.length) {
+                return -1
+            }
+            int count = Math.min(length, Math.min(bytes.length, failureAfterBytes) - index)
+            System.arraycopy(bytes, index, buffer, offset, count)
+            index += count
+            count
+        }
+    }
+}

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMultipartOperationsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMultipartOperationsSpec.groovy
@@ -18,10 +18,12 @@ import io.micronaut.objectstorage.response.UploadResponse
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
 import jakarta.inject.Inject
+import org.opentest4j.TestAbortedException
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
 import java.util.Base64
 
 @MicronautTest
@@ -100,6 +102,7 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
 
         then:
         Files.exists(createResponse.nativeResponse.path)
+        createResponse.nativeResponse instanceof LocalStorageMultipartUpload
         operations.listObjects().empty
 
         when:
@@ -113,6 +116,53 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
         entry.metadata == metadata
         entry.contentType.get() == CONTENT_TYPE
         !Files.exists(createResponse.nativeResponse.path)
+    }
+
+    void 'local multipart complete marks upload terminal before best-effort cleanup'() {
+        given:
+        assumePosixPermissionsSupported(configuration.path)
+        String key = 'multipart-local/completed-before-cleanup.txt'
+        def fixture = createUploadWithSinglePart(key)
+        Path partsPath = fixture.uploadPath.resolve('parts')
+        setOwnerReadExecuteOnly(partsPath)
+
+        when:
+        def response = multipartOperations.completeMultipartUpload(new CompleteMultipartUploadRequest(fixture.upload, [fixture.part]))
+        def entry = operations.retrieve(key).get()
+
+        then:
+        response.ETag
+        entry.inputStream.text == 'part'
+        Files.exists(fixture.uploadPath)
+        Files.exists(completedPropertiesPath(fixture.uploadPath))
+        !Files.exists(fixture.uploadPath.resolve('upload.properties'))
+
+        when:
+        multipartOperations.uploadPart(new UploadPartRequest(fixture.upload, 2, UploadRequest.fromBytes('late'.bytes, key, CONTENT_TYPE)))
+
+        then:
+        ObjectStorageException uploadPartException = thrown()
+        uploadPartException.message == "Local multipart upload is already completed: ${fixture.upload.uploadId}"
+
+        when:
+        multipartOperations.listParts(new ListMultipartPartsRequest(fixture.upload, 10))
+
+        then:
+        ObjectStorageException listPartsException = thrown()
+        listPartsException.message == "Local multipart upload is already completed: ${fixture.upload.uploadId}"
+
+        when:
+        multipartOperations.completeMultipartUpload(new CompleteMultipartUploadRequest(fixture.upload, [fixture.part]))
+
+        then:
+        ObjectStorageException completeException = thrown()
+        completeException.message == "Local multipart upload is already completed: ${fixture.upload.uploadId}"
+
+        cleanup:
+        restoreOwnerOnlyDirectoryPermissions(partsPath)
+        if (fixture != null) {
+            multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(fixture.upload))
+        }
     }
 
     void 'failed local multipart part replacement preserves the previously uploaded part'() {
@@ -138,6 +188,41 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
         listedParts*.ETag == [originalPart.part.ETag]
         response.ETag
         entry.inputStream.text == 'original'
+    }
+
+    void 'local multipart part replacement rejects corrupt existing metadata before committing replacement'() {
+        given:
+        String key = "multipart-local/corrupt-replacement-${scenario}.txt"
+        def createResponse = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE))
+        def upload = createResponse.upload
+        multipartOperations.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes('original'.bytes, key, CONTENT_TYPE)))
+        Path propertiesPath = partPropertiesPath(createResponse.nativeResponse.path, 1)
+        Properties originalProperties = loadProperties(propertiesPath)
+        Path originalPartPath = partDataPath(createResponse.nativeResponse.path, originalProperties.getProperty('file'))
+        Properties corruptProperties = new Properties()
+        corruptProperties.putAll(originalProperties)
+        tamper(corruptProperties)
+        storeProperties(propertiesPath, corruptProperties)
+
+        when:
+        multipartOperations.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes('replacement'.bytes, key, CONTENT_TYPE)))
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message == expectedMessage
+        Files.exists(originalPartPath)
+        findPartDataFiles(createResponse.nativeResponse.path) == [originalPartPath]
+
+        cleanup:
+        if (createResponse != null && propertiesPath != null && originalProperties != null) {
+            storeProperties(propertiesPath, originalProperties)
+            multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+        }
+
+        where:
+        scenario     | tamper                                                                  | expectedMessage
+        'incomplete' | { Properties properties -> properties.remove('file') }                   | 'Local multipart part metadata is incomplete: 1'
+        'invalid'    | { Properties properties -> properties.setProperty('file', '../1.part') } | 'Invalid local multipart part file: ../1.part'
     }
 
     void 'successful local multipart part replacement commits the latest part'() {
@@ -215,6 +300,77 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
 
         then:
         !Files.exists(createResponse.nativeResponse.path)
+    }
+
+    void 'local multipart abort is retry-safe when active metadata is already gone'() {
+        given:
+        String key = 'multipart-local/missing-active-metadata.txt'
+        def createResponse = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE))
+        def upload = createResponse.upload
+        Files.delete(createResponse.nativeResponse.path.resolve('upload.properties'))
+
+        when:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+
+        then:
+        noExceptionThrown()
+        !Files.exists(createResponse.nativeResponse.path)
+    }
+
+    void 'local multipart abort validates completed metadata before deleting leftover state'() {
+        given:
+        String key = 'multipart-local/completed-abort.txt'
+        def createResponse = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE))
+        def upload = createResponse.upload
+        Files.move(createResponse.nativeResponse.path.resolve('upload.properties'), completedPropertiesPath(createResponse.nativeResponse.path))
+        def wrongKeyUpload = new MultipartUploadHandle('multipart-local/wrong.txt', upload.uploadId)
+
+        when:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(wrongKeyUpload))
+
+        then:
+        ObjectStorageException e = thrown()
+        e.message == 'Multipart upload key does not match local upload session'
+        Files.exists(createResponse.nativeResponse.path)
+
+        when:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+
+        then:
+        noExceptionThrown()
+        !Files.exists(createResponse.nativeResponse.path)
+    }
+
+    void 'local multipart part upload closes the consumed input stream'() {
+        given:
+        String key = 'multipart-local/close-part-stream.txt'
+        def upload = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE)).upload
+        def request = new CloseTrackingUploadRequest(key, CONTENT_TYPE, 'part'.bytes)
+
+        when:
+        multipartOperations.uploadPart(new UploadPartRequest(upload, 1, request))
+
+        then:
+        request.closed
+
+        cleanup:
+        if (upload != null) {
+            multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+        }
+    }
+
+    void 'local direct upload closes the consumed input stream'() {
+        given:
+        String key = 'multipart-local/close-direct-stream.txt'
+        def request = new CloseTrackingUploadRequest(key, CONTENT_TYPE, 'direct'.bytes)
+
+        when:
+        operations.upload(request)
+
+        then:
+        request.closed
     }
 
     void 'local multipart complete rejects ETag mismatches'() {
@@ -501,6 +657,19 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
         uploadPath.resolve('parts').resolve(fileName)
     }
 
+    private static Path completedPropertiesPath(Path uploadPath) {
+        uploadPath.resolve('completed.properties')
+    }
+
+    private static List<Path> findPartDataFiles(Path uploadPath) {
+        Files.list(uploadPath.resolve('parts')).withCloseable { stream ->
+            stream
+                .filter { path -> path.fileName.toString().endsWith('.part') }
+                .sorted()
+                .toList()
+        }
+    }
+
     private static Properties loadProperties(Path path) {
         Properties properties = new Properties()
         Files.newInputStream(path).withCloseable { properties.load(it) }
@@ -509,6 +678,29 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
 
     private static void storeProperties(Path path, Properties properties) {
         Files.newOutputStream(path).withCloseable { properties.store(it, 'test') }
+    }
+
+    private static void assumePosixPermissionsSupported(Path path) {
+        if (!path.fileSystem.supportedFileAttributeViews().contains('posix')) {
+            throw new TestAbortedException('POSIX file permissions are not supported in this environment')
+        }
+    }
+
+    private static void setOwnerReadExecuteOnly(Path path) {
+        Files.setPosixFilePermissions(path, EnumSet.of(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_EXECUTE
+        ))
+    }
+
+    private static void restoreOwnerOnlyDirectoryPermissions(Path path) {
+        if (path != null && Files.exists(path) && path.fileSystem.supportedFileAttributeViews().contains('posix')) {
+            Files.setPosixFilePermissions(path, EnumSet.of(
+                PosixFilePermission.OWNER_READ,
+                PosixFilePermission.OWNER_WRITE,
+                PosixFilePermission.OWNER_EXECUTE
+            ))
+        }
     }
 
     private static final class MultipartUploadFixture {
@@ -620,6 +812,63 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
             System.arraycopy(bytes, index, buffer, offset, count)
             index += count
             count
+        }
+    }
+
+    private static final class CloseTrackingUploadRequest implements UploadRequest {
+        private final String key
+        private final String contentType
+        private final byte[] bytes
+        private final CloseTrackingInputStream inputStream
+
+        private CloseTrackingUploadRequest(String key, String contentType, byte[] bytes) {
+            this.key = key
+            this.contentType = contentType
+            this.bytes = bytes
+            this.inputStream = new CloseTrackingInputStream(bytes)
+        }
+
+        @Override
+        Optional<String> getContentType() {
+            Optional.of(contentType)
+        }
+
+        @Override
+        String getKey() {
+            key
+        }
+
+        @Override
+        Optional<Long> getContentSize() {
+            Optional.of((long) bytes.length)
+        }
+
+        @Override
+        InputStream getInputStream() {
+            inputStream
+        }
+
+        @Override
+        Map<String, String> getMetadata() {
+            [:]
+        }
+
+        boolean isClosed() {
+            inputStream.closed
+        }
+    }
+
+    private static final class CloseTrackingInputStream extends ByteArrayInputStream {
+        private boolean closed
+
+        private CloseTrackingInputStream(byte[] bytes) {
+            super(bytes)
+        }
+
+        @Override
+        void close() throws IOException {
+            closed = true
+            super.close()
         }
     }
 }

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageNamedSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageNamedSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.objectstorage.local
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
 import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.multipart.MultipartObjectStorageOperations
 import io.micronaut.test.annotation.MockBean
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
@@ -23,10 +24,20 @@ class LocalStorageNamedSpec extends Specification {
     @Named("source-storage")
     ObjectStorageOperations<?, ?, ?> storageOperations
 
+    @Inject
+    @Named("source-storage")
+    MultipartObjectStorageOperations<?, ?, ?> multipartStorageOperations
+
     void "it can inject named storage operations"() {
         expect:
         storageOperations
         storageOperations instanceof LocalStorageOperations
+    }
+
+    void "it can inject named multipart storage operations"() {
+        expect:
+        multipartStorageOperations
+        multipartStorageOperations instanceof LocalStorageMultipartOperations
     }
 
     @Requires(property = "spec.name", value = SPEC_NAME)

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePathTraversalSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePathTraversalSpec.groovy
@@ -2,7 +2,9 @@ package io.micronaut.objectstorage.local
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.objectstorage.multipart.AbortMultipartUploadRequest
+import io.micronaut.objectstorage.multipart.CompleteMultipartUploadRequest
 import io.micronaut.objectstorage.multipart.CreateMultipartUploadRequest
+import io.micronaut.objectstorage.multipart.ListMultipartPartsRequest
 import io.micronaut.objectstorage.multipart.UploadPartRequest
 import io.micronaut.objectstorage.request.ListObjectsRequest
 import io.micronaut.objectstorage.request.UploadRequest
@@ -255,12 +257,129 @@ class LocalStoragePathTraversalSpec extends Specification {
         ctx.getBean(LocalStorageBucketOperations).delete("bucket")
 
         then:
-        thrown IllegalStateException
+        thrown IllegalArgumentException
         !Files.list(multipartTarget).withCloseable { stream -> stream.findAny().present }
 
         cleanup:
         ctx?.close()
         deleteRecursively(tmp)
+    }
+
+    def 'symlinked provider-managed #component parent is not followed during bucket delete'() {
+        given:
+        Path tmp = Files.createTempDirectory("micronaut-object-storage")
+        ApplicationContext ctx = null
+        Path outside = tmp.resolve("outside")
+        Files.createDirectory(outside)
+        Path bucket = tmp.resolve("bucket")
+        Files.createDirectory(bucket)
+        Path providerTarget = outside.resolve("${component}-target")
+        Path protectedBucketState = providerTarget.resolve("bucket")
+        Files.createDirectories(protectedBucketState)
+        Files.writeString(protectedBucketState.resolve("protected"), "keep")
+        Path providerRoot = internalPath(tmp, providerRootSegments)
+        Files.createDirectories(providerRoot.parent)
+        assumeSymbolicLinksSupported(tmp)
+        Files.createSymbolicLink(providerRoot, providerTarget)
+
+        ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
+
+        when:
+        ctx.getBean(LocalStorageBucketOperations).delete("bucket")
+
+        then:
+        thrown IllegalArgumentException
+        Files.exists(protectedBucketState.resolve("protected"))
+
+        cleanup:
+        ctx?.close()
+        deleteRecursively(tmp)
+
+        where:
+        component         | providerRootSegments
+        'metadata object' | [LocalStorageLayout.METADATA_DIRECTORY, LocalStorageLayout.OBJECTS_DIRECTORY]
+        'multipart'       | [LocalStorageLayout.MULTIPART_DIRECTORY]
+        'snapshot'        | [LocalStorageLayout.SNAPSHOT_DIRECTORY]
+    }
+
+    def 'symlinked multipart parts directory is rejected during list parts'() {
+        given:
+        Path tmp = Files.createTempDirectory("micronaut-object-storage")
+        ApplicationContext ctx = null
+        Path outside = tmp.resolve("outside")
+        Files.createDirectory(outside)
+        Path bucket = tmp.resolve("bucket")
+        Files.createDirectory(bucket)
+        Path partsTarget = outside.resolve("parts-target")
+        Files.createDirectory(partsTarget)
+        assumeSymbolicLinksSupported(tmp)
+
+        ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
+        LocalStorageMultipartOperations multipartOperations = ctx.getBean(LocalStorageMultipartOperations)
+        def createResponse = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest("public", "text/plain"))
+        Files.createSymbolicLink(createResponse.nativeResponse.path.resolve("parts"), partsTarget)
+
+        when:
+        multipartOperations.listParts(new ListMultipartPartsRequest(createResponse.upload, 10))
+
+        then:
+        thrown IllegalArgumentException
+        !Files.list(partsTarget).withCloseable { stream -> stream.findAny().present }
+
+        cleanup:
+        ctx?.close()
+        deleteRecursively(tmp)
+    }
+
+    def 'symlinked multipart part data is rejected during complete'() {
+        given:
+        Path tmp = Files.createTempDirectory("micronaut-object-storage")
+        ApplicationContext ctx = null
+        Path outside = tmp.resolve("outside")
+        Files.createDirectory(outside)
+        Path bucket = tmp.resolve("bucket")
+        Files.createDirectory(bucket)
+        Path secret = outside.resolve("secret")
+        Files.writeString(secret, "keep")
+        assumeSymbolicLinksSupported(tmp)
+
+        ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
+        LocalStorageMultipartOperations multipartOperations = ctx.getBean(LocalStorageMultipartOperations)
+        def createResponse = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest("public", "text/plain"))
+        def uploadPart = multipartOperations.uploadPart(new UploadPartRequest(
+            createResponse.upload,
+            1,
+            UploadRequest.fromBytes("safe".bytes, "public", "text/plain")
+        ))
+        Properties properties = loadProperties(createResponse.nativeResponse.path.resolve("parts").resolve("1.properties"))
+        Path partPath = createResponse.nativeResponse.path.resolve("parts").resolve(properties.getProperty("file"))
+        Files.delete(partPath)
+        Files.createSymbolicLink(partPath, secret)
+
+        when:
+        multipartOperations.completeMultipartUpload(new CompleteMultipartUploadRequest(createResponse.upload, [uploadPart.part]))
+
+        then:
+        thrown IllegalArgumentException
+        Files.readString(secret) == "keep"
+
+        cleanup:
+        ctx?.close()
+        deleteRecursively(tmp)
+    }
+
+    private static Path internalPath(Path tmp, List<String> segments) {
+        Path path = tmp.resolve(LocalStorageOperations.INTERNAL_DIRECTORY)
+        for (String segment : segments) {
+            path = path.resolve(segment)
+        }
+        path
+    }
+
+    private static Properties loadProperties(Path path) {
+        Properties properties = new Properties()
+        Files.newInputStream(path).withCloseable { properties.load(it) }
+        properties
     }
 
     private static void assumeSymbolicLinksSupported(Path directory) {

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePathTraversalSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePathTraversalSpec.groovy
@@ -1,6 +1,9 @@
 package io.micronaut.objectstorage.local
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.objectstorage.multipart.AbortMultipartUploadRequest
+import io.micronaut.objectstorage.multipart.CreateMultipartUploadRequest
+import io.micronaut.objectstorage.multipart.UploadPartRequest
 import io.micronaut.objectstorage.request.ListObjectsRequest
 import io.micronaut.objectstorage.request.UploadRequest
 import org.opentest4j.TestAbortedException
@@ -133,6 +136,127 @@ class LocalStoragePathTraversalSpec extends Specification {
             .resolve(LocalStorageOperations.OBJECTS_DIRECTORY)
             .resolve("bucket")
             .resolve("public"))
+
+        cleanup:
+        ctx?.close()
+        deleteRecursively(tmp)
+    }
+
+    def 'symlinked root multipart directory is rejected during create multipart upload'() {
+        given:
+        Path tmp = Files.createTempDirectory("micronaut-object-storage")
+        ApplicationContext ctx = null
+        Path outside = tmp.resolve("outside")
+        Files.createDirectory(outside)
+        Path bucket = tmp.resolve("bucket")
+        Files.createDirectory(bucket)
+        Path multipartTarget = outside.resolve("multipart-target")
+        Files.createDirectory(multipartTarget)
+        assumeSymbolicLinksSupported(tmp)
+        Files.createDirectories(tmp.resolve(LocalStorageOperations.INTERNAL_DIRECTORY))
+        Files.createSymbolicLink(
+            tmp.resolve(LocalStorageOperations.INTERNAL_DIRECTORY).resolve(LocalStorageOperations.MULTIPART_DIRECTORY),
+            multipartTarget
+        )
+
+        ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
+
+        when:
+        ctx.getBean(LocalStorageMultipartOperations).createMultipartUpload(new CreateMultipartUploadRequest("public", "text/plain"))
+
+        then:
+        thrown IllegalArgumentException
+        !Files.list(multipartTarget).withCloseable { stream -> stream.findAny().present }
+
+        cleanup:
+        ctx?.close()
+        deleteRecursively(tmp)
+    }
+
+    def 'symlinked multipart upload directory is rejected during upload part'() {
+        given:
+        Path tmp = Files.createTempDirectory("micronaut-object-storage")
+        ApplicationContext ctx = null
+        Path outside = tmp.resolve("outside")
+        Files.createDirectory(outside)
+        Path bucket = tmp.resolve("bucket")
+        Files.createDirectory(bucket)
+        Path multipartTarget = outside.resolve("multipart-target")
+        Files.createDirectory(multipartTarget)
+        assumeSymbolicLinksSupported(tmp)
+
+        ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
+        LocalStorageMultipartOperations multipartOperations = ctx.getBean(LocalStorageMultipartOperations)
+        def createResponse = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest("public", "text/plain"))
+        LocalStorageBucketOperations.deleteRecursively(createResponse.nativeResponse.path)
+        Files.createSymbolicLink(createResponse.nativeResponse.path, multipartTarget)
+
+        when:
+        multipartOperations.uploadPart(new UploadPartRequest(createResponse.upload, 1, UploadRequest.fromBytes("evil".bytes, "public", "text/plain")))
+
+        then:
+        thrown IllegalArgumentException
+        !Files.list(multipartTarget).withCloseable { stream -> stream.findAny().present }
+
+        cleanup:
+        ctx?.close()
+        deleteRecursively(tmp)
+    }
+
+    def 'symlinked multipart upload directory is rejected during abort'() {
+        given:
+        Path tmp = Files.createTempDirectory("micronaut-object-storage")
+        ApplicationContext ctx = null
+        Path outside = tmp.resolve("outside")
+        Files.createDirectory(outside)
+        Path bucket = tmp.resolve("bucket")
+        Files.createDirectory(bucket)
+        Path multipartTarget = outside.resolve("multipart-target")
+        Files.createDirectory(multipartTarget)
+        assumeSymbolicLinksSupported(tmp)
+
+        ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
+        LocalStorageMultipartOperations multipartOperations = ctx.getBean(LocalStorageMultipartOperations)
+        def createResponse = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest("public", "text/plain"))
+        LocalStorageBucketOperations.deleteRecursively(createResponse.nativeResponse.path)
+        Files.createSymbolicLink(createResponse.nativeResponse.path, multipartTarget)
+
+        when:
+        multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(createResponse.upload))
+
+        then:
+        thrown IllegalArgumentException
+        !Files.list(multipartTarget).withCloseable { stream -> stream.findAny().present }
+
+        cleanup:
+        ctx?.close()
+        deleteRecursively(tmp)
+    }
+
+    def 'symlinked multipart bucket state is not followed during bucket delete'() {
+        given:
+        Path tmp = Files.createTempDirectory("micronaut-object-storage")
+        ApplicationContext ctx = null
+        Path outside = tmp.resolve("outside")
+        Files.createDirectory(outside)
+        Path bucket = tmp.resolve("bucket")
+        Files.createDirectory(bucket)
+        Path multipartTarget = outside.resolve("multipart-target")
+        Files.createDirectory(multipartTarget)
+        Path multipartRoot = tmp.resolve(LocalStorageOperations.INTERNAL_DIRECTORY)
+            .resolve(LocalStorageOperations.MULTIPART_DIRECTORY)
+        Files.createDirectories(multipartRoot)
+        assumeSymbolicLinksSupported(tmp)
+        Files.createSymbolicLink(multipartRoot.resolve("bucket"), multipartTarget)
+
+        ctx = ApplicationContext.run(["micronaut.object-storage.local.a.path": bucket.toString()])
+
+        when:
+        ctx.getBean(LocalStorageBucketOperations).delete("bucket")
+
+        then:
+        thrown IllegalStateException
+        !Files.list(multipartTarget).withCloseable { stream -> stream.findAny().present }
 
         cleanup:
         ctx?.close()

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePrimarySpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePrimarySpec.groovy
@@ -41,9 +41,12 @@ class LocalStoragePrimarySpec extends Specification {
 
     void "local multipart storage is primary"() {
         when:
+        def beans = ctx.getBeansOfType(MultipartObjectStorageOperations)
         def operations = ctx.getBean(MultipartObjectStorageOperations)
 
         then:
+        beans.size() == 2
+        beans.any { it instanceof LocalStorageMultipartOperations }
         operations instanceof LocalStorageMultipartOperations
     }
 

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePrimarySpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStoragePrimarySpec.groovy
@@ -5,6 +5,7 @@ import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
 import io.micronaut.objectstorage.ObjectStorageOperations
+import io.micronaut.objectstorage.multipart.MultipartObjectStorageOperations
 import io.micronaut.test.annotation.MockBean
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
@@ -36,6 +37,14 @@ class LocalStoragePrimarySpec extends Specification {
 
         then:
         operations instanceof LocalStorageOperations
+    }
+
+    void "local multipart storage is primary"() {
+        when:
+        def operations = ctx.getBean(MultipartObjectStorageOperations)
+
+        then:
+        operations instanceof LocalStorageMultipartOperations
     }
 
     @Requires(property = "spec.name", value = SPEC_NAME)

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageReservedMetadataSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageReservedMetadataSpec.groovy
@@ -83,8 +83,11 @@ class LocalStorageReservedMetadataSpec extends Specification implements TestProp
         operations.upload(UploadRequest.fromBytes('visible'.bytes, 'visible.txt', 'text/plain'))
         def bucketPath = operations.retrieve('visible.txt').get().nativeEntry.parent
         Path internalDirectory = bucketPath.resolve(LocalStorageOperations.INTERNAL_DIRECTORY)
+        Path multipartDirectory = internalDirectory.resolve(LocalStorageOperations.MULTIPART_DIRECTORY)
         Path snapshotDirectory = internalDirectory.resolve(LocalStorageOperations.SNAPSHOT_DIRECTORY)
         Path legacyMetadataDirectory = bucketPath.resolve(LocalStorageOperations.LEGACY_METADATA_DIRECTORY)
+        Files.createDirectories(multipartDirectory)
+        Files.writeString(multipartDirectory.resolve('temporary'), 'hidden')
         Files.createDirectories(snapshotDirectory)
         Files.writeString(snapshotDirectory.resolve('temporary'), 'hidden')
         Files.createDirectories(legacyMetadataDirectory)
@@ -94,6 +97,7 @@ class LocalStorageReservedMetadataSpec extends Specification implements TestProp
         operations.listObjects(new ListObjectsRequest(5, '.mn-storage')).keys.empty
         operations.listObjects(new ListObjectsRequest(5, '.mn-storage/')).keys.empty
         operations.listObjects(new ListObjectsRequest(5, '.mn-storage/metadata')).keys.empty
+        operations.listObjects(new ListObjectsRequest(5, '.mn-storage/multipart')).keys.empty
         operations.listObjects(new ListObjectsRequest(5, '.mn-storage/snapshots')).keys.empty
         operations.listObjects(new ListObjectsRequest(5, '.metadata')).keys.empty
         operations.listObjects(new ListObjectsRequest(5, '.metadata/')).keys.empty
@@ -103,6 +107,8 @@ class LocalStorageReservedMetadataSpec extends Specification implements TestProp
         cleanup:
         Files.deleteIfExists(legacyMetadataDirectory.resolve('visible.txt'))
         Files.deleteIfExists(legacyMetadataDirectory)
+        Files.deleteIfExists(multipartDirectory.resolve('temporary'))
+        Files.deleteIfExists(multipartDirectory)
         Files.deleteIfExists(snapshotDirectory.resolve('temporary'))
         Files.deleteIfExists(snapshotDirectory)
     }

--- a/src/main/docs/guide/local.adoc
+++ b/src/main/docs/guide/local.adoc
@@ -16,18 +16,18 @@ micronaut:
 NOTE: When added to the classpath, api:objectstorage.local.LocalStorageOperations[] becomes the primary implementation of
 api:objectstorage.ObjectStorageOperations[].
 
-NOTE: The local storage implementation reserves the `.mn-storage` key namespace for provider-managed metadata and
-temporary rollback files. It also reserves the legacy `.metadata` key namespace used by released older versions for
-metadata sidecars. User object keys cannot be `.mn-storage`, `.metadata`, or start with either reserved namespace
-followed by `/` (or the equivalent platform file separator). Local bucket names and configured local bucket directory
-names cannot use those reserved namespaces either.
+NOTE: The local storage implementation reserves the `.mn-storage` key namespace for provider-managed metadata,
+multipart upload state, and temporary rollback files. It also reserves the legacy `.metadata` key namespace used by
+released older versions for metadata sidecars. User object keys cannot be `.mn-storage`, `.metadata`, or start with
+either reserved namespace followed by `/` (or the equivalent platform file separator). Local bucket names and configured
+local bucket directory names cannot use those reserved namespaces either.
 
 The local implementation is also the reference provider for
 api:objectstorage.metadata.ObjectMetadataOperations[] and api:objectstorage.metadata.BucketMetadataOperations[].
 Provider-managed files live under one `.mn-storage` directory in the storage root that contains the configured bucket.
 Object metadata sidecars live under `.mn-storage/metadata/objects/<bucket>/<key>`, bucket metadata sidecars live under
-`.mn-storage/metadata/buckets/<bucket>`, and temporary local file rollback snapshots live under
-`.mn-storage/snapshots/<bucket>`.
+`.mn-storage/metadata/buckets/<bucket>`, in-progress multipart upload state lives under
+`.mn-storage/multipart/<bucket>`, and temporary local file rollback snapshots live under `.mn-storage/snapshots/<bucket>`.
 
 For compatibility with persistent local storage paths created by released older versions, metadata reads also check
 legacy per-bucket `.metadata` sidecars. New metadata writes use the root `.mn-storage` layout, and deletes remove both
@@ -51,3 +51,5 @@ include::doc-examples/example-java/src/test/resources/application-testing.yml[]
 ----
 
 The concrete implementation of `ObjectStorageOperations` is api:objectstorage.local.LocalStorageOperations[].
+The local module also provides api:objectstorage.multipart.MultipartObjectStorageOperations[] for multipart upload lifecycle support.
+See the <<multipartUploads,Multipart Uploads>> guide for the portable multipart API.

--- a/src/main/docs/guide/multipartUploads.adoc
+++ b/src/main/docs/guide/multipartUploads.adoc
@@ -32,7 +32,7 @@ The multipart lifecycle uses the following portable request and response types:
 | Supported
 
 | Local Storage
-| Not yet supported
+| Supported
 |===
 
 == Lifecycle Rules
@@ -43,7 +43,8 @@ The multipart lifecycle uses the following portable request and response types:
 - Object metadata and content type are set when creating the multipart upload, not on each individual part.
 - Providers may enforce their own part-size limits. Amazon S3 requires each non-final part to be at least
   5 MiB. Oracle Cloud Infrastructure Object Storage requires stricter non-final chunks; use chunks greater
-  than 10 MiB, for example 11 MiB. The final part may be smaller.
+  than 10 MiB, for example 11 MiB. The local storage provider does not enforce a multipart part-size
+  minimum. The final part may be smaller.
 - `listParts` is read-only and exposes provider pagination through opaque continuation tokens.
 - `completeMultipartUpload` requires a strictly ordered part manifest.
 - Retrying `completeMultipartUpload` is only safe when reusing the same upload id and exact part manifest.


### PR DESCRIPTION
## Summary
Adds multipart upload lifecycle support for the local object storage provider.

This implements `MultipartObjectStorageOperations` for local storage, including create, upload part, list parts, complete, and abort operations. Multipart state is stored under the provider-managed `.mn-storage/multipart/<bucket>` namespace so it remains hidden from normal object listing.

## Details
- Adds local multipart upload session storage and cleanup.
- Stores content type and metadata at multipart creation time and applies them when completing the upload.
- Uses opaque local continuation tokens for `listParts`.
- Marks completed uploads terminal before best-effort cleanup, so completed handles cannot be reused.
- Preserves retry-safe abort behavior while validating active or completed local metadata when present.
- Avoids corrupting existing uploaded parts when a replacement `uploadPart` attempt fails.
- Closes consumed local upload streams in direct and multipart upload paths.
- Hardens provider-managed cleanup paths against symlink traversal.
- Adds a public local native create response type, `LocalStorageMultipartUpload`.
- Keeps multipart scratch state out of user-visible listings and bucket contents.
- Extends the shared multipart TCK for local storage.
- Adds local-specific coverage for cleanup, path traversal, file permissions, primary/named bean selection, continuation-token validation, and reserved namespace behavior.
- Updates the local and multipart upload guides.

## Issue
Fixes #788
