### PR TITLE
Support first-class InputStream uploads

### DIFF
--- a/doc-examples/example-groovy/src/main/groovy/example/ProfileService.groovy
+++ b/doc-examples/example-groovy/src/main/groovy/example/ProfileService.groovy
@@ -31,6 +31,19 @@ class ProfileService {
     }
     //end::upload[]
 
+    //tag::input-stream-upload[]
+    String saveProfilePicture(String userId, InputStream inputStream, long contentLength) {
+        UploadRequest request = UploadRequest.fromInputStream(
+            inputStream,
+            "${userId}/profile.jpg",
+            "image/jpeg",
+            contentLength // <1>
+        )
+        request.metadata = [source: "validated-upload"] // <2>
+        objectStorage.upload(request).key
+    }
+    //end::input-stream-upload[]
+
     //tag::retrieve[]
     Optional<Path> retrieveProfilePicture(String userId, String fileName) {
         String key = "${userId}/${fileName}"

--- a/doc-examples/example-java/src/main/java/example/ProfileService.java
+++ b/doc-examples/example-java/src/main/java/example/ProfileService.java
@@ -16,6 +16,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.Map;
 import java.util.Optional;
 
 //tag::beginclass[]
@@ -38,6 +39,19 @@ public class ProfileService {
         return response.getKey(); // <3>
     }
     //end::upload[]
+
+    //tag::input-stream-upload[]
+    public String saveProfilePicture(String userId, InputStream inputStream, long contentLength) {
+        UploadRequest request = UploadRequest.fromInputStream(
+            inputStream,
+            userId + "/profile.jpg",
+            "image/jpeg",
+            contentLength // <1>
+        );
+        request.setMetadata(Map.of("source", "validated-upload")); // <2>
+        return objectStorage.upload(request).getKey();
+    }
+    //end::input-stream-upload[]
 
     //tag::retrieve[]
     public Optional<Path> retrieveProfilePicture(String userId, String fileName) {

--- a/doc-examples/example-kotlin/src/main/kotlin/example/ProfileService.kt
+++ b/doc-examples/example-kotlin/src/main/kotlin/example/ProfileService.kt
@@ -7,6 +7,7 @@ import io.micronaut.objectstorage.request.UploadRequest
 import io.micronaut.objectstorage.response.ListObjectsResponse
 import jakarta.inject.Singleton
 import java.io.File
+import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
@@ -23,6 +24,19 @@ open class ProfileService(private val objectStorage: ObjectStorageOperations<*, 
         return response.key // <3>
     }
     //end::upload[]
+
+    //tag::input-stream-upload[]
+    open fun saveProfilePicture(userId: String, inputStream: InputStream, contentLength: Long): String? {
+        val request = UploadRequest.fromInputStream(
+            inputStream,
+            "$userId/profile.jpg",
+            "image/jpeg",
+            contentLength // <1>
+        )
+        request.metadata = mapOf("source" to "validated-upload") // <2>
+        return objectStorage.upload(request).key
+    }
+    //end::input-stream-upload[]
 
     //tag::retrieve[]
     open fun retrieveProfilePicture(userId: String, fileName: String): Path? {

--- a/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3OperationsUploadWithConsumerSpec.groovy
+++ b/object-storage-aws/src/test/groovy/io/micronaut/objectstorage/aws/AwsS3OperationsUploadWithConsumerSpec.groovy
@@ -24,7 +24,6 @@ import spock.lang.Specification
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.nio.file.Path
-import java.util.Optional
 
 @Property(name = "micronaut.object-storage.aws.default.bucket", value = "profile-pictures-bucket")
 @Property(name = "spec.name", value = SPEC_NAME)
@@ -65,7 +64,11 @@ class AwsS3OperationsUploadWithConsumerSpec extends Specification {
     void "known-length uploads use the streaming AWS request body path"() {
         given:
         byte[] bytes = "stream-body".bytes
-        UploadRequest uploadRequest = new StubUploadRequest("stream.txt", bytes, true)
+        UploadRequest uploadRequest = UploadRequest.fromInputStream(
+            new ByteArrayInputStream(bytes),
+            "stream.txt",
+            bytes.length
+        )
 
         when:
         objectStorage.upload(uploadRequest)
@@ -81,7 +84,10 @@ class AwsS3OperationsUploadWithConsumerSpec extends Specification {
     void "unknown-length uploads keep the byte-array fallback"() {
         given:
         byte[] bytes = "fallback-body".bytes
-        UploadRequest uploadRequest = new StubUploadRequest("fallback.txt", bytes, false)
+        UploadRequest uploadRequest = UploadRequest.fromInputStream(
+            new ByteArrayInputStream(bytes),
+            "fallback.txt"
+        )
 
         when:
         objectStorage.upload(uploadRequest)
@@ -143,35 +149,4 @@ class AwsS3OperationsUploadWithConsumerSpec extends Specification {
         }
     }
 
-    private static final class StubUploadRequest implements UploadRequest {
-        private final String key
-        private final byte[] bytes
-        private final boolean knownLength
-
-        StubUploadRequest(String key, byte[] bytes, boolean knownLength) {
-            this.key = key
-            this.bytes = bytes
-            this.knownLength = knownLength
-        }
-
-        @Override
-        Optional<String> getContentType() {
-            return Optional.of("text/plain")
-        }
-
-        @Override
-        String getKey() {
-            return key
-        }
-
-        @Override
-        Optional<Long> getContentSize() {
-            return knownLength ? Optional.of(bytes.length as long) : Optional.empty()
-        }
-
-        @Override
-        InputStream getInputStream() {
-            return new ByteArrayInputStream(bytes)
-        }
-    }
 }

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/request/InputStreamUploadRequest.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/request/InputStreamUploadRequest.java
@@ -27,9 +27,15 @@ import java.util.Optional;
 /**
  * An {@link UploadRequest} backed by an {@link InputStream}.
  *
- * <p>The request returns the same stream instance and is intended for a single upload. Providing the
- * content length allows providers to stream the request without buffering and is required by some
- * provider operations.</p>
+ * <p>The request returns the same stream instance and does not copy or buffer its contents. Callers
+ * must not access the stream while an upload is in progress. Provider implementations may close the
+ * stream, so callers that own it should ensure it is closed after a blocking upload returns or after
+ * a reactive upload terminates.</p>
+ *
+ * <p>Because the stream is not recreated, automatic retries may require a stream that supports
+ * {@link InputStream#mark(int)} and {@link InputStream#reset()}. A non-repeatable stream may fail if a
+ * provider retries after consuming part of it. Providing the content length allows providers to
+ * stream the request without buffering and is required by some provider operations.</p>
  *
  * @since 3.1.0
  */
@@ -60,7 +66,7 @@ public class InputStreamUploadRequest extends AbstractUploadRequest {
      *
      * @param inputStream the source input stream.
      * @param key the key under which the object will be stored.
-     * @param contentLength the content length, in bytes.
+     * @param contentLength the number of bytes to read from the stream.
      * @since 3.1.0
      */
     public InputStreamUploadRequest(@NonNull InputStream inputStream,
@@ -75,7 +81,7 @@ public class InputStreamUploadRequest extends AbstractUploadRequest {
      * @param inputStream the source input stream.
      * @param key the key under which the object will be stored.
      * @param contentType the content type, or {@code null} when unknown.
-     * @param contentLength the content length in bytes, or {@code null} when unknown.
+     * @param contentLength the number of bytes to read from the stream, or {@code null} when unknown.
      * @since 3.1.0
      */
     public InputStreamUploadRequest(@NonNull InputStream inputStream,
@@ -91,7 +97,7 @@ public class InputStreamUploadRequest extends AbstractUploadRequest {
      * @param inputStream the source input stream.
      * @param key the key under which the object will be stored.
      * @param contentType the content type, or {@code null} when unknown.
-     * @param contentLength the content length in bytes, or {@code null} when unknown.
+     * @param contentLength the number of bytes to read from the stream, or {@code null} when unknown.
      * @param metadata key-value pairs to store with the object.
      * @since 3.1.0
      */

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/request/InputStreamUploadRequest.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/request/InputStreamUploadRequest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.request;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.io.InputStream;
+import java.net.URLConnection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An {@link UploadRequest} backed by an {@link InputStream}.
+ *
+ * <p>The request returns the same stream instance and is intended for a single upload. Providing the
+ * content length allows providers to stream the request without buffering and is required by some
+ * provider operations.</p>
+ *
+ * @since 3.1.0
+ */
+public class InputStreamUploadRequest extends AbstractUploadRequest {
+
+    @NonNull
+    private final InputStream inputStream;
+
+    @NonNull
+    private final String key;
+
+    @Nullable
+    private final Long contentLength;
+
+    /**
+     * Creates a request with an unknown content length and a content type inferred from the key.
+     *
+     * @param inputStream the source input stream.
+     * @param key the key under which the object will be stored.
+     * @since 3.1.0
+     */
+    public InputStreamUploadRequest(@NonNull InputStream inputStream, @NonNull String key) {
+        this(inputStream, key, URLConnection.guessContentTypeFromName(key), null);
+    }
+
+    /**
+     * Creates a request with a known content length and a content type inferred from the key.
+     *
+     * @param inputStream the source input stream.
+     * @param key the key under which the object will be stored.
+     * @param contentLength the content length, in bytes.
+     * @since 3.1.0
+     */
+    public InputStreamUploadRequest(@NonNull InputStream inputStream,
+                                    @NonNull String key,
+                                    long contentLength) {
+        this(inputStream, key, URLConnection.guessContentTypeFromName(key), contentLength);
+    }
+
+    /**
+     * Creates a request with optional content type and content length.
+     *
+     * @param inputStream the source input stream.
+     * @param key the key under which the object will be stored.
+     * @param contentType the content type, or {@code null} when unknown.
+     * @param contentLength the content length in bytes, or {@code null} when unknown.
+     * @since 3.1.0
+     */
+    public InputStreamUploadRequest(@NonNull InputStream inputStream,
+                                    @NonNull String key,
+                                    @Nullable String contentType,
+                                    @Nullable Long contentLength) {
+        this(inputStream, key, contentType, contentLength, Collections.emptyMap());
+    }
+
+    /**
+     * Creates a request with optional content type, optional content length, and metadata.
+     *
+     * @param inputStream the source input stream.
+     * @param key the key under which the object will be stored.
+     * @param contentType the content type, or {@code null} when unknown.
+     * @param contentLength the content length in bytes, or {@code null} when unknown.
+     * @param metadata key-value pairs to store with the object.
+     * @since 3.1.0
+     */
+    public InputStreamUploadRequest(@NonNull InputStream inputStream,
+                                    @NonNull String key,
+                                    @Nullable String contentType,
+                                    @Nullable Long contentLength,
+                                    @NonNull Map<String, String> metadata) {
+        if (contentLength != null && contentLength < 0) {
+            throw new IllegalArgumentException("contentLength must not be negative");
+        }
+        this.inputStream = inputStream;
+        this.key = key;
+        this.contentType = contentType;
+        this.contentLength = contentLength;
+        this.metadata = metadata;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public Optional<String> getContentType() {
+        return Optional.ofNullable(contentType);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public Optional<Long> getContentSize() {
+        return Optional.ofNullable(contentLength);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public InputStream getInputStream() {
+        return inputStream;
+    }
+}

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/request/UploadRequest.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/request/UploadRequest.java
@@ -187,6 +187,12 @@ public interface UploadRequest {
     Optional<Long> getContentSize();
 
     /**
+     * Returns an input stream of the object to be stored.
+     *
+     * <p>Callers must not access the stream while an upload is in progress. Provider implementations
+     * may close it, so callers that own the stream should ensure it is closed after a blocking upload
+     * returns or after a reactive upload terminates.</p>
+     *
      * @return an input stream of the object to be stored.
      */
     @NonNull

--- a/object-storage-core/src/main/java/io/micronaut/objectstorage/request/UploadRequest.java
+++ b/object-storage-core/src/main/java/io/micronaut/objectstorage/request/UploadRequest.java
@@ -16,6 +16,7 @@
 package io.micronaut.objectstorage.request;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.http.multipart.CompletedFileUpload;
 import io.micronaut.http.multipart.StreamingFileUpload;
 
@@ -71,6 +72,57 @@ public interface UploadRequest {
                                    @NonNull String key,
                                    @NonNull String contentType) {
         return new BytesUploadRequest(bytes, key, contentType);
+    }
+
+    /**
+     * Creates an upload request backed by an input stream whose content length is unknown.
+     *
+     * @param inputStream the source input stream.
+     * @param key the key under which the object will be stored ({@code path/to/file}).
+     * @return An {@link UploadRequest} from the given input stream and key.
+     * @since 3.1.0
+     */
+    @NonNull
+    static UploadRequest fromInputStream(@NonNull InputStream inputStream, @NonNull String key) {
+        return new InputStreamUploadRequest(inputStream, key);
+    }
+
+    /**
+     * Creates an upload request backed by an input stream with a known content length.
+     * Providing the content length allows providers to stream the request without buffering and is
+     * required by some provider operations.
+     *
+     * @param inputStream the source input stream.
+     * @param key the key under which the object will be stored ({@code path/to/file}).
+     * @param contentLength the content length, in bytes.
+     * @return An {@link UploadRequest} from the given parameters.
+     * @since 3.1.0
+     */
+    @NonNull
+    static UploadRequest fromInputStream(@NonNull InputStream inputStream,
+                                         @NonNull String key,
+                                         long contentLength) {
+        return new InputStreamUploadRequest(inputStream, key, contentLength);
+    }
+
+    /**
+     * Creates an upload request backed by an input stream.
+     * Providing the content length allows providers to stream the request without buffering and is
+     * required by some provider operations.
+     *
+     * @param inputStream the source input stream.
+     * @param key the key under which the object will be stored ({@code path/to/file}).
+     * @param contentType the content type, or {@code null} when unknown.
+     * @param contentLength the content length in bytes, or {@code null} when unknown.
+     * @return An {@link UploadRequest} from the given parameters.
+     * @since 3.1.0
+     */
+    @NonNull
+    static UploadRequest fromInputStream(@NonNull InputStream inputStream,
+                                         @NonNull String key,
+                                         @Nullable String contentType,
+                                         @Nullable Long contentLength) {
+        return new InputStreamUploadRequest(inputStream, key, contentType, contentLength);
     }
 
     /**

--- a/object-storage-core/src/test/groovy/io/micronaut/objectstorage/request/InputStreamUploadRequestSpec.groovy
+++ b/object-storage-core/src/test/groovy/io/micronaut/objectstorage/request/InputStreamUploadRequestSpec.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.request
+
+import spock.lang.Specification
+
+import java.io.ByteArrayInputStream
+
+class InputStreamUploadRequestSpec extends Specification {
+
+    private static final byte[] BYTES = "streaming upload body".bytes
+
+    void "it can be created with a known content length"() {
+        given:
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(BYTES)
+
+        when:
+        InputStreamUploadRequest request = UploadRequest.fromInputStream(
+            inputStream,
+            "uploads/body.txt",
+            BYTES.length
+        ) as InputStreamUploadRequest
+        request.metadata = [source: "validated"]
+
+        then:
+        request.key == "uploads/body.txt"
+        request.contentType == Optional.of("text/plain")
+        request.contentSize == Optional.of(BYTES.length as long)
+        request.inputStream.is(inputStream)
+        request.metadata == [source: "validated"]
+    }
+
+    void "it can be created with unknown content type and content length"() {
+        given:
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(BYTES)
+
+        when:
+        InputStreamUploadRequest request = UploadRequest.fromInputStream(
+            inputStream,
+            "uploads/body",
+            null,
+            null
+        ) as InputStreamUploadRequest
+
+        then:
+        request.key == "uploads/body"
+        request.contentType.empty
+        request.contentSize.empty
+        request.inputStream.is(inputStream)
+        request.metadata.isEmpty()
+    }
+
+    void "it accepts metadata in the full constructor"() {
+        given:
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(BYTES)
+
+        when:
+        InputStreamUploadRequest request = new InputStreamUploadRequest(
+            inputStream,
+            "uploads/body.json",
+            "application/json",
+            BYTES.length,
+            [owner: "micronaut"]
+        )
+
+        then:
+        request.contentType == Optional.of("application/json")
+        request.contentSize == Optional.of(BYTES.length as long)
+        request.metadata == [owner: "micronaut"]
+    }
+
+    void "it rejects a negative content length"() {
+        when:
+        UploadRequest.fromInputStream(new ByteArrayInputStream(BYTES), "uploads/body.txt", -1)
+
+        then:
+        IllegalArgumentException e = thrown()
+        e.message == "contentLength must not be negative"
+    }
+}

--- a/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/ObjectStorageOperationsSpecification.groovy
+++ b/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/ObjectStorageOperationsSpecification.groovy
@@ -26,6 +26,7 @@ import org.opentest4j.TestAbortedException
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
+import java.io.ByteArrayInputStream
 import java.net.HttpURLConnection
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -173,6 +174,36 @@ abstract class ObjectStorageOperationsSpecification extends Specification {
                 createTestFile('dir'),
                 createTestFile('dir/subdir'),
         ]
+    }
+
+    void 'it can upload, get and delete object from an input stream'() {
+        given:
+        ObjectStorageOperations<?, ?, ?> storage = getObjectStorage()
+        byte[] bytes = 'streaming-object-storage'.bytes
+        String key = 'streams/upload.txt'
+        UploadRequest uploadRequest = UploadRequest.fromInputStream(
+            new ByteArrayInputStream(bytes),
+            key,
+            CONTENT_TYPE,
+            bytes.length as long
+        )
+        uploadRequest.metadata = METADATA
+
+        when:
+        UploadResponse response = storage.upload(uploadRequest)
+        Optional<ObjectStorageEntry<?>> objectStorageEntry = storage.retrieve(key)
+
+        then:
+        response.ETag
+        objectStorageEntry.present
+        objectStorageEntry.get().inputStream.bytes == bytes
+        objectStorageEntry.get().contentType == Optional.of(CONTENT_TYPE)
+        if (emulatorSupportsMetadata()) {
+            assert objectStorageEntry.get().metadata == METADATA
+        }
+
+        cleanup:
+        storage.delete(key)
     }
 
     void 'it can list objects with portable pagination semantics'() {

--- a/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/ReactiveObjectStorageOperationsSpecification.groovy
+++ b/object-storage-tck/src/main/groovy/io/micronaut/objectstorage/ReactiveObjectStorageOperationsSpecification.groovy
@@ -24,6 +24,7 @@ import reactor.core.publisher.Mono
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
+import java.io.ByteArrayInputStream
 import java.time.Duration
 
 abstract class ReactiveObjectStorageOperationsSpecification extends Specification {
@@ -167,6 +168,36 @@ abstract class ReactiveObjectStorageOperationsSpecification extends Specificatio
             ObjectStorageOperationsSpecification.createTestFile('dir'),
             ObjectStorageOperationsSpecification.createTestFile('dir/subdir'),
         ]
+    }
+
+    void 'it can upload, get and delete an input stream reactively'() {
+        given:
+        ReactiveObjectStorageOperations<?, ?, ?> storage = getObjectStorage()
+        byte[] bytes = 'reactive-streaming-object-storage'.bytes
+        String key = 'streams/reactive-upload.txt'
+        UploadRequest uploadRequest = UploadRequest.fromInputStream(
+            new ByteArrayInputStream(bytes),
+            key,
+            CONTENT_TYPE,
+            bytes.length as long
+        )
+        uploadRequest.metadata = METADATA
+
+        when:
+        UploadResponse response = awaitOne(storage.upload(uploadRequest))
+        Optional<ObjectStorageEntry<?>> objectStorageEntry = awaitOne(storage.retrieve(key))
+
+        then:
+        response.ETag
+        objectStorageEntry.present
+        objectStorageEntry.get().inputStream.bytes == bytes
+        objectStorageEntry.get().contentType == Optional.of(CONTENT_TYPE)
+        if (emulatorSupportsMetadata()) {
+            assert objectStorageEntry.get().metadata == METADATA
+        }
+
+        cleanup:
+        awaitOne(storage.delete(key))
     }
 
     void 'it can list objects reactively with portable pagination semantics'() {

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -77,6 +77,18 @@ If you receive a `StreamingFileUpload` in a multipart controller, you can forwar
 
 snippet::example.UploadController[project-base="doc-examples/example", source="main", indent="0", tags="streaming"]
 
+If the content is already available as an `InputStream`, for example after validating or transforming an incoming
+request stream, you can upload it directly without first collecting it into a byte array:
+
+snippet::example.ProfileService[project-base="doc-examples/example", source="main", indent="0", tags="input-stream-upload"]
+
+<1> Supply the content length whenever it is known. This allows providers to stream the content directly; some provider
+    operations require it. In particular, synchronous AWS S3 uploads buffer unknown-length streams, and AWS S3 and OCI
+    multipart part uploads require a declared content length.
+<2> Content type and metadata work the same way as for other api:objectstorage.request.UploadRequest[] implementations.
+
+An api:objectstorage.request.InputStreamUploadRequest[] returns the same stream instance and is intended for one upload.
+
 == Retrieving files
 
 snippet::example.ProfileService[project-base="doc-examples/example", source="main", indent="0", tags="retrieve"]

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -87,7 +87,13 @@ snippet::example.ProfileService[project-base="doc-examples/example", source="mai
     multipart part uploads require a declared content length.
 <2> Content type and metadata work the same way as for other api:objectstorage.request.UploadRequest[] implementations.
 
-An api:objectstorage.request.InputStreamUploadRequest[] returns the same stream instance and is intended for one upload.
+An api:objectstorage.request.InputStreamUploadRequest[] returns the same stream instance without copying or buffering it.
+Do not access the stream while a blocking upload is running or until a reactive upload terminates. Provider
+implementations may close the stream; code that owns it should ensure it is closed after the upload completes.
+
+Because the same stream instance is used for the whole upload, automatic retries may require a stream that supports
+`mark` and `reset`. In particular, a synchronous AWS S3 upload with a non-repeatable stream can fail if the SDK retries
+after consuming part of the stream.
 
 == Retrieving files
 


### PR DESCRIPTION
## Summary

- add a public InputStreamUploadRequest with optional content type and content length
- add UploadRequest factories and metadata support consistent with existing request types
- define stream ownership, blocking/reactive completion, and retryability semantics
- verify portable blocking and reactive provider behavior plus AWS known-length streaming versus unknown-length buffering
- document stream lifecycle and provider content-length requirements with Java, Groovy, and Kotlin examples

Fixes #823