### PR TITLE
Add local metadata persistence modes

### DIFF
--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketMetadataOperations.java
@@ -42,10 +42,12 @@ import java.util.concurrent.locks.Lock;
 final class LocalStorageBucketMetadataOperations implements BucketMetadataOperations<Path> {
 
     private final LocalStorageLayout layout;
+    private final LocalStorageMetadataMode metadataMode;
     private final boolean supportsPosixPermissions;
 
     LocalStorageBucketMetadataOperations(@Parameter LocalStorageConfiguration configuration) {
         this.layout = new LocalStorageLayout(configuration);
+        this.metadataMode = configuration.getMetadataMode();
         layout.requireBucketRoot("bucket metadata operations");
         this.supportsPosixPermissions = layout.storageRoot().getFileSystem().supportedFileAttributeViews().contains("posix");
     }
@@ -53,6 +55,9 @@ final class LocalStorageBucketMetadataOperations implements BucketMetadataOperat
     @Override
     @NonNull
     public Optional<BucketMetadataEntry<Path>> retrieve(@NonNull String name) {
+        if (metadataMode == LocalStorageMetadataMode.NONE) {
+            return Optional.empty();
+        }
         Path metadataFile = metadataFilePath(name);
         try {
             return Optional.of(LocalStorageMetadataSupport.readBucketMetadata(metadataFile, name));
@@ -65,6 +70,9 @@ final class LocalStorageBucketMetadataOperations implements BucketMetadataOperat
 
     @Override
     public void save(@NonNull BucketMetadataWrite write) {
+        if (metadataMode == LocalStorageMetadataMode.NONE) {
+            throw new ObjectStorageException("Local storage metadata mode NONE does not support bucket metadata persistence");
+        }
         Path bucketPath = layout.bucketPath(write.name());
         Lock bucketLock = LocalStorageLocks.bucketReadLock(bucketPath);
         bucketLock.lock();

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageBucketOperations.java
@@ -42,12 +42,18 @@ import java.util.concurrent.locks.Lock;
 @EachBean(LocalStorageConfiguration.class)
 final class LocalStorageBucketOperations implements BucketOperations<Path> {
     private final LocalStorageLayout layout;
+    private final LocalStorageMetadataMode metadataMode;
     private final BucketMetadataOperations<Path> bucketMetadataOperations;
+    private final LocalStorageBucketMetadataOperations sidecarMetadataOperations;
 
     LocalStorageBucketOperations(@Parameter LocalStorageConfiguration configuration,
                                  BucketMetadataOperations<Path> bucketMetadataOperations) {
         this.layout = new LocalStorageLayout(configuration);
+        this.metadataMode = configuration.getMetadataMode();
         this.bucketMetadataOperations = bucketMetadataOperations;
+        this.sidecarMetadataOperations = bucketMetadataOperations instanceof LocalStorageBucketMetadataOperations localOperations
+            ? localOperations
+            : new LocalStorageBucketMetadataOperations(configuration);
         layout.requireBucketRoot("bucket operations");
     }
 
@@ -90,7 +96,12 @@ final class LocalStorageBucketOperations implements BucketOperations<Path> {
                     // Deleting a missing bucket is a no-op for user files, but provider state can still be stale.
                 }
                 deleteProviderManagedBucketState(name);
-                bucketMetadataOperations.delete(name);
+                if (metadataMode == LocalStorageMetadataMode.ENABLED) {
+                    bucketMetadataOperations.delete(name);
+                } else {
+                    // A custom SPI bean must never be invoked in NONE mode.
+                    sidecarMetadataOperations.delete(name);
+                }
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageConfiguration.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageConfiguration.java
@@ -46,6 +46,9 @@ public class LocalStorageConfiguration extends AbstractObjectStorageConfiguratio
     @NonNull
     private Path path;
 
+    @NonNull
+    private LocalStorageMetadataMode metadataMode = LocalStorageMetadataMode.ENABLED;
+
     public LocalStorageConfiguration(@Parameter String name) {
         super(name);
     }
@@ -72,6 +75,27 @@ public class LocalStorageConfiguration extends AbstractObjectStorageConfiguratio
      */
     public void setPath(@NonNull Path path) {
         this.path = path;
+    }
+
+    /**
+     * The metadata persistence mode for this local storage configuration.
+     *
+     * @return The metadata persistence mode.
+     * @since 3.1.1
+     */
+    @NonNull
+    public LocalStorageMetadataMode getMetadataMode() {
+        return metadataMode;
+    }
+
+    /**
+     * Sets the metadata persistence mode for this local storage configuration.
+     *
+     * @param metadataMode The metadata persistence mode.
+     * @since 3.1.1
+     */
+    public void setMetadataMode(@NonNull LocalStorageMetadataMode metadataMode) {
+        this.metadataMode = metadataMode;
     }
 
     /**

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMetadataMode.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMetadataMode.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.objectstorage.local;
+
+/**
+ * Controls whether the local storage provider persists object and bucket metadata.
+ *
+ * @author Ayoub Ait Abdellah
+ * @since 3.1.1
+ */
+public enum LocalStorageMetadataMode {
+
+    /**
+     * Persist metadata through the configured metadata operations. The built-in implementation
+     * uses filesystem sidecars.
+     */
+    ENABLED,
+
+    /**
+     * Persist no object or bucket metadata.
+     */
+    NONE
+}

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageMultipartOperations.java
@@ -56,17 +56,20 @@ final class LocalStorageMultipartOperations implements MultipartObjectStorageOpe
 
     private final LocalStorageOperations objectStorageOperations;
     private final LocalStorageMultipartUploadState uploadState;
+    private final LocalStorageMetadataMode metadataMode;
 
     LocalStorageMultipartOperations(@Parameter LocalStorageConfiguration configuration,
                                     LocalStorageOperations objectStorageOperations) {
         LocalStorageLayout layout = new LocalStorageLayout(configuration);
         this.objectStorageOperations = objectStorageOperations;
         this.uploadState = new LocalStorageMultipartUploadState(layout);
+        this.metadataMode = configuration.getMetadataMode();
     }
 
     @Override
     @NonNull
     public CreateMultipartUploadResponse<LocalStorageMultipartUpload> createMultipartUpload(@NonNull CreateMultipartUploadRequest request) {
+        LocalStorageOperations.validateMetadata(metadataMode, request.getMetadata());
         String uploadId = UUID.randomUUID().toString();
         Path uploadPath = uploadState.createUpload(request, uploadId);
         return CreateMultipartUploadResponse.of(

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageObjectMetadataOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageObjectMetadataOperations.java
@@ -45,16 +45,21 @@ import java.util.concurrent.locks.Lock;
 final class LocalStorageObjectMetadataOperations implements ObjectMetadataOperations<Path> {
 
     private final LocalStorageLayout layout;
+    private final LocalStorageMetadataMode metadataMode;
     private final boolean supportsPosixPermissions;
 
     LocalStorageObjectMetadataOperations(@Parameter LocalStorageConfiguration configuration) {
         this.layout = new LocalStorageLayout(configuration);
+        this.metadataMode = configuration.getMetadataMode();
         this.supportsPosixPermissions = layout.storageRoot().getFileSystem().supportedFileAttributeViews().contains("posix");
     }
 
     @Override
     @NonNull
     public Optional<ObjectMetadataEntry<Path>> retrieve(@NonNull String key) {
+        if (metadataMode == LocalStorageMetadataMode.NONE) {
+            return Optional.empty();
+        }
         for (Path metadataFile : layout.objectMetadataReadPaths(key)) {
             try {
                 return Optional.of(LocalStorageMetadataSupport.readObjectMetadata(metadataFile, key));
@@ -70,6 +75,9 @@ final class LocalStorageObjectMetadataOperations implements ObjectMetadataOperat
 
     @Override
     public void save(@NonNull ObjectMetadataWrite write) {
+        if (metadataMode == LocalStorageMetadataMode.NONE) {
+            throw new ObjectStorageException("Local storage metadata mode NONE does not support object metadata persistence");
+        }
         Lock bucketLock = LocalStorageLocks.bucketReadLock(layout.configuredBucketPath());
         bucketLock.lock();
         try {

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -215,6 +215,9 @@ public class LocalStorageOperations implements ObjectStorageOperations<
                 prepareMetadataForMutation(key);
                 StoredFileSnapshot snapshot = snapshotStoredFile(path);
                 if (!snapshot.exists()) {
+                    if (metadataMode == LocalStorageMetadataMode.ENABLED) {
+                        objectMetadataOperations.delete(key);
+                    }
                     return new LocalStorageFile(null);
                 }
                 RuntimeException failure = null;

--- a/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
+++ b/object-storage-local/src/main/java/io/micronaut/objectstorage/local/LocalStorageOperations.java
@@ -85,7 +85,9 @@ public class LocalStorageOperations implements ObjectStorageOperations<
 
     private final LocalStorageConfiguration configuration;
     private final LocalStorageLayout layout;
+    private final LocalStorageMetadataMode metadataMode;
     private final ObjectMetadataOperations<Path> objectMetadataOperations;
+    private final LocalStorageObjectMetadataOperations sidecarMetadataOperations;
     private final boolean supportsPosixPermissions;
 
     /**
@@ -112,12 +114,22 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         this(configuration, (ObjectMetadataOperations<Path>) objectMetadataOperations);
     }
 
+    /**
+     * Create local storage operations with a custom metadata persistence implementation.
+     *
+     * @param configuration The local storage configuration.
+     * @param objectMetadataOperations The object metadata operations.
+     */
     @Inject
     public LocalStorageOperations(@Parameter LocalStorageConfiguration configuration,
                                   ObjectMetadataOperations<Path> objectMetadataOperations) {
         this.configuration = configuration;
         this.layout = new LocalStorageLayout(configuration);
+        this.metadataMode = configuration.getMetadataMode();
         this.objectMetadataOperations = objectMetadataOperations;
+        this.sidecarMetadataOperations = objectMetadataOperations instanceof LocalStorageObjectMetadataOperations localOperations
+            ? localOperations
+            : new LocalStorageObjectMetadataOperations(configuration);
         this.supportsPosixPermissions = configuration.getPath().getFileSystem().supportedFileAttributeViews().contains("posix");
     }
 
@@ -131,6 +143,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     @NonNull
     public UploadResponse<LocalStorageFile> upload(@NonNull UploadRequest request,
                                                    @NonNull Consumer<LocalStorageFile> requestConsumer) {
+        validateMetadata(metadataMode, request.getMetadata());
         String key = request.getKey();
         Path file = layout.objectPath(key);
         Lock bucketLock = LocalStorageLocks.bucketReadLock(layout.configuredBucketPath());
@@ -145,16 +158,19 @@ public class LocalStorageOperations implements ObjectStorageOperations<
                 RuntimeException failure = null;
                 boolean preserveSnapshot = false;
                 try {
+                    prepareMetadataForMutation(key);
                     eTag = storeFile(file, request.getInputStream());
-                    objectMetadataOperations.save(new ObjectMetadataWrite(
-                        key,
-                        request.getMetadata(),
-                        Map.of(),
-                        request.getContentType().orElse(null),
-                        request.getContentSize().orElse(null),
-                        eTag,
-                        null
-                    ));
+                    if (metadataMode == LocalStorageMetadataMode.ENABLED) {
+                        objectMetadataOperations.save(new ObjectMetadataWrite(
+                            key,
+                            request.getMetadata(),
+                            Map.of(),
+                            request.getContentType().orElse(null),
+                            request.getContentSize().orElse(null),
+                            eTag,
+                            null
+                        ));
+                    }
                 } catch (RuntimeException e) {
                     failure = e;
                     boolean restored = restoreStoredFileAfterFailure(file, snapshot, e);
@@ -182,7 +198,7 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         return file.map(path -> new LocalStorageEntry(
             key,
             path,
-            objectMetadataOperations.retrieve(key).map(ObjectMetadataEntry::metadata).orElse(Collections.emptyMap())
+            retrieveMetadata(key)
         ));
     }
 
@@ -196,16 +212,18 @@ public class LocalStorageOperations implements ObjectStorageOperations<
         try {
             mutationLock.lock();
             try {
+                prepareMetadataForMutation(key);
                 StoredFileSnapshot snapshot = snapshotStoredFile(path);
                 if (!snapshot.exists()) {
-                    objectMetadataOperations.delete(key);
                     return new LocalStorageFile(null);
                 }
                 RuntimeException failure = null;
                 boolean preserveSnapshot = false;
                 try {
                     deleteFile(path);
-                    objectMetadataOperations.delete(key);
+                    if (metadataMode == LocalStorageMetadataMode.ENABLED) {
+                        objectMetadataOperations.delete(key);
+                    }
                 } catch (RuntimeException e) {
                     failure = e;
                     boolean restored = restoreStoredFileAfterFailure(path, snapshot, e);
@@ -391,12 +409,15 @@ public class LocalStorageOperations implements ObjectStorageOperations<
     }
 
     private void copyStoredFile(String sourceKey, Path source, String destinationKey, Path destinationFile) {
+        prepareMetadataForMutation(destinationKey);
         StoredFileSnapshot snapshot = snapshotStoredFile(destinationFile);
         RuntimeException failure = null;
         boolean preserveSnapshot = false;
         try (InputStream in = newInputStreamNoFollow(source)) {
             String eTag = storeFile(destinationFile, in);
-            copyObjectMetadata(sourceKey, destinationKey, eTag);
+            if (metadataMode == LocalStorageMetadataMode.ENABLED) {
+                copyObjectMetadata(sourceKey, destinationKey, eTag);
+            }
         } catch (IOException e) {
             ObjectStorageException objectStorageException = new ObjectStorageException("Error copying file: " + source, e);
             failure = objectStorageException;
@@ -434,6 +455,28 @@ public class LocalStorageOperations implements ObjectStorageOperations<
                 null
             ))
         );
+    }
+
+    private Map<String, String> retrieveMetadata(String key) {
+        if (metadataMode == LocalStorageMetadataMode.NONE) {
+            return Collections.emptyMap();
+        }
+        return objectMetadataOperations.retrieve(key)
+            .map(ObjectMetadataEntry::metadata)
+            .orElse(Collections.emptyMap());
+    }
+
+    private void prepareMetadataForMutation(String key) {
+        if (metadataMode == LocalStorageMetadataMode.NONE) {
+            // Remove only built-in local sidecars. A custom SPI bean must never be invoked in NONE mode.
+            sidecarMetadataOperations.delete(key);
+        }
+    }
+
+    static void validateMetadata(LocalStorageMetadataMode metadataMode, Map<String, String> metadata) {
+        if (metadataMode == LocalStorageMetadataMode.NONE && !metadata.isEmpty()) {
+            throw new ObjectStorageException("Local storage metadata mode NONE does not support user metadata");
+        }
     }
 
     private StoredFileSnapshot snapshotStoredFile(Path file) {

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMetadataModeSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMetadataModeSpec.groovy
@@ -1,0 +1,332 @@
+package io.micronaut.objectstorage.local
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.objectstorage.ObjectStorageException
+import io.micronaut.objectstorage.metadata.BucketMetadataOperations
+import io.micronaut.objectstorage.metadata.BucketMetadataWrite
+import io.micronaut.objectstorage.metadata.ObjectMetadataOperations
+import io.micronaut.objectstorage.metadata.ObjectMetadataWrite
+import io.micronaut.objectstorage.multipart.AbortMultipartUploadRequest
+import io.micronaut.objectstorage.multipart.CompleteMultipartUploadRequest
+import io.micronaut.objectstorage.multipart.CreateMultipartUploadRequest
+import io.micronaut.objectstorage.multipart.UploadPartRequest
+import io.micronaut.objectstorage.request.UploadRequest
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+
+class LocalStorageMetadataModeSpec extends Specification {
+
+    void 'metadata mode defaults and binds for multiple named configurations'() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+            (property('default', 'enabled'))      : true,
+            (property('metadata', 'enabled'))      : true,
+            (property('metadata', 'metadata-mode')): 'enabled',
+            (property('none', 'enabled'))         : true,
+            (property('none', 'metadata-mode'))   : 'none'
+        ])
+
+        expect:
+        configuration(context, 'default').metadataMode == LocalStorageMetadataMode.ENABLED
+        configuration(context, 'metadata').metadataMode == LocalStorageMetadataMode.ENABLED
+        configuration(context, 'none').metadataMode == LocalStorageMetadataMode.NONE
+
+        cleanup:
+        context.close()
+    }
+
+    void 'invalid metadata mode fails configuration binding clearly'() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+            (property('default', 'enabled'))      : true,
+            (property('default', 'metadata-mode')): 'database'
+        ])
+
+        when:
+        configuration(context, 'default')
+
+        then:
+        Exception exception = thrown()
+        exception.message.contains('metadata-mode') || exception.message.contains('metadataMode')
+        exception.message.contains('database')
+
+        cleanup:
+        context.close()
+    }
+
+    void 'none upload returns deterministic content etag without persisting metadata'() {
+        given:
+        Path root = Files.createTempDirectory('local-none-upload')
+        LocalStorageConfiguration configuration = noneConfiguration(root.resolve('default'))
+        LocalStorageOperations operations = new LocalStorageOperations(configuration)
+
+        when:
+        def first = operations.upload(UploadRequest.fromBytes('hello'.bytes, 'first.txt', 'text/plain'))
+        def repeated = operations.upload(UploadRequest.fromBytes('hello'.bytes, 'second.txt', 'text/plain'))
+        def changed = operations.upload(UploadRequest.fromBytes('changed'.bytes, 'third.txt', 'text/plain'))
+        def entry = operations.retrieve('first.txt').get()
+
+        then:
+        first.ETag == sha256ETag('hello')
+        repeated.ETag == first.ETag
+        changed.ETag != first.ETag
+        entry.inputStream.text == 'hello'
+        entry.metadata.isEmpty()
+        entry.contentType.get() == 'text/plain'
+        !Files.exists(objectSidecar(root, 'first.txt'))
+        !Files.exists(legacySidecar(root.resolve('default'), 'first.txt'))
+
+        cleanup:
+        LocalStorageBucketOperations.deleteRecursively(root)
+    }
+
+    void 'explicit enabled mode preserves built-in metadata behavior'() {
+        given:
+        Path root = Files.createTempDirectory('local-explicit-metadata')
+        LocalStorageOperations operations = new LocalStorageOperations(enabledConfiguration(root.resolve('default')))
+        def request = UploadRequest.fromBytes('content'.bytes, 'object.txt')
+        request.metadata = [owner: 'micronaut']
+
+        when:
+        def response = operations.upload(request)
+        def entry = operations.retrieve('object.txt').get()
+
+        then:
+        response.ETag == sha256ETag('content')
+        entry.metadata == [owner: 'micronaut']
+        Files.exists(objectSidecar(root, 'object.txt'))
+
+        cleanup:
+        LocalStorageBucketOperations.deleteRecursively(root)
+    }
+
+    void 'none rejects metadata before overwriting an existing object'() {
+        given:
+        Path root = Files.createTempDirectory('local-none-reject')
+        LocalStorageConfiguration configuration = noneConfiguration(root.resolve('default'))
+        LocalStorageOperations operations = new LocalStorageOperations(configuration)
+        operations.upload(UploadRequest.fromBytes('original'.bytes, 'object.txt'))
+        def rejected = UploadRequest.fromBytes('replacement'.bytes, 'object.txt')
+        rejected.metadata = [owner: 'application']
+
+        when:
+        operations.upload(rejected)
+
+        then:
+        ObjectStorageException exception = thrown()
+        exception.message == 'Local storage metadata mode NONE does not support user metadata'
+        operations.retrieve('object.txt').get().inputStream.text == 'original'
+
+        cleanup:
+        LocalStorageBucketOperations.deleteRecursively(root)
+    }
+
+    void 'none bypasses an injected metadata provider'() {
+        given:
+        Path root = Files.createTempDirectory('local-none-custom-provider')
+        LocalStorageConfiguration configuration = noneConfiguration(root.resolve('default'))
+        ObjectMetadataOperations<Path> metadataOperations = Mock()
+        LocalStorageOperations operations = new LocalStorageOperations(configuration, metadataOperations)
+
+        when:
+        operations.upload(UploadRequest.fromBytes('content'.bytes, 'object.txt'))
+        operations.retrieve('object.txt')
+        operations.delete('object.txt')
+
+        then:
+        0 * metadataOperations._
+
+        cleanup:
+        LocalStorageBucketOperations.deleteRecursively(root)
+    }
+
+    void 'none built-in metadata operations never read or save sidecars'() {
+        given:
+        Path root = Files.createTempDirectory('local-none-metadata-operations')
+        Path bucket = root.resolve('default')
+        Files.createDirectories(bucket)
+        Path objectSidecar = objectSidecar(root, 'object.txt')
+        Path bucketSidecar = root.resolve('.mn-storage/metadata/buckets/default')
+        Files.createDirectories(objectSidecar.parent)
+        Files.createDirectories(bucketSidecar.parent)
+        Files.writeString(objectSidecar, 'owner=stale')
+        Files.writeString(bucketSidecar, 'owner=stale')
+        LocalStorageConfiguration configuration = noneConfiguration(bucket)
+        LocalStorageObjectMetadataOperations objects = new LocalStorageObjectMetadataOperations(configuration)
+        LocalStorageBucketMetadataOperations buckets = new LocalStorageBucketMetadataOperations(configuration)
+
+        expect:
+        objects.retrieve('object.txt').empty
+        buckets.retrieve('default').empty
+
+        when:
+        objects.save(new ObjectMetadataWrite('object.txt', [owner: 'application']))
+
+        then:
+        ObjectStorageException objectException = thrown()
+        objectException.message == 'Local storage metadata mode NONE does not support object metadata persistence'
+
+        when:
+        buckets.save(new BucketMetadataWrite('default', [owner: 'application']))
+
+        then:
+        ObjectStorageException bucketException = thrown()
+        bucketException.message == 'Local storage metadata mode NONE does not support bucket metadata persistence'
+        Files.exists(objectSidecar)
+        Files.exists(bucketSidecar)
+
+        cleanup:
+        LocalStorageBucketOperations.deleteRecursively(root)
+    }
+
+    void 'none copy and delete clean stale current and legacy sidecars'() {
+        given:
+        Path root = Files.createTempDirectory('local-none-stale')
+        Path bucket = root.resolve('default')
+        LocalStorageConfiguration enabledConfig = enabledConfiguration(bucket)
+        LocalStorageOperations enabledOperations = new LocalStorageOperations(enabledConfig)
+        def sourceRequest = UploadRequest.fromBytes('source'.bytes, 'source.txt')
+        sourceRequest.metadata = [owner: 'source']
+        def destinationRequest = UploadRequest.fromBytes('destination'.bytes, 'destination.txt')
+        destinationRequest.metadata = [owner: 'destination']
+        enabledOperations.upload(sourceRequest)
+        enabledOperations.upload(destinationRequest)
+        Path legacy = legacySidecar(bucket, 'destination.txt')
+        Files.createDirectories(legacy.parent)
+        Files.writeString(legacy, 'owner=legacy')
+
+        and:
+        LocalStorageOperations noneOperations = new LocalStorageOperations(noneConfiguration(bucket))
+
+        when:
+        noneOperations.copy('source.txt', 'destination.txt')
+
+        then:
+        noneOperations.retrieve('destination.txt').get().inputStream.text == 'source'
+        noneOperations.retrieve('destination.txt').get().metadata.isEmpty()
+        !Files.exists(objectSidecar(root, 'destination.txt'))
+        !Files.exists(legacy)
+        Files.exists(objectSidecar(root, 'source.txt'))
+
+        when:
+        noneOperations.delete('destination.txt')
+        noneOperations.upload(UploadRequest.fromBytes('recreated'.bytes, 'destination.txt'))
+        LocalStorageOperations switchedBack = new LocalStorageOperations(enabledConfiguration(bucket))
+
+        then:
+        switchedBack.retrieve('destination.txt').get().metadata.isEmpty()
+
+        cleanup:
+        LocalStorageBucketOperations.deleteRecursively(root)
+    }
+
+    void 'none multipart rejects metadata before state creation and completes metadata-free uploads'() {
+        given:
+        Path root = Files.createTempDirectory('local-none-multipart')
+        LocalStorageConfiguration configuration = noneConfiguration(root.resolve('default'))
+        LocalStorageOperations operations = new LocalStorageOperations(configuration)
+        LocalStorageMultipartOperations multipart = new LocalStorageMultipartOperations(configuration, operations)
+        Path multipartRoot = root.resolve('.mn-storage/multipart/default')
+
+        when:
+        multipart.createMultipartUpload(new CreateMultipartUploadRequest('rejected.txt', 'text/plain', [owner: 'application']))
+
+        then:
+        ObjectStorageException exception = thrown()
+        exception.message == 'Local storage metadata mode NONE does not support user metadata'
+        !Files.exists(multipartRoot)
+
+        when:
+        def created = multipart.createMultipartUpload(new CreateMultipartUploadRequest('completed.txt', 'text/plain'))
+        def part = multipart.uploadPart(new UploadPartRequest(
+            created.upload,
+            1,
+            UploadRequest.fromBytes('content'.bytes, 'completed.txt', 'text/plain')
+        ))
+        def completed = multipart.completeMultipartUpload(new CompleteMultipartUploadRequest(created.upload, [part.part]))
+
+        then:
+        completed.ETag == sha256ETag('content')
+        operations.retrieve('completed.txt').get().inputStream.text == 'content'
+        operations.retrieve('completed.txt').get().metadata.isEmpty()
+        !Files.exists(objectSidecar(root, 'completed.txt'))
+        !Files.exists(created.nativeResponse.path)
+
+        when:
+        def aborted = multipart.createMultipartUpload(new CreateMultipartUploadRequest('aborted.txt'))
+        multipart.abortMultipartUpload(new AbortMultipartUploadRequest(aborted.upload))
+
+        then:
+        !Files.exists(aborted.nativeResponse.path)
+
+        cleanup:
+        LocalStorageBucketOperations.deleteRecursively(root)
+    }
+
+    void 'none bucket lifecycle creates no metadata sidecar and cleans provider working state'() {
+        given:
+        Path root = Files.createTempDirectory('local-none-bucket')
+        LocalStorageConfiguration configuration = noneConfiguration(root.resolve('default'))
+        BucketMetadataOperations<Path> metadataOperations = Mock()
+        LocalStorageBucketOperations buckets = new LocalStorageBucketOperations(configuration, metadataOperations)
+        Path workingState = root.resolve('.mn-storage/multipart/other/upload')
+
+        when:
+        buckets.create('other')
+        Files.createDirectories(workingState)
+        Files.writeString(workingState.resolve('state'), 'state')
+
+        then:
+        buckets.retrieve('other').present
+        !Files.exists(root.resolve('.mn-storage/metadata/buckets/other'))
+
+        when:
+        buckets.delete('other')
+
+        then:
+        !buckets.retrieve('other').present
+        !Files.exists(workingState)
+        0 * metadataOperations._
+
+        cleanup:
+        LocalStorageBucketOperations.deleteRecursively(root)
+    }
+
+    private static LocalStorageConfiguration configuration(ApplicationContext context, String name) {
+        context.getBean(LocalStorageConfiguration, Qualifiers.byName(name))
+    }
+
+    private static LocalStorageConfiguration noneConfiguration(Path path) {
+        LocalStorageConfiguration configuration = new LocalStorageConfiguration('default')
+        configuration.path = path
+        configuration.metadataMode = LocalStorageMetadataMode.NONE
+        configuration
+    }
+
+    private static LocalStorageConfiguration enabledConfiguration(Path path) {
+        LocalStorageConfiguration configuration = new LocalStorageConfiguration('default')
+        configuration.path = path
+        configuration.metadataMode = LocalStorageMetadataMode.ENABLED
+        configuration
+    }
+
+    private static String property(String name, String property) {
+        "${LocalStorageConfiguration.PREFIX}.${name}.${property}"
+    }
+
+    private static Path objectSidecar(Path root, String key) {
+        root.resolve('.mn-storage/metadata/objects/default').resolve(key)
+    }
+
+    private static Path legacySidecar(Path bucket, String key) {
+        bucket.resolve('.metadata').resolve(key)
+    }
+
+    private static String sha256ETag(String text) {
+        MessageDigest.getInstance('SHA-256').digest(text.bytes).encodeHex().toString()
+    }
+}

--- a/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMetadataModeSpec.groovy
+++ b/object-storage-local/src/test/groovy/io/micronaut/objectstorage/local/LocalStorageMetadataModeSpec.groovy
@@ -104,6 +104,27 @@ class LocalStorageMetadataModeSpec extends Specification {
         LocalStorageBucketOperations.deleteRecursively(root)
     }
 
+    void 'enabled delete removes metadata when object bytes are already missing'() {
+        given:
+        Path root = Files.createTempDirectory('local-enabled-missing-object')
+        Path bucket = root.resolve('default')
+        LocalStorageOperations operations = new LocalStorageOperations(enabledConfiguration(bucket))
+        def request = UploadRequest.fromBytes('content'.bytes, 'missing.txt')
+        request.metadata = [owner: 'micronaut']
+        operations.upload(request)
+        Files.delete(bucket.resolve('missing.txt'))
+
+        when:
+        operations.delete('missing.txt')
+
+        then:
+        !Files.exists(objectSidecar(root, 'missing.txt'))
+        !Files.exists(legacySidecar(bucket, 'missing.txt'))
+
+        cleanup:
+        LocalStorageBucketOperations.deleteRecursively(root)
+    }
+
     void 'none rejects metadata before overwriting an existing object'() {
         given:
         Path root = Files.createTempDirectory('local-none-reject')

--- a/src/main/docs/guide/local.adoc
+++ b/src/main/docs/guide/local.adoc
@@ -11,10 +11,40 @@ micronaut:
     local:
       default:
         enabled: true
+        metadata-mode: enabled
 ----
 
 NOTE: When added to the classpath, api:objectstorage.local.LocalStorageOperations[] becomes the primary implementation of
 api:objectstorage.ObjectStorageOperations[].
+
+The `metadata-mode` property controls persistent metadata ownership:
+
+`ENABLED`:: The default. The local provider persists metadata through the configured metadata SPI. The built-in
+implementation uses filesystem sidecars.
+`NONE`:: The local provider persists object bytes but no object or bucket metadata sidecars.
+
+Applications that own persistent metadata in a database can select `NONE`:
+
+[configuration]
+----
+micronaut:
+  object-storage:
+    local:
+      default:
+        enabled: true
+        path: /data/storage/objects
+        metadata-mode: none
+----
+
+In `NONE` mode, uploads with non-empty user metadata are rejected before the destination is mutated. Content type and
+content length may still be used during an operation, but they are not persisted as sidecars. Uploads continue calculating
+SHA-256 while streaming content and return the lowercase digest as the ETag. Retrieval returns the object bytes, an empty
+metadata map, and the existing filename-based content-type result.
+
+Applications choosing `NONE` are responsible for persisting any logical metadata they need, including ownership, content
+type, size, timestamps, object identity, and the ETag returned after a successful upload. The application must coordinate
+its own database transaction with successful object operations; the local provider does not access or participate in the
+application database.
 
 NOTE: The local storage implementation reserves the `.mn-storage` key namespace for provider-managed metadata,
 multipart upload state, temporary write files, and temporary rollback files. It also reserves the legacy `.metadata` key
@@ -23,10 +53,16 @@ or start with either reserved namespace followed by `/` (or the equivalent platf
 and configured local bucket directory names cannot use those reserved namespaces either.
 
 The local implementation is also the reference provider for
-api:objectstorage.metadata.ObjectMetadataOperations[] and api:objectstorage.metadata.BucketMetadataOperations[].
-Provider-managed files live under one `.mn-storage` directory in the storage root that contains the configured bucket.
-Object metadata sidecars live under `.mn-storage/metadata/objects/<bucket>/<key>`, bucket metadata sidecars live under
-`.mn-storage/metadata/buckets/<bucket>`, in-progress multipart upload state lives under
+api:objectstorage.metadata.ObjectMetadataOperations[] and api:objectstorage.metadata.BucketMetadataOperations[]. In
+`ENABLED` mode, configured implementations of those SPIs remain responsible for metadata persistence. With the built-in
+implementation, provider-managed files live under one `.mn-storage` directory in the storage root that contains the
+configured bucket. Object metadata sidecars live under `.mn-storage/metadata/objects/<bucket>/<key>`, bucket metadata
+sidecars live under `.mn-storage/metadata/buckets/<bucket>`, and legacy per-bucket `.metadata` sidecars remain readable.
+New sidecar writes use the root `.mn-storage` layout, and deletes remove both the current and legacy sidecars for the
+affected object.
+
+The `.mn-storage` directory is not exclusively a metadata directory and can still exist in `NONE` mode. In-progress
+multipart upload state lives under
 `.mn-storage/multipart/<bucket>`, temporary local file rollback snapshots live under `.mn-storage/snapshots/<bucket>`,
 and in-flight local file writes use typed provider temp directories under `.mn-storage/tmp/<bucket>`, such as `objects`,
 `object-metadata`, and `bucket-metadata`. Before creating a new replacement temporary file, local writes opportunistically
@@ -44,9 +80,11 @@ crash-atomic transaction across both. Custom metadata providers, including datab
 responsible for their own metadata durability, cleanup lifecycle, and any higher-level transaction or compensation
 behavior.
 
-For compatibility with persistent local storage paths created by released older versions, the built-in local sidecar
-metadata provider also checks legacy per-bucket `.metadata` sidecars. New built-in sidecar metadata writes use the root
-`.mn-storage` layout, and deletes remove both the root sidecar and the legacy `.metadata` sidecar for the deleted object.
+Switching to `NONE` does not recursively purge existing metadata. `NONE` never reads current or legacy sidecars, and an
+upload, copy, or delete removes current and legacy sidecars for the affected key before mutating its bytes. This prevents
+stale metadata from reappearing for that key if the configuration later switches back to `ENABLED`. Unrelated sidecars
+remain in place and require an explicit migration cleanup. Provider-managed directories and legacy `.metadata` remain
+hidden from object listing in both modes, although direct filesystem users can see them.
 
 By default, it will create a temporary folder to store the files, but you can configure it to use a specific folder:
 


### PR DESCRIPTION
## Summary

- add local `metadata-mode` configuration with `enabled` and `none` values
- keep the existing metadata SPI supported and use it whenever metadata mode is enabled
- allow metadata-free local storage with deterministic SHA-256 ETags and stale-sidecar cleanup
- document local metadata ownership and mode-switch behavior

## Behavior

`enabled` is the default and preserves the current local metadata behavior, including configured metadata SPI implementations and built-in filesystem sidecars.

`none` stores object bytes and provider working state only. It rejects non-empty user metadata before mutation, returns empty metadata on retrieval, bypasses metadata persistence, and removes stale current or legacy sidecars for keys that are uploaded, copied, or deleted.

## Verification

- `./gradlew :micronaut-object-storage-local:test` — 209 tests passed, 2 existing skips
- `./gradlew :micronaut-object-storage-local:japiCmp`
- `./gradlew spotlessCheck`
- `./gradlew docs`
- `git diff --check`

The repository-wide check was previously attempted; unrelated AWS Testcontainers tests were blocked by the local Docker Ryuk certificate configuration.
