### PR TITLE
Generate deterministic content-based ETags for local storage

### DIFF
--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageETag.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageETag.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.local;
+
+import org.jspecify.annotations.NonNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+final class LocalStorageETag {
+
+    private static final HexFormat HEX_FORMAT = HexFormat.of();
+
+    private LocalStorageETag() {
+    }
+
+    @NonNull
+    static String transferTo(@NonNull InputStream inputStream, @NonNull OutputStream outputStream) throws IOException {
+        MessageDigest digest = newSha256Digest();
+        DigestOutputStream digestOutputStream = new DigestOutputStream(outputStream, digest);
+        inputStream.transferTo(digestOutputStream);
+        digestOutputStream.flush();
+        return HEX_FORMAT.formatHex(digest.digest());
+    }
+
+    @NonNull
+    private static MessageDigest newSha256Digest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 digest is not available", e);
+        }
+    }
+
+}

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartUploadState.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartUploadState.java
@@ -119,9 +119,7 @@ final class LocalStorageMultipartUploadState {
         if (!mkdirs(partsPath)) {
             throw new ObjectStorageException("Error creating local multipart part directories: " + partsPath);
         }
-        String eTag = UUID.randomUUID().toString();
-        String partFileName = partNumber + "-" + eTag + MULTIPART_PART_EXTENSION;
-        Path partFile = multipartPartDataPath(uploadPath, partFileName);
+        Path partFile = null;
         Path temporaryPartFile = null;
         Path temporaryPartPropertiesFile = null;
         boolean partFileCommitted = false;
@@ -129,8 +127,10 @@ final class LocalStorageMultipartUploadState {
         try {
             temporaryPartFile = createTempFile(partsPath, partNumber + "-", MULTIPART_PART_EXTENSION + ".tmp");
             temporaryPartPropertiesFile = createTempFile(partsPath, partNumber + "-", MULTIPART_PART_PROPERTIES_EXTENSION + ".tmp");
-            storeFile(temporaryPartFile, inputStream);
+            String eTag = storeFile(temporaryPartFile, inputStream);
             long partSize = size(temporaryPartFile);
+            String partFileName = partNumber + "-" + UUID.randomUUID() + MULTIPART_PART_EXTENSION;
+            partFile = multipartPartDataPath(uploadPath, partFileName);
             Properties properties = new Properties();
             properties.setProperty(MULTIPART_PART_ETAG_PROPERTY, eTag);
             properties.setProperty(MULTIPART_PART_SIZE_PROPERTY, Long.toString(partSize));
@@ -352,13 +352,13 @@ final class LocalStorageMultipartUploadState {
         }
     }
 
-    private void storeFile(Path file, InputStream inputStream) {
+    private String storeFile(Path file, InputStream inputStream) {
         try (InputStream in = inputStream) {
             if (!mkdirs(file.getParent())) {
                 throw new ObjectStorageException("Error creating local multipart part directories: " + file);
             }
             try (OutputStream fileOut = LocalStorageIoSupport.newOutputStreamNoFollow(file, supportsPosixPermissions)) {
-                in.transferTo(fileOut);
+                return LocalStorageETag.transferTo(in, fileOut);
             }
         } catch (IOException e) {
             throw new ObjectStorageException("Error copying multipart part to: " + file, e);

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -49,7 +49,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.UUID;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
@@ -137,6 +136,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         Lock bucketLock = LocalStorageLocks.bucketReadLock(layout.configuredBucketPath());
         ReentrantLock mutationLock = LocalStorageLocks.objectMutationLock(file);
         LocalStorageFile localFile;
+        String eTag;
         bucketLock.lock();
         try {
             mutationLock.lock();
@@ -145,14 +145,14 @@ public class LocalStorageOperations implements ObjectStorageOperations<
                 RuntimeException failure = null;
                 boolean preserveSnapshot = false;
                 try {
-                    storeFile(file, request.getInputStream());
+                    eTag = storeFile(file, request.getInputStream());
                     objectMetadataOperations.save(new ObjectMetadataWrite(
                         key,
                         request.getMetadata(),
                         Map.of(),
                         request.getContentType().orElse(null),
                         request.getContentSize().orElse(null),
-                        null,
+                        eTag,
                         null
                     ));
                 } catch (RuntimeException e) {
@@ -171,7 +171,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
             bucketLock.unlock();
         }
         requestConsumer.accept(localFile);
-        return UploadResponse.of(key, UUID.randomUUID().toString(), localFile);
+        return UploadResponse.of(key, eTag, localFile);
     }
 
     @Override
@@ -371,8 +371,8 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         RuntimeException failure = null;
         boolean preserveSnapshot = false;
         try (InputStream in = newInputStreamNoFollow(source)) {
-            storeFile(destinationFile, in);
-            copyObjectMetadata(sourceKey, destinationKey);
+            String eTag = storeFile(destinationFile, in);
+            copyObjectMetadata(sourceKey, destinationKey, eTag);
         } catch (IOException e) {
             ObjectStorageException objectStorageException = new ObjectStorageException("Error copying file: " + source, e);
             failure = objectStorageException;
@@ -389,7 +389,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         }
     }
 
-    private void copyObjectMetadata(String sourceKey, String destinationKey) {
+    private void copyObjectMetadata(String sourceKey, String destinationKey, String eTag) {
         objectMetadataOperations.retrieve(sourceKey).ifPresentOrElse(entry ->
             objectMetadataOperations.save(new ObjectMetadataWrite(
                 destinationKey,
@@ -397,10 +397,18 @@ public class LocalStorageOperations implements ObjectStorageOperations<
                 entry.attributes(),
                 entry.contentType(),
                 entry.contentLength(),
-                entry.etag(),
+                eTag,
                 entry.lastModified()
             )),
-            () -> objectMetadataOperations.delete(destinationKey)
+            () -> objectMetadataOperations.save(new ObjectMetadataWrite(
+                destinationKey,
+                Map.of(),
+                Map.of(),
+                null,
+                null,
+                eTag,
+                null
+            ))
         );
     }
 
@@ -514,21 +522,23 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         // After a successful mutation, leftover snapshots are cleanup debt, not operation failure.
     }
 
-    private Path storeFile(Path file, InputStream inputStream) {
+    private String storeFile(Path file, InputStream inputStream) {
         mkdirs(configuration.getPath(), file.getParent());
         Path temporaryDirectory = layout.objectTemporaryDirectory();
+        String[] eTag = new String[1];
         try (InputStream in = inputStream) {
             LocalStorageIoSupport.rejectSymbolicLinks(layout.storageRoot(), temporaryDirectory);
             mkdirs(layout.rootInternalDirectory(), temporaryDirectory);
             LocalStorageIoSupport.rejectSymbolicLinks(layout.storageRoot(), temporaryDirectory);
-            return LocalStorageIoSupport.writeAndReplace(
+            LocalStorageIoSupport.writeAndReplace(
                 file,
                 temporaryDirectory,
                 TEMPORARY_FILE_PREFIX,
                 TEMPORARY_FILE_SUFFIX,
                 supportsPosixPermissions,
-                in::transferTo
+                out -> eTag[0] = LocalStorageETag.transferTo(in, out)
             );
+            return eTag[0];
         } catch (IOException e) {
             throw new ObjectStorageException("Error copying file to: " + file, e);
         }

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageCustomMetadataOperationsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageCustomMetadataOperationsSpec.groovy
@@ -8,6 +8,7 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 
 import java.nio.file.Files
 import java.nio.file.Path
+import java.security.MessageDigest
 
 @Property(name = "spec.name", value = AbstractLocalStorageCustomMetadataSpec.SPEC_NAME)
 @Property(name = "micronaut.object-storage.local.default.enabled", value = "true")
@@ -33,24 +34,38 @@ class LocalStorageCustomMetadataOperationsSpec extends AbstractLocalStorageCusto
         objectMetadataOperations.deletedKeys == ['nested/object.txt']
     }
 
+    void 'local object storage delegates content etag to configured metadata operations'() {
+        when:
+        def firstResponse = operations.upload(UploadRequest.fromBytes('hello'.bytes, 'etag/first.txt', 'text/plain'))
+        def secondResponse = operations.upload(UploadRequest.fromBytes('hello'.bytes, 'etag/second.txt', 'text/plain'))
+        def changedResponse = operations.upload(UploadRequest.fromBytes('hello!'.bytes, 'etag/changed.txt', 'text/plain'))
+
+        then:
+        firstResponse.ETag == sha256ETag('hello')
+        firstResponse.ETag == secondResponse.ETag
+        firstResponse.ETag != changedResponse.ETag
+        objectMetadataOperations.retrieve('etag/first.txt').get().etag == firstResponse.ETag
+    }
+
     void 'local copy delegates object metadata to configured metadata operations'() {
         given:
         UploadRequest request = UploadRequest.fromBytes('hello'.bytes, 'source.txt', 'text/plain')
         request.metadata = [source: 'custom']
-        operations.upload(request)
+        def sourceResponse = operations.upload(request)
 
         when:
         operations.copy('source.txt', 'copy.txt')
 
         then:
         objectMetadataOperations.retrieve('copy.txt').get().metadata == [source: 'custom']
+        objectMetadataOperations.retrieve('copy.txt').get().etag == sourceResponse.ETag
         operations.retrieve('copy.txt').get().metadata == [source: 'custom']
         operations.retrieve('copy.txt').get().inputStream.text == 'hello'
     }
 
-    void 'local copy deletes destination metadata when source metadata is missing'() {
+    void 'local copy persists content etag when source metadata is missing'() {
         given:
-        operations.upload(UploadRequest.fromBytes('source'.bytes, 'source-without-metadata.txt', 'text/plain'))
+        def sourceResponse = operations.upload(UploadRequest.fromBytes('source'.bytes, 'source-without-metadata.txt', 'text/plain'))
         UploadRequest destination = UploadRequest.fromBytes('destination'.bytes, 'destination.txt', 'text/plain')
         destination.metadata = [source: 'stale']
         operations.upload(destination)
@@ -61,8 +76,9 @@ class LocalStorageCustomMetadataOperationsSpec extends AbstractLocalStorageCusto
         operations.copy('source-without-metadata.txt', 'destination.txt')
 
         then:
-        objectMetadataOperations.deletedKeys == ['destination.txt']
-        !objectMetadataOperations.retrieve('destination.txt').present
+        objectMetadataOperations.deletedKeys.empty
+        objectMetadataOperations.retrieve('destination.txt').get().metadata == [:]
+        objectMetadataOperations.retrieve('destination.txt').get().etag == sourceResponse.ETag
         operations.retrieve('destination.txt').get().metadata == [:]
         operations.retrieve('destination.txt').get().inputStream.text == 'source'
     }
@@ -107,5 +123,11 @@ class LocalStorageCustomMetadataOperationsSpec extends AbstractLocalStorageCusto
         if (Files.exists(rootDirectory)) {
             LocalStorageBucketOperations.deleteRecursively(rootDirectory)
         }
+    }
+    private static String sha256ETag(String text) {
+        MessageDigest.getInstance('SHA-256')
+            .digest(text.bytes)
+            .collect { String.format('%02x', it & 0xff) }
+            .join()
     }
 }

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMetadataCompatibilitySpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMetadataCompatibilitySpec.groovy
@@ -13,8 +13,9 @@ import java.nio.file.LinkOption
 import java.nio.file.Path
 import java.nio.file.attribute.FileTime
 import java.nio.file.attribute.PosixFilePermission
-import java.util.concurrent.TimeUnit
+import java.security.MessageDigest
 import java.util.Properties
+import java.util.concurrent.TimeUnit
 
 class LocalStorageMetadataCompatibilitySpec extends Specification {
 
@@ -47,6 +48,23 @@ class LocalStorageMetadataCompatibilitySpec extends Specification {
         !Files.exists(rootDirectory.resolve(LocalStorageOperations.INTERNAL_DIRECTORY))
         !Files.exists(bucketPath.resolve(LocalStorageOperations.INTERNAL_DIRECTORY))
         !Files.exists(bucketPath.resolve(LocalStorageOperations.LEGACY_METADATA_DIRECTORY))
+    }
+
+    void 'local upload persists deterministic content etag in sidecar metadata'() {
+        given:
+        def operations = ctx.getBean(LocalStorageOperations)
+        def metadataOperations = ctx.getBean(LocalStorageObjectMetadataOperations)
+
+        when:
+        def firstResponse = operations.upload(UploadRequest.fromBytes('hello'.bytes, 'first.txt', 'text/plain'))
+        def secondResponse = operations.upload(UploadRequest.fromBytes('hello'.bytes, 'second.txt', 'text/plain'))
+        def changedResponse = operations.upload(UploadRequest.fromBytes('hello!'.bytes, 'changed.txt', 'text/plain'))
+
+        then:
+        firstResponse.ETag == sha256ETag('hello')
+        firstResponse.ETag == secondResponse.ETag
+        firstResponse.ETag != changedResponse.ETag
+        metadataOperations.retrieve('first.txt').get().etag == firstResponse.ETag
     }
 
     void 'legacy metadata sidecars without a marker stay in legacy mode even for structured-looking keys'() {
@@ -268,5 +286,12 @@ class LocalStorageMetadataCompatibilitySpec extends Specification {
         if (directory != null && permissions != null && Files.exists(directory, LinkOption.NOFOLLOW_LINKS)) {
             Files.setPosixFilePermissions(directory, permissions)
         }
+    }
+
+    private static String sha256ETag(String text) {
+        MessageDigest.getInstance('SHA-256')
+            .digest(text.bytes)
+            .collect { String.format('%02x', it & 0xff) }
+            .join()
     }
 }

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMultipartOperationsSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMultipartOperationsSpec.groovy
@@ -24,7 +24,15 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermission
+import java.security.MessageDigest
 import java.util.Base64
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
 
 @MicronautTest
 class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperationsSpecification implements TestPropertyProvider {
@@ -42,6 +50,9 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
 
     @Inject
     LocalStorageConfiguration configuration
+
+    @Inject
+    LocalStorageObjectMetadataOperations objectMetadataOperations
 
     @Override
     ObjectStorageOperations<?, ?, ?> getObjectStorage() {
@@ -118,6 +129,29 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
         !Files.exists(createResponse.nativeResponse.path)
     }
 
+    void 'local multipart uses content etags for parts and completed object'() {
+        given:
+        String key = 'multipart-local/content-etag.txt'
+        def createResponse = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE))
+        def upload = createResponse.upload
+
+        when:
+        def firstPart = multipartOperations.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes('micro'.bytes, key, CONTENT_TYPE)))
+        def secondPart = multipartOperations.uploadPart(new UploadPartRequest(upload, 2, UploadRequest.fromBytes('naut'.bytes, key, CONTENT_TYPE)))
+
+        then:
+        firstPart.part.ETag == sha256ETag('micro')
+        secondPart.part.ETag == sha256ETag('naut')
+
+        when:
+        def response = multipartOperations.completeMultipartUpload(new CompleteMultipartUploadRequest(upload, [firstPart.part, secondPart.part]))
+
+        then:
+        response.ETag == sha256ETag('micronaut')
+        objectMetadataOperations.retrieve(key).get().etag == response.ETag
+        !Files.exists(createResponse.nativeResponse.path)
+    }
+
     void 'local multipart complete marks upload terminal before best-effort cleanup'() {
         given:
         assumePosixPermissionsSupported(configuration.path)
@@ -188,6 +222,92 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
         listedParts*.ETag == [originalPart.part.ETag]
         response.ETag
         entry.inputStream.text == 'original'
+    }
+
+    void 'identical multipart part replacements use unique backing files'() {
+        given:
+        String key = 'multipart-local/unique-part-files.txt'
+        def createResponse = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE))
+        def upload = createResponse.upload
+
+        when:
+        def originalPart = multipartOperations.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes('same'.bytes, key, CONTENT_TYPE)))
+        def replacementPart = multipartOperations.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes('same'.bytes, key, CONTENT_TYPE)))
+
+        then:
+        originalPart.part.ETag == replacementPart.part.ETag
+        originalPart.nativeResponse.path != replacementPart.nativeResponse.path
+        !Files.exists(originalPart.nativeResponse.path)
+        Files.exists(replacementPart.nativeResponse.path)
+
+        cleanup:
+        if (createResponse != null && Files.exists(createResponse.nativeResponse.path)) {
+            multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+        }
+    }
+
+    void 'failed identical multipart part replacement preserves the active part file'() {
+        given:
+        String key = 'multipart-local/identical-replacement.txt'
+        def createResponse = multipartOperations.createMultipartUpload(new CreateMultipartUploadRequest(key, CONTENT_TYPE))
+        def upload = createResponse.upload
+        def originalPart = multipartOperations.uploadPart(new UploadPartRequest(upload, 1, UploadRequest.fromBytes('same'.bytes, key, CONTENT_TYPE)))
+        Path propertiesPath = partPropertiesPath(createResponse.nativeResponse.path, 1)
+        Properties originalProperties = loadProperties(propertiesPath)
+        Path originalPartPath = partDataPath(createResponse.nativeResponse.path, originalProperties.getProperty('file'))
+        CountDownLatch writeStarted = new CountDownLatch(1)
+        CountDownLatch allowWriteToFinish = new CountDownLatch(1)
+        ExecutorService executor = Executors.newSingleThreadExecutor()
+        Future<?> replacement = null
+
+        when:
+        replacement = executor.submit({
+            multipartOperations.uploadPart(new UploadPartRequest(
+                upload,
+                1,
+                new BlockingUploadRequest(key, CONTENT_TYPE, 'same'.bytes, writeStarted, allowWriteToFinish)
+            ))
+        } as Callable)
+
+        then:
+        writeStarted.await(5, TimeUnit.SECONDS)
+
+        when:
+        Files.delete(propertiesPath)
+        Files.createDirectory(propertiesPath)
+        Files.writeString(propertiesPath.resolve('blocker'), 'blocker')
+        allowWriteToFinish.countDown()
+        replacement.get(5, TimeUnit.SECONDS)
+
+        then:
+        ExecutionException e = thrown()
+        e.cause instanceof ObjectStorageException
+        Files.exists(originalPartPath)
+        findPartDataFiles(createResponse.nativeResponse.path) == [originalPartPath]
+
+        when:
+        LocalStorageBucketOperations.deleteRecursively(propertiesPath)
+        storeProperties(propertiesPath, originalProperties)
+        def listedParts = multipartOperations.listParts(new ListMultipartPartsRequest(upload, 10)).parts
+        def response = multipartOperations.completeMultipartUpload(new CompleteMultipartUploadRequest(upload, [originalPart.part]))
+
+        then:
+        listedParts*.ETag == [originalPart.part.ETag]
+        response.ETag == sha256ETag('same')
+        operations.retrieve(key).get().inputStream.text == 'same'
+
+        cleanup:
+        allowWriteToFinish.countDown()
+        executor?.shutdownNow()
+        if (propertiesPath != null && Files.isDirectory(propertiesPath)) {
+            LocalStorageBucketOperations.deleteRecursively(propertiesPath)
+        }
+        if (propertiesPath != null && originalProperties != null && Files.exists(propertiesPath.parent) && !Files.exists(propertiesPath)) {
+            storeProperties(propertiesPath, originalProperties)
+        }
+        if (createResponse != null && Files.exists(createResponse.nativeResponse.path)) {
+            multipartOperations.abortMultipartUpload(new AbortMultipartUploadRequest(upload))
+        }
     }
 
     void 'local multipart part replacement rejects corrupt existing metadata before committing replacement'() {
@@ -703,6 +823,13 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
         }
     }
 
