### PR TITLE
Start 3.2.x at 3.2.0-SNAPSHOT with core 5.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=3.1.1-SNAPSHOT
+projectVersion=3.2.0-SNAPSHOT
 projectGroup=io.micronaut.objectstorage
 
 title=Micronaut Object Storage

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
-micronaut-platform = "5.0.5"
-micronaut = "5.1.7"
+micronaut-platform = "5.1.4"
+micronaut = "5.2.0"
 micronaut-test = "5.1.0"
-micronaut-aws = "5.0.2"
+micronaut-aws = "5.1.1"
 micronaut-azure = "6.1.0"
-micronaut-gcp = "6.0.0"
-micronaut-oracle-cloud = "6.1.2"
-micronaut-test-resources = "4.0.0"
+micronaut-gcp = "6.1.0"
+micronaut-oracle-cloud = "6.1.3"
+micronaut-test-resources = "4.2.0"
 micronaut-validation = "5.1.0"
 micronaut-logging = "2.1.0"
 


### PR DESCRIPTION
Starts the new minor branch `3.2.x` (created from `3.1.x`) at `3.2.0-SNAPSHOT` and moves it to Micronaut core 5.2.0.

Core 5.2 may only land in a new, unreleased minor of each library, so it does not go to `3.1.x`, whose minor is already released. Tracked in micronaut-projects/micronaut-core#13110.

The `gradle/libs.versions.toml` changes of the Renovate PR #854 on `3.1.x` are reused here.
Switching the default and Renovate base branch to `3.2.x` is left to the maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)