### PR TITLE
Support gRPC transport for Google Cloud Storage

### DIFF
--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageFactory.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageFactory.java
@@ -22,6 +22,7 @@ import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.gcp.GoogleCloudConfiguration;
 import io.micronaut.gcp.condition.RequiresGoogleProjectId;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.jspecify.annotations.NonNull;
 
@@ -32,16 +33,31 @@ import org.jspecify.annotations.NonNull;
 @Factory
 public class GoogleCloudStorageFactory {
 
+    private final GoogleCloudStorageModuleConfiguration objectStorageConfiguration;
+
+    /**
+     * Creates a Google Cloud Storage factory with the default module configuration.
+     */
+    public GoogleCloudStorageFactory() {
+        this(new GoogleCloudStorageModuleConfiguration());
+    }
+
+    @Inject
+    GoogleCloudStorageFactory(GoogleCloudStorageModuleConfiguration objectStorageConfiguration) {
+        this.objectStorageConfiguration = objectStorageConfiguration;
+    }
+
     /**
      * @param configuration The Google Cloud Configuration
-     * @param googleCredentials        The Google Credentials
+     * @param googleCredentials The Google Credentials
      * @return The storage instance
      */
     @RequiresGoogleProjectId
     @Singleton
     public StorageOptions.@NonNull Builder builder(@NonNull GoogleCloudConfiguration configuration,
                                                    @NonNull GoogleCredentials googleCredentials) {
-        return StorageOptions.newBuilder()
+        var builder = objectStorageConfiguration.isGrpcEnabled() ? StorageOptions.grpc() : StorageOptions.newBuilder();
+        return builder
             .setProjectId(configuration.getProjectId())
             .setCredentials(googleCredentials);
     }

--- a/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageModuleConfiguration.java
+++ b/object-storage-gcp/src/main/java/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageModuleConfiguration.java
@@ -27,11 +27,33 @@ import io.micronaut.objectstorage.configuration.AbstractObjectStorageModuleConfi
 @ConfigurationProperties(GoogleCloudStorageConfiguration.PREFIX)
 public class GoogleCloudStorageModuleConfiguration extends AbstractObjectStorageModuleConfiguration {
 
+    private boolean grpcEnabled;
+
     /**
      * Whether to enable or disable the whole Google Cloud Storage module.
      */
     @Override
     public boolean isEnabled() {
         return enabled;
+    }
+
+    /**
+     * Whether to use gRPC as the transport for Google Cloud Storage.
+     *
+     * @return {@code true} if gRPC transport is enabled
+     * @since 3.1.1
+     */
+    public boolean isGrpcEnabled() {
+        return grpcEnabled;
+    }
+
+    /**
+     * Sets whether to use gRPC as the transport for Google Cloud Storage.
+     *
+     * @param grpcEnabled Whether gRPC transport is enabled
+     * @since 3.1.1
+     */
+    public void setGrpcEnabled(boolean grpcEnabled) {
+        this.grpcEnabled = grpcEnabled;
     }
 }

--- a/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageFactorySpec.groovy
+++ b/object-storage-gcp/src/test/groovy/io/micronaut/objectstorage/googlecloud/GoogleCloudStorageFactorySpec.groovy
@@ -1,0 +1,85 @@
+package io.micronaut.objectstorage.googlecloud
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.cloud.storage.GrpcStorageOptions
+import com.google.cloud.storage.HttpStorageOptions
+import com.google.cloud.storage.StorageOptions
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.event.BeanCreatedEvent
+import io.micronaut.context.event.BeanCreatedEventListener
+import jakarta.inject.Singleton
+import org.jspecify.annotations.NonNull
+import spock.lang.Shared
+import spock.lang.Specification
+
+class GoogleCloudStorageFactorySpec extends Specification {
+
+    private static final String SPEC_NAME = 'GoogleCloudStorageFactorySpec'
+
+    @Shared
+    static GoogleCredentials credentialsMock
+
+    void "uses gRPC storage options when gRPC transport is enabled"() {
+        given:
+        credentialsMock = Mock(GoogleCredentials)
+        ApplicationContext context = ApplicationContext.run([
+                'gcp.project-id'                                            : 'test-project',
+                'gcp.credentials.enabled'                                   : false,
+                (GoogleCloudStorageConfiguration.PREFIX + '.grpc-enabled')  : true,
+                'spec.name'                                                 : SPEC_NAME
+        ])
+
+        when:
+        StorageOptions storageOptions = context.getBean(StorageOptions)
+
+        then:
+        storageOptions instanceof GrpcStorageOptions
+        storageOptions.quotaProjectId == 'custom-quota-project'
+
+        cleanup:
+        context.close()
+    }
+
+    void "uses HTTP storage options by default"() {
+        given:
+        credentialsMock = Mock(GoogleCredentials)
+        ApplicationContext context = ApplicationContext.run([
+                'gcp.project-id'          : 'test-project',
+                'gcp.credentials.enabled' : false,
+                'spec.name'               : SPEC_NAME
+        ])
+
+        when:
+        StorageOptions storageOptions = context.getBean(StorageOptions)
+
+        then:
+        storageOptions instanceof HttpStorageOptions
+
+        cleanup:
+        context.close()
+    }
+
+    @Factory
+    @Requires(property = 'spec.name', value = SPEC_NAME)
+    static class TestCredentialsFactory {
+
+        @Singleton
+        @Primary
+        GoogleCredentials googleCredentials() {
+            credentialsMock
+        }
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = SPEC_NAME)
+    static class StorageOptionsBuilderCustomizer implements BeanCreatedEventListener<StorageOptions.Builder> {
+
+        @Override
+        StorageOptions.Builder onCreated(@NonNull BeanCreatedEvent<StorageOptions.Builder> event) {
+            event.bean.setQuotaProjectId('custom-quota-project')
+        }
+    }
+}

--- a/src/main/docs/guide/gcp.adoc
+++ b/src/main/docs/guide/gcp.adoc
@@ -9,6 +9,10 @@ The object storage specific configuration options available are:
 
 include::{includedir}configurationProperties/io.micronaut.objectstorage.googlecloud.GoogleCloudStorageConfiguration.adoc[]
 
+The module-wide configuration options available are:
+
+include::{includedir}configurationProperties/io.micronaut.objectstorage.googlecloud.GoogleCloudStorageModuleConfiguration.adoc[]
+
 For example:
 
 .`src/main/resources/application-gcp.yml`
@@ -28,7 +32,18 @@ The `gs:` alias only resolves buckets that are already configured under `microna
 
 == Advanced configuration
 
-For configuration properties other than the specified above, you can add bean to your application that implements
+The Google Cloud Storage client uses the JSON-over-HTTP transport by default. To use the gRPC transport, set
+`grpc-enabled` to `true`:
+
+[configuration]
+----
+micronaut:
+  object-storage:
+    gcp:
+      grpc-enabled: true
+----
+
+For configuration properties other than the specified above, you can add a bean to your application that implements
 https://docs.micronaut.io/latest/guide/#events[`BeanCreatedEventListener`]. For example:
 
 [source,java]


### PR DESCRIPTION
## Summary

- add `micronaut.object-storage.gcp.grpc-enabled` as an opt-in gRPC transport setting
- preserve JSON-over-HTTP as the default transport
- keep `StorageOptions.Builder` available to `BeanCreatedEventListener` customizers
- document the new configuration option

## Testing

- `./gradlew :micronaut-object-storage-gcp:test`
- `./gradlew check`
- `./gradlew -q japiCmp`
- `./gradlew -q publishGuide docs`

Closes #852

**AI attestation:** OpenAI Codex implemented, tested, documented, and prepared this pull request on behalf of @altaiezior. I verified the four-file diff against issue #852, the GPG-signed commit, 36 GCP module tests with 0 failures, the repository-wide check with 133 successful tasks, binary compatibility, and generated documentation.