+    private static String sha256ETag(String text) {
+        MessageDigest.getInstance('SHA-256')
+            .digest(text.bytes)
+            .collect { String.format('%02x', it & 0xff) }
+            .join()
+    }
+
     private static final class MultipartUploadFixture {
         private final MultipartUploadHandle upload
         private final Path uploadPath
@@ -776,6 +903,97 @@ class LocalStorageMultipartOperationsSpec extends MultipartObjectStorageOperatio
         @Override
         Map<String, String> getMetadata() {
             [:]
+        }
+    }
+
+    private static final class BlockingUploadRequest implements UploadRequest {
+        private final String key
+        private final String contentType
+        private final byte[] bytes
+        private final BlockingInputStream inputStream
+
+        private BlockingUploadRequest(String key,
+                                      String contentType,
+                                      byte[] bytes,
+                                      CountDownLatch writeStarted,
+                                      CountDownLatch allowWriteToFinish) {
+            this.key = key
+            this.contentType = contentType
+            this.bytes = bytes
+            this.inputStream = new BlockingInputStream(bytes, writeStarted, allowWriteToFinish)
+        }
+
+        @Override
+        Optional<String> getContentType() {
+            Optional.of(contentType)
+        }
+
+        @Override
+        String getKey() {
+            key
+        }
+
+        @Override
+        Optional<Long> getContentSize() {
+            Optional.of((long) bytes.length)
+        }
+
+        @Override
+        InputStream getInputStream() {
+            inputStream
+        }
+
+        @Override
+        Map<String, String> getMetadata() {
+            [:]
+        }
+    }
+
+    private static final class BlockingInputStream extends InputStream {
+        private final ByteArrayInputStream delegate
+        private final CountDownLatch writeStarted
+        private final CountDownLatch allowWriteToFinish
+        private boolean blocked
+
+        private BlockingInputStream(byte[] bytes,
+                                    CountDownLatch writeStarted,
+                                    CountDownLatch allowWriteToFinish) {
+            this.delegate = new ByteArrayInputStream(bytes)
+            this.writeStarted = writeStarted
+            this.allowWriteToFinish = allowWriteToFinish
+        }
+
+        @Override
+        int read() throws IOException {
+            awaitWrite()
+            delegate.read()
+        }
+
+        @Override
+        int read(byte[] buffer, int offset, int length) throws IOException {
+            awaitWrite()
+            delegate.read(buffer, offset, length)
+        }
+
+        @Override
+        void close() throws IOException {
+            delegate.close()
+        }
+
+        private void awaitWrite() throws IOException {
+            if (blocked) {
+                return
+            }
+            blocked = true
+            writeStarted.countDown()
+            try {
+                if (!allowWriteToFinish.await(5, TimeUnit.SECONDS)) {
+                    throw new IOException('timed out waiting to finish upload')
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt()
+                throw new IOException('interrupted while waiting to finish upload', e)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- generate deterministic SHA-256 ETags while streaming local object content to disk
- persist upload and copy ETags through the configured object metadata operations
- use content-derived ETags for multipart parts and completed objects
- preserve active multipart data when an identical replacement fails during its properties commit

Local ETags use the opaque `sha256-<lowercase hex digest>` format. Existing metadata and multipart state remain readable because stored ETags continue to be treated as opaque values.

## Compatibility

This change does not add or modify public API signatures. It replaces random local UUID ETags with deterministic content-derived values while retaining the existing locking, atomic replacement, fsync, and rollback behavior.

Closes #821
